### PR TITLE
[Dart] fix: missing description emit when freezed is used

### DIFF
--- a/packages/quicktype-core/src/language/Dart.ts
+++ b/packages/quicktype-core/src/language/Dart.ts
@@ -788,6 +788,11 @@ export class DartRenderer extends ConvenienceRenderer {
                 this.emitLine("const factory ", className, "({");
                 this.indent(() => {
                     this.forEachClassProperty(c, "none", (name, jsonName, prop) => {
+                        const description = this.descriptionForClassProperty(c, jsonName);
+                        if (description !== undefined) {
+                            this.emitDescription(description);
+                        }
+
                         const required =
                             this._options.requiredProperties ||
                             (this._options.nullSafety && (!prop.type.isNullable || !prop.isOptional));


### PR DESCRIPTION
When using the Dart generator in combination with `--use-freezed`, the description provided in a JSON schema is not added to each class property. The counterpart (not using "freezed") does add descriptions.

I don't believe it was an intended behaviour, just a missed feature, but let me know.