### PR TITLE
feat(Rust): Add option to skip serializing empty optional fields

### DIFF
--- a/packages/quicktype-core/src/language/Rust.ts
+++ b/packages/quicktype-core/src/language/Rust.ts
@@ -49,6 +49,7 @@ export const rustOptions = {
     deriveDebug: new BooleanOption("derive-debug", "Derive Debug impl", false),
     deriveClone: new BooleanOption("derive-clone", "Derive Clone impl", false),
     derivePartialEq: new BooleanOption("derive-partial-eq", "Derive PartialEq impl", false),
+    skipSerializingNone: new BooleanOption("skip-serializing-none", "Skip serializing empty Option fields", false),
     edition2018: new BooleanOption("edition-2018", "Edition 2018", true),
     leadingComments: new BooleanOption("leading-comments", "Leading Comments", true)
 };
@@ -127,7 +128,8 @@ export class RustTargetLanguage extends TargetLanguage {
             rustOptions.deriveClone,
             rustOptions.derivePartialEq,
             rustOptions.edition2018,
-            rustOptions.leadingComments
+            rustOptions.leadingComments,
+            rustOptions.skipSerializingNone,
         ];
     }
 }
@@ -363,6 +365,13 @@ export class RustRenderer extends ConvenienceRenderer {
         }
     }
 
+    private emitSkipSerializeNone(t: Type) {
+        if (t instanceof UnionType) {
+            const nullable = nullableFromUnion(t);
+            if (nullable !== null) this.emitLine('#[serde(skip_serializing_if = "Option::is_none")]'); 
+        }
+    }
+
     private get visibility(): string {
         if (this._options.visibility === Visibility.Crate) {
             return "pub(crate) ";
@@ -400,6 +409,7 @@ export class RustRenderer extends ConvenienceRenderer {
             this.forEachClassProperty(c, blankLines, (name, jsonName, prop) => {
                 this.emitDescription(this.descriptionForClassProperty(c, jsonName));
                 this.emitRenameAttribute(name, jsonName, defaultStyle, preferedNamingStyle);
+                this._options.skipSerializingNone && this.emitSkipSerializeNone(prop.type);
                 this.emitLine(this.visibility, name, ": ", this.breakCycle(prop.type, true), ",");
             });
 


### PR DESCRIPTION
Adds an option `--skip-serializing-none` for Rust. With the option on, it will instruct `serde` to skip serializing the optional fields if they are empty (None).

Can reduce the size and noisiness of the json output for large structs with many optional fields.