### PR TITLE
adds option to rust keywords

### DIFF
--- a/packages/quicktype-core/src/language/Rust.ts
+++ b/packages/quicktype-core/src/language/Rust.ts
@@ -203,7 +203,10 @@ const keywords = [
     "default",
     "dyn",
     "'static",
-    "union"
+    "union",
+
+    // Conflict between `std::Option` and potentially generated Option
+    "option"
 ];
 
 const isAsciiLetterOrUnderscoreOrDigit = (codePoint: number): boolean => {


### PR DESCRIPTION
prevents a compilation error when a struct called Option is generated and optional fields are present in the structs.

fixes #2385