### PR TITLE
C++: force include for types in vector and map

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus.ts
@@ -1075,7 +1075,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         const result: TypeRecord[] = [];
         const recur = (forceInclude: boolean, isVariant: boolean, l: number, t: Type) => {
             if (t instanceof ArrayType) {
-                recur(forceInclude, isVariant, l + 1, t.items);
+                recur(true, isVariant, l + 1, t.items);
             } else if (t instanceof ClassType) {
                 result.push({
                     name: this.nameForNamedType(t),
@@ -1085,7 +1085,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                     forceInclude
                 });
             } else if (t instanceof MapType) {
-                recur(forceInclude, isVariant, l + 1, t.values);
+                recur(true, isVariant, l + 1, t.values);
             } else if (t instanceof EnumType) {
                 result.push({
                     name: this.nameForNamedType(t),


### PR DESCRIPTION
Fix #2402
