### PR TITLE
fixed #2411

### DIFF
--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -226,7 +226,7 @@ export class Ref {
     get name(): string {
         const path = Array.from(this.path);
 
-        for (;;) {
+        for (; ;) {
             const e = path.pop();
             if (e === undefined || e.kind === PathElementKind.Root) {
                 let name = this.addressURI !== undefined ? this.addressURI.filename() : "";
@@ -399,7 +399,7 @@ class Canonizer {
     private readonly _map = new EqualityMap<Ref, Location>();
     private readonly _schemaAddressesAdded = new Set<string>();
 
-    constructor(private readonly _ctx: RunContext) {}
+    constructor(private readonly _ctx: RunContext) { }
 
     private addIDs(schema: any, loc: Location) {
         if (schema === null) return;
@@ -536,7 +536,7 @@ class Resolver {
         private readonly _ctx: RunContext,
         private readonly _store: JSONSchemaStore,
         private readonly _canonizer: Canonizer
-    ) {}
+    ) { }
 
     private async tryResolveVirtualRef(
         fetchBase: Location,
@@ -548,7 +548,7 @@ class Resolver {
         // we don't know its $id mapping yet, which means we don't know where we
         // will end up.  What we do if we encounter a new schema is add all its
         // IDs first, and then try to canonize again.
-        for (;;) {
+        for (; ;) {
             const loc = this._canonizer.canonize(fetchBase, virtualRef);
             const canonical = loc.canonicalRef;
             assert(canonical.hasAddress, "Canonical ref can't be resolved without an address");
@@ -808,7 +808,7 @@ async function addTypesInSchema(
             } else if (typeof items === "object") {
                 const itemsLoc = loc.push("items");
                 itemType = await toType(checkJSONSchema(items, itemsLoc.canonicalRef), itemsLoc, singularAttributes);
-            } else if (items !== undefined) {
+            } else if (items !== undefined && items !== true) {
                 return messageError("SchemaArrayItemsMustBeStringOrArray", withRef(loc, { actual: items }));
             } else {
                 itemType = typeBuilder.getPrimitiveType("any");

--- a/script/quicktype
+++ b/script/quicktype
@@ -3,7 +3,7 @@
 # This runs quicktype, ensuring dependencies are installed
 # and rebuilding quicktype first.
 #
-# Use script/quickertype to skip reinstalling dependencies
+# Use script/quickesttype to skip reinstalling dependencies
 # and rebuilding PureScript for 10s faster runs if you
 # are just working on TargetLanguage code in TypeScript.
 


### PR DESCRIPTION
See #2411. Tested with the example:

1. put into `test.json`:
   ```
   {
      "$schema": "https://json-schema.org/draft/2020-12/schema",
      "properties": {
          "enum": {
              "type": "array",
              "items": true
          }
     }
   }
   ```
2. `script/quicktype --src test.json --src-lang schema --just-types -o test.ts`
3. output:

    ```
    export interface TestObject {
        enum?: any[];
        [property: string]: any;
    }
    ```

I didn't look into how to test everything, but would be happy to do so if given a pointer