### PR TITLE
fix: Typescript zod (and effect) language uses block scoped variables before they've been declared

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod.ts
@@ -279,7 +279,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
         //items to process on the next pass
         let deferredIndices: number[] = [];
 
-        //defensive: make sure we don't loop foreever, even complex sets shouldn't require many passes
+        //defensive: make sure we don't loop forever, even complex sets shouldn't require many passes
         const MAX_PASSES = 999;
         let passNum = 0;
         do {
@@ -324,6 +324,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
             if (passNum > MAX_PASSES) {
                 //giving up
                 order.push(...deferredIndices);
+                console.warn("Exceeded maximum number of passes when determining output order, output may contain forward references");
             }
         } while (indices.length > 0 && passNum <= MAX_PASSES);
 


### PR DESCRIPTION
By ensuring that referenced types are defined before they are referenced. Tested on a fairly large set of interconnected schemas for the [bridging API](https://fdc3.finos.org/docs/agent-bridging/spec) in the [FDC3 standard](https://fdc3.finos.org/docs/fdc3-standard).

Please let me know if there's a more idiomatic way to get to the types underlying sets, unions, intersections, arrays etc..

resolves https://github.com/glideapps/quicktype/issues/2414

@ryoid @Southclaws @dvdsgl
P.S. The TypeScript effect schema language uses the same code in its generation and probably also needs these changes - I don't have a test set-up for that one however.