### PR TITLE
fix: Expose the prefer-const-values Typescript language setting via CLI

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptFlow.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow.ts
@@ -51,7 +51,8 @@ export abstract class TypeScriptFlowBaseTargetLanguage extends JavaScriptTargetL
             tsFlowOptions.converters,
             tsFlowOptions.rawType,
             tsFlowOptions.preferUnions,
-            tsFlowOptions.preferTypes
+            tsFlowOptions.preferTypes,
+            tsFlowOptions.preferConstValues
         ];
     }
 


### PR DESCRIPTION
resolves #2345 
A previous PR (#2314) introduced the ability to generate const values in Typescript but didn't expose that option correctly for use through the CLI. This one-line PR exposes the option (which works a treat!)

@DanielBretzigheimer 