### PR TITLE
Improve Error Messaging for Enumeration Conversion

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus.ts
@@ -1982,7 +1982,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                             "; break;"
                         );
                     });
-                    this.emitLine('default: throw std::runtime_error("This should not happen");');
+                    this.emitLine(`default: throw std::runtime_error("Unexpected value in enumeration \\"${enumName}\\": " + std::to_string(static_cast<int>(x)));`);
                 });
             }
         );


### PR DESCRIPTION
Enhance clarity and informativeness of error messages in the C++ code generator for enum type conversions. Update the default case in `to_json` function to include the specific enumeration name and the unexpected value in the error message. This aids in quicker debugging and aligns with best practices in error messaging.