### PR TITLE
Fix Python class member comment placement

### DIFF
--- a/packages/quicktype-core/src/language/Python.ts
+++ b/packages/quicktype-core/src/language/Python.ts
@@ -461,8 +461,8 @@ export class PythonRenderer extends ConvenienceRenderer {
                     this.emitLine("pass");
                 } else {
                     this.forEachClassProperty(t, "none", (name, jsonName, cp) => {
-                        this.emitDescription(this.descriptionForClassProperty(t, jsonName));
                         this.emitLine(name, this.typeHint(": ", this.pythonType(cp.type, true)));
+                        this.emitDescription(this.descriptionForClassProperty(t, jsonName));
                     });
                 }
                 this.ensureBlankLine();


### PR DESCRIPTION
## Description

For the variable descriptions to be correctly parsed as Python variable docstrings, they need to be place beneath the variable declarations.

Tested with 
[foo.json](https://github.com/glideapps/quicktype/files/13382029/foo.json)


### Before

<img width="1121" alt="截圖 2023-11-17 凌晨2 32 23" src="https://github.com/glideapps/quicktype/assets/6112039/7fb24820-b920-4bde-8262-9a309269b112">

### After

<img width="1080" alt="截圖 2023-11-17 凌晨2 32 49" src="https://github.com/glideapps/quicktype/assets/6112039/2aff484b-ffd6-4f48-8853-4adf009e72a7">
