### PR TITLE
Adding missing export of new Golang option

### DIFF
--- a/packages/quicktype-core/src/language/Golang.ts
+++ b/packages/quicktype-core/src/language/Golang.ts
@@ -40,7 +40,8 @@ export class GoTargetLanguage extends TargetLanguage {
             goOptions.packageName,
             goOptions.multiFileOutput,
             goOptions.justTypesAndPackage,
-            goOptions.fieldTags
+            goOptions.fieldTags,
+            goOptions.omitEmpty
         ];
     }
 


### PR DESCRIPTION
Followup to https://github.com/glideapps/quicktype/pull/2449

Apologies, I was concentrating on adding the functionality to the library I needed, I didn't check how the flag was exported. Unintended screw up due to my over-reliance on the live reload functionality.