### PR TITLE
Swift: apply Sendable unless it's class and mutable

### DIFF
--- a/packages/quicktype-core/src/language/Swift.ts
+++ b/packages/quicktype-core/src/language/Swift.ts
@@ -567,7 +567,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
             protocols.push("Equatable");
         }
 
-        if (this._options.sendable && !this._options.mutableProperties && !this._options.objcSupport) {
+        if (this._options.sendable && (!this._options.mutableProperties || !isClass) && !this._options.objcSupport) {
             protocols.push("Sendable");
         }
 


### PR DESCRIPTION
`Sendable` conformance should be applied unless it's a class _and_ mutable. This fixes #2291.