### PR TITLE
fix: add supportsOptionalClassProperties to TypeScriptZod target language

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod.ts
@@ -46,6 +46,10 @@ export class TypeScriptZodTargetLanguage extends TargetLanguage {
         return mapping;
     }
 
+		get supportsOptionalClassProperties(): boolean {
+			return true;
+		}
+
     protected makeRenderer(
         renderContext: RenderContext,
         untypedOptionValues: { [name: string]: any }


### PR DESCRIPTION
### Summary
Added `supportsOptionalClassProperties` to `TypeScriptZodTargetLanguage` in order to fix handling of optional properties in JSON Schema that are not listed in `required` array.

### JSON Schema
```json
{
  "properties": {
    "foo": { "type": "string" },           // standard string
    "bar": { "type": ["string", "null"] }, // string | null union
    "baz": { "type": "string" },           // string, optional
    "qux": { "type": ["string", "null"] }, // string | null union, optional
  },
  "required": ["foo", "bar"]
}
```

### Old
```ts
export const Schema = z.object({
  foo: z.string(),                               // standard string
  bar: z.union(z.string(), z.null()),            // string | null union
  baz: z.union(z.string(), z.null()).optional(), // string, optional
  qux: z.union(z.string(), z.null()).optional(), // string | null union, optional
})
```

### New
```ts
export const Schema = z.object({
  foo: z.string(),                               // standard string
  bar: z.union(z.string(), z.null()),            // string | null union
  baz: z.string().optional(),                    // string, optional
  qux: z.union(z.string(), z.null()).optional(), // string | null union, optional
})