### PR TITLE
fix: removes default leading comment in Crystal

### DIFF
--- a/packages/quicktype-core/src/language/Crystal.ts
+++ b/packages/quicktype-core/src/language/Crystal.ts
@@ -380,33 +380,6 @@ export class CrystalRenderer extends ConvenienceRenderer {
             this.emitCommentLines(this.leadingComments);
             return;
         }
-
-        this.emitMultiline(
-            `# Example code that deserializes and serializes the model:
-#
-# require "json"
-#
-# class Location
-#   include JSON::Serializable
-#
-#   @[JSON::Field(key: "lat")]
-#   property latitude : Float64
-#
-#   @[JSON::Field(key: "lng")]
-#   property longitude : Float64
-# end
-#
-# class House
-#   include JSON::Serializable
-#   property address : String
-#   property location : Location?
-# end
-#
-# house = House.from_json(%({"address": "Crystal Road 1234", "location": {"lat": 12.3, "lng": 34.5}}))
-# house.address  # => "Crystal Road 1234"
-# house.location # => #<Location:0x10cd93d80 @latitude=12.3, @longitude=34.5>
-`
-        );
     }
 
     protected emitSourceStructure(): void {


### PR DESCRIPTION
fixes #1672 

### Changes
- Removes hard-coded leading comment in Crystal language renderer