### PR TITLE
feat: Support more leading comment types

### DIFF
--- a/packages/quicktype-core/src/ConvenienceRenderer.ts
+++ b/packages/quicktype-core/src/ConvenienceRenderer.ts
@@ -836,11 +836,17 @@ export abstract class ConvenienceRenderer extends Renderer {
         let first = true;
         for (const line of lines) {
             let start = first ? firstLineStart : lineStart;
+            first = false;
+
             if (this.sourcelikeToString(line) === "") {
                 start = trimEnd(start);
             }
-            this.emitLine(start, line);
-            first = false;
+
+            if (lineEnd) {
+                this.emitLine(start, line, lineEnd);
+            } else {
+                this.emitLine(start, line);
+            }
         }
         if (afterComment !== undefined) {
             this.emitLine(afterComment);

--- a/packages/quicktype-core/src/ConvenienceRenderer.ts
+++ b/packages/quicktype-core/src/ConvenienceRenderer.ts
@@ -24,7 +24,7 @@ import { descriptionTypeAttributeKind, propertyDescriptionsTypeAttributeKind } f
 import { enumCaseNames, objectPropertyNames, unionMemberName, getAccessorName } from "./attributes/AccessorNames";
 import { transformationForType, followTargetType, Transformation } from "./Transformers";
 import { TargetLanguage } from "./TargetLanguage";
-import { type Comment, isStringComment } from "./support/Comments";
+import { type Comment, isStringComment, type CommentOptions } from "./support/Comments";
 
 const wordWrap: (s: string) => string = require("wordwrap")(90);
 
@@ -813,13 +813,7 @@ export abstract class ConvenienceRenderer extends Renderer {
             } else if ("descriptionBlock" in comment) {
                 this.emitDescriptionBlock(comment.descriptionBlock);
             } else {
-                this.emitCommentLines(
-                    comment.customLines,
-                    comment.lineStart,
-                    comment.beforeLine,
-                    comment.afterLine,
-                    comment.firstLineStart
-                );
+                this.emitCommentLines(comment.customLines, comment);
             }
 
             this.ensureBlankLine();
@@ -828,17 +822,14 @@ export abstract class ConvenienceRenderer extends Renderer {
 
     protected emitCommentLines(
         lines: Sourcelike[],
-        lineStart?: string,
-        beforeLine?: string,
-        afterLine?: string,
-        firstLineStart?: string
+        {
+            lineStart = this.commentLineStart,
+            firstLineStart = lineStart,
+            beforeLine,
+            afterLine,
+            lineEnd
+        }: CommentOptions = {}
     ): void {
-        if (lineStart === undefined) {
-            lineStart = this.commentLineStart;
-        }
-        if (firstLineStart === undefined) {
-            firstLineStart = lineStart;
-        }
         if (beforeLine !== undefined) {
             this.emitLine(beforeLine);
         }

--- a/packages/quicktype-core/src/ConvenienceRenderer.ts
+++ b/packages/quicktype-core/src/ConvenienceRenderer.ts
@@ -24,6 +24,7 @@ import { descriptionTypeAttributeKind, propertyDescriptionsTypeAttributeKind } f
 import { enumCaseNames, objectPropertyNames, unionMemberName, getAccessorName } from "./attributes/AccessorNames";
 import { transformationForType, followTargetType, Transformation } from "./Transformers";
 import { TargetLanguage } from "./TargetLanguage";
+import { type Comment, isStringComment } from "./support/Comments";
 
 const wordWrap: (s: string) => string = require("wordwrap")(90);
 
@@ -801,6 +802,28 @@ export abstract class ConvenienceRenderer extends Renderer {
 
     protected get commentLineStart(): string {
         return "// ";
+    }
+
+    protected emitComments(comments: Comment[]): void {
+        comments.forEach(comment => {
+            if (isStringComment(comment)) {
+                this.emitCommentLines([comment]);
+            } else if ("lines" in comment) {
+                this.emitCommentLines(comment.lines);
+            } else if ("descriptionBlock" in comment) {
+                this.emitDescriptionBlock(comment.descriptionBlock);
+            } else {
+                this.emitCommentLines(
+                    comment.customLines,
+                    comment.lineStart,
+                    comment.beforeLine,
+                    comment.afterLine,
+                    comment.firstLineStart
+                );
+            }
+
+            this.ensureBlankLine();
+        });
     }
 
     protected emitCommentLines(

--- a/packages/quicktype-core/src/ConvenienceRenderer.ts
+++ b/packages/quicktype-core/src/ConvenienceRenderer.ts
@@ -825,13 +825,13 @@ export abstract class ConvenienceRenderer extends Renderer {
         {
             lineStart = this.commentLineStart,
             firstLineStart = lineStart,
-            beforeLine,
-            afterLine,
-            lineEnd
+            lineEnd,
+            beforeComment,
+            afterComment
         }: CommentOptions = {}
     ): void {
-        if (beforeLine !== undefined) {
-            this.emitLine(beforeLine);
+        if (beforeComment !== undefined) {
+            this.emitLine(beforeComment);
         }
         let first = true;
         for (const line of lines) {
@@ -842,8 +842,8 @@ export abstract class ConvenienceRenderer extends Renderer {
             this.emitLine(start, line);
             first = false;
         }
-        if (afterLine !== undefined) {
-            this.emitLine(afterLine);
+        if (afterComment !== undefined) {
+            this.emitLine(afterComment);
         }
     }
 

--- a/packages/quicktype-core/src/Renderer.ts
+++ b/packages/quicktype-core/src/Renderer.ts
@@ -6,7 +6,7 @@ import { Source, Sourcelike, NewlineSource, annotated, sourcelikeToSource, newli
 import { AnnotationData, IssueAnnotationData } from "./Annotation";
 import { assert, panic } from "./support/Support";
 import { TargetLanguage } from "./TargetLanguage";
-import { type LeadingComments } from "./support/Comments";
+import { type Comment } from "./support/Comments";
 
 export type RenderResult = {
     sources: ReadonlyMap<string, Source>;
@@ -41,7 +41,7 @@ function lineIndentation(line: string): { indent: number; text: string | null } 
 
 export type RenderContext = {
     typeGraph: TypeGraph;
-    leadingComments?: LeadingComments;
+    leadingComments?: Comment[];
 };
 
 export type ForEachPosition = "first" | "last" | "middle" | "only";
@@ -121,7 +121,7 @@ class EmitContext {
 
 export abstract class Renderer {
     protected readonly typeGraph: TypeGraph;
-    protected readonly leadingComments: LeadingComments | undefined;
+    protected readonly leadingComments: Comment[] | undefined;
 
     private _names: ReadonlyMap<Name, string> | undefined;
     private _finishedFiles: Map<string, Source>;

--- a/packages/quicktype-core/src/Renderer.ts
+++ b/packages/quicktype-core/src/Renderer.ts
@@ -6,6 +6,7 @@ import { Source, Sourcelike, NewlineSource, annotated, sourcelikeToSource, newli
 import { AnnotationData, IssueAnnotationData } from "./Annotation";
 import { assert, panic } from "./support/Support";
 import { TargetLanguage } from "./TargetLanguage";
+import { type LeadingComments } from "./support/Comments";
 
 export type RenderResult = {
     sources: ReadonlyMap<string, Source>;
@@ -40,7 +41,7 @@ function lineIndentation(line: string): { indent: number; text: string | null } 
 
 export type RenderContext = {
     typeGraph: TypeGraph;
-    leadingComments: string[] | undefined;
+    leadingComments?: LeadingComments;
 };
 
 export type ForEachPosition = "first" | "last" | "middle" | "only";
@@ -120,7 +121,7 @@ class EmitContext {
 
 export abstract class Renderer {
     protected readonly typeGraph: TypeGraph;
-    protected readonly leadingComments: string[] | undefined;
+    protected readonly leadingComments: LeadingComments | undefined;
 
     private _names: ReadonlyMap<Name, string> | undefined;
     private _finishedFiles: Map<string, Source>;
@@ -128,7 +129,10 @@ export abstract class Renderer {
 
     private _emitContext: EmitContext;
 
-    constructor(protected readonly targetLanguage: TargetLanguage, renderContext: RenderContext) {
+    constructor(
+        protected readonly targetLanguage: TargetLanguage,
+        renderContext: RenderContext
+    ) {
         this.typeGraph = renderContext.typeGraph;
         this.leadingComments = renderContext.leadingComments;
 

--- a/packages/quicktype-core/src/Run.ts
+++ b/packages/quicktype-core/src/Run.ts
@@ -19,6 +19,7 @@ import { InputData } from "./input/Inputs";
 import { flattenStrings } from "./rewrites/FlattenStrings";
 import { makeTransformations } from "./MakeTransformations";
 import { TransformedStringTypeKind } from "./Type";
+import { type LeadingComments } from "./support/Comments";
 
 export function getTargetLanguage(nameOrInstance: string | TargetLanguage): TargetLanguage {
     if (typeof nameOrInstance === "object") {
@@ -137,7 +138,7 @@ export type NonInferenceOptions = {
     /** Don't render output.  This is mainly useful for benchmarking. */
     noRender: boolean;
     /** If given, output these comments at the beginning of the main output file */
-    leadingComments: string[] | undefined;
+    leadingComments?: LeadingComments;
     /** Options for the target language's renderer */
     rendererOptions: RendererOptions;
     /** String to use for one indentation level.  If not given, use the target language's default. */

--- a/packages/quicktype-core/src/Run.ts
+++ b/packages/quicktype-core/src/Run.ts
@@ -19,7 +19,7 @@ import { InputData } from "./input/Inputs";
 import { flattenStrings } from "./rewrites/FlattenStrings";
 import { makeTransformations } from "./MakeTransformations";
 import { TransformedStringTypeKind } from "./Type";
-import { type LeadingComments } from "./support/Comments";
+import { type Comment } from "./support/Comments";
 
 export function getTargetLanguage(nameOrInstance: string | TargetLanguage): TargetLanguage {
     if (typeof nameOrInstance === "object") {
@@ -138,7 +138,7 @@ export type NonInferenceOptions = {
     /** Don't render output.  This is mainly useful for benchmarking. */
     noRender: boolean;
     /** If given, output these comments at the beginning of the main output file */
-    leadingComments?: LeadingComments;
+    leadingComments?: Comment[];
     /** Options for the target language's renderer */
     rendererOptions: RendererOptions;
     /** String to use for one indentation level.  If not given, use the target language's default. */

--- a/packages/quicktype-core/src/TargetLanguage.ts
+++ b/packages/quicktype-core/src/TargetLanguage.ts
@@ -9,7 +9,7 @@ import { defined } from "./support/Support";
 import { ConvenienceRenderer } from "./ConvenienceRenderer";
 import { Type } from "./Type";
 import { DateTimeRecognizer, DefaultDateTimeRecognizer } from "./DateTime";
-import { type LeadingComments } from "./support/Comments";
+import { type Comment } from "./support/Comments";
 
 export type MultiFileRenderResult = ReadonlyMap<string, SerializedRenderResult>;
 
@@ -46,7 +46,7 @@ export abstract class TargetLanguage {
         typeGraph: TypeGraph,
         givenOutputFilename: string,
         alphabetizeProperties: boolean,
-        leadingComments: LeadingComments | undefined,
+        leadingComments: Comment[] | undefined,
         rendererOptions: { [name: string]: any },
         indentation?: string
     ): MultiFileRenderResult {

--- a/packages/quicktype-core/src/TargetLanguage.ts
+++ b/packages/quicktype-core/src/TargetLanguage.ts
@@ -9,11 +9,16 @@ import { defined } from "./support/Support";
 import { ConvenienceRenderer } from "./ConvenienceRenderer";
 import { Type } from "./Type";
 import { DateTimeRecognizer, DefaultDateTimeRecognizer } from "./DateTime";
+import { type LeadingComments } from "./support/Comments";
 
 export type MultiFileRenderResult = ReadonlyMap<string, SerializedRenderResult>;
 
 export abstract class TargetLanguage {
-    constructor(readonly displayName: string, readonly names: string[], readonly extension: string) {}
+    constructor(
+        readonly displayName: string,
+        readonly names: string[],
+        readonly extension: string
+    ) {}
 
     protected abstract getOptions(): Option<any>[];
 
@@ -41,7 +46,7 @@ export abstract class TargetLanguage {
         typeGraph: TypeGraph,
         givenOutputFilename: string,
         alphabetizeProperties: boolean,
-        leadingComments: string[] | undefined,
+        leadingComments: LeadingComments | undefined,
         rendererOptions: { [name: string]: any },
         indentation?: string
     ): MultiFileRenderResult {

--- a/packages/quicktype-core/src/language/CJSON.ts
+++ b/packages/quicktype-core/src/language/CJSON.ts
@@ -3948,7 +3948,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
      * @param lines: description block lines
      */
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, {lineStart:" * ", beforeLine: "/**", afterLine: " */"});
+        this.emitCommentLines(lines, { lineStart: " * ", beforeComment: "/**", afterComment: " */" });
     }
 
     /**

--- a/packages/quicktype-core/src/language/CJSON.ts
+++ b/packages/quicktype-core/src/language/CJSON.ts
@@ -3948,7 +3948,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
      * @param lines: description block lines
      */
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, " * ", "/**", " */");
+        this.emitCommentLines(lines, {lineStart:" * ", beforeLine: "/**", afterLine: " */"});
     }
 
     /**

--- a/packages/quicktype-core/src/language/CPlusPlus.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus.ts
@@ -860,7 +860,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, " * ", "/**", " */");
+        this.emitCommentLines(lines, {lineStart: " * ", beforeLine: "/**", afterLine: " */"});
     }
 
     protected emitBlock(line: Sourcelike, withSemicolon: boolean, f: () => void, withIndent = true): void {

--- a/packages/quicktype-core/src/language/CPlusPlus.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus.ts
@@ -860,7 +860,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, {lineStart: " * ", beforeLine: "/**", afterLine: " */"});
+        this.emitCommentLines(lines, { lineStart: " * ", beforeComment: "/**", afterComment: " */" });
     }
 
     protected emitBlock(line: Sourcelike, withSemicolon: boolean, f: () => void, withIndent = true): void {

--- a/packages/quicktype-core/src/language/CPlusPlus.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus.ts
@@ -783,9 +783,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         }
 
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else if (!this._options.justTypes) {
             this.emitCommentLines([" To parse this JSON data, first install", ""]);
             if (this._options.boost) {

--- a/packages/quicktype-core/src/language/CPlusPlus.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus.ts
@@ -383,7 +383,10 @@ function addQualifier(qualifier: Sourcelike, qualified: Sourcelike[]): Sourcelik
 }
 
 class WrappingCode {
-    constructor(private readonly start: Sourcelike[], private readonly end: Sourcelike[]) {}
+    constructor(
+        private readonly start: Sourcelike[],
+        private readonly end: Sourcelike[]
+    ) {}
 
     wrap(qualifier: Sourcelike, inner: Sourcelike): Sourcelike {
         return [addQualifier(qualifier, this.start), inner, this.end];
@@ -780,7 +783,9 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
         }
 
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else if (!this._options.justTypes) {
             this.emitCommentLines([" To parse this JSON data, first install", ""]);
             if (this._options.boost) {

--- a/packages/quicktype-core/src/language/CSharp.ts
+++ b/packages/quicktype-core/src/language/CSharp.ts
@@ -648,9 +648,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
 
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else {
             this.emitDefaultLeadingComments();
         }

--- a/packages/quicktype-core/src/language/CSharp.ts
+++ b/packages/quicktype-core/src/language/CSharp.ts
@@ -474,7 +474,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
         if (this._csOptions.dense) {
             this.emitLine(start, lines.join("; "), "</summary>");
         } else {
-            this.emitCommentLines(lines, { lineStart: "/// ", beforeLine: start, afterLine: "/// </summary>" });
+            this.emitCommentLines(lines, { lineStart: "/// ", beforeComment: start, afterComment: "/// </summary>" });
         }
     }
 

--- a/packages/quicktype-core/src/language/CSharp.ts
+++ b/packages/quicktype-core/src/language/CSharp.ts
@@ -474,7 +474,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
         if (this._csOptions.dense) {
             this.emitLine(start, lines.join("; "), "</summary>");
         } else {
-            this.emitCommentLines(lines, "/// ", start, "/// </summary>");
+            this.emitCommentLines(lines, { lineStart: "/// ", beforeLine: start, afterLine: "/// </summary>" });
         }
     }
 

--- a/packages/quicktype-core/src/language/CSharp.ts
+++ b/packages/quicktype-core/src/language/CSharp.ts
@@ -648,7 +648,9 @@ export class CSharpRenderer extends ConvenienceRenderer {
 
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else {
             this.emitDefaultLeadingComments();
         }

--- a/packages/quicktype-core/src/language/Crystal.ts
+++ b/packages/quicktype-core/src/language/Crystal.ts
@@ -377,7 +377,9 @@ export class CrystalRenderer extends ConvenienceRenderer {
 
     protected emitLeadingComments(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
             return;
         }
 

--- a/packages/quicktype-core/src/language/Crystal.ts
+++ b/packages/quicktype-core/src/language/Crystal.ts
@@ -377,9 +377,7 @@ export class CrystalRenderer extends ConvenienceRenderer {
 
     protected emitLeadingComments(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
             return;
         }
 

--- a/packages/quicktype-core/src/language/Dart.ts
+++ b/packages/quicktype-core/src/language/Dart.ts
@@ -327,9 +327,7 @@ export class DartRenderer extends ConvenienceRenderer {
 
     protected emitFileHeader(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         }
 
         if (this._options.justTypes) return;

--- a/packages/quicktype-core/src/language/Dart.ts
+++ b/packages/quicktype-core/src/language/Dart.ts
@@ -375,7 +375,7 @@ export class DartRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, { lineStart: "///", beforeLine: "" });
+        this.emitCommentLines(lines, { lineStart: "///", beforeComment: "" });
     }
 
     protected emitBlock(line: Sourcelike, f: () => void): void {

--- a/packages/quicktype-core/src/language/Dart.ts
+++ b/packages/quicktype-core/src/language/Dart.ts
@@ -375,7 +375,7 @@ export class DartRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, "///", "");
+        this.emitCommentLines(lines, { lineStart: "///", beforeLine: "" });
     }
 
     protected emitBlock(line: Sourcelike, f: () => void): void {

--- a/packages/quicktype-core/src/language/Dart.ts
+++ b/packages/quicktype-core/src/language/Dart.ts
@@ -327,7 +327,9 @@ export class DartRenderer extends ConvenienceRenderer {
 
     protected emitFileHeader(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         }
 
         if (this._options.justTypes) return;

--- a/packages/quicktype-core/src/language/Elm.ts
+++ b/packages/quicktype-core/src/language/Elm.ts
@@ -574,9 +574,7 @@ export class ElmRenderer extends ConvenienceRenderer {
         });
 
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else if (!this._options.justTypes) {
             this.emitCommentLines([
                 "To decode the JSON data, add this file to your project, run",

--- a/packages/quicktype-core/src/language/Elm.ts
+++ b/packages/quicktype-core/src/language/Elm.ts
@@ -231,7 +231,7 @@ export class ElmRenderer extends ConvenienceRenderer {
         if (lines.length === 1) {
             this.emitLine("{-| ", lines[0], " -}");
         } else {
-            this.emitCommentLines(lines, { firstLineStart: "{-| ", lineStart: "", afterLine: "-}" });
+            this.emitCommentLines(lines, { firstLineStart: "{-| ", lineStart: "", afterComment: "-}" });
         }
     }
 

--- a/packages/quicktype-core/src/language/Elm.ts
+++ b/packages/quicktype-core/src/language/Elm.ts
@@ -229,7 +229,7 @@ export class ElmRenderer extends ConvenienceRenderer {
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
         if (lines.length === 1) {
-            this.emitLine("{-| ", lines[0], " -}");
+            this.emitComments([{ customLines: lines, lineStart: "{-| ", lineEnd: " -}" }]);
         } else {
             this.emitCommentLines(lines, { firstLineStart: "{-| ", lineStart: "", afterComment: "-}" });
         }

--- a/packages/quicktype-core/src/language/Elm.ts
+++ b/packages/quicktype-core/src/language/Elm.ts
@@ -231,7 +231,7 @@ export class ElmRenderer extends ConvenienceRenderer {
         if (lines.length === 1) {
             this.emitLine("{-| ", lines[0], " -}");
         } else {
-            this.emitCommentLines(lines, "", undefined, "-}", "{-| ");
+            this.emitCommentLines(lines, { firstLineStart: "{-| ", lineStart: "", afterLine: "-}" });
         }
     }
 

--- a/packages/quicktype-core/src/language/Elm.ts
+++ b/packages/quicktype-core/src/language/Elm.ts
@@ -574,7 +574,9 @@ export class ElmRenderer extends ConvenienceRenderer {
         });
 
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else if (!this._options.justTypes) {
             this.emitCommentLines([
                 "To decode the JSON data, add this file to your project, run",

--- a/packages/quicktype-core/src/language/Haskell.ts
+++ b/packages/quicktype-core/src/language/Haskell.ts
@@ -185,7 +185,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
         if (lines.length === 1) {
-            this.emitLine("{-| ", lines[0], " -}");
+            this.emitComments([{ customLines: lines, lineStart: "{-| ", lineEnd: " -}" }]);
         } else {
             this.emitCommentLines(lines, {
                 firstLineStart: "{-| ",

--- a/packages/quicktype-core/src/language/Haskell.ts
+++ b/packages/quicktype-core/src/language/Haskell.ts
@@ -187,7 +187,11 @@ export class HaskellRenderer extends ConvenienceRenderer {
         if (lines.length === 1) {
             this.emitLine("{-| ", lines[0], " -}");
         } else {
-            this.emitCommentLines(lines, "", undefined, "-}", "{-| ");
+            this.emitCommentLines(lines, {
+                firstLineStart: "{-| ",
+                lineStart: "",
+                afterLine: "-}"
+            });
         }
     }
 

--- a/packages/quicktype-core/src/language/Haskell.ts
+++ b/packages/quicktype-core/src/language/Haskell.ts
@@ -190,7 +190,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
             this.emitCommentLines(lines, {
                 firstLineStart: "{-| ",
                 lineStart: "",
-                afterLine: "-}"
+                afterComment: "-}"
             });
         }
     }

--- a/packages/quicktype-core/src/language/Java.ts
+++ b/packages/quicktype-core/src/language/Java.ts
@@ -603,7 +603,7 @@ export class JavaRenderer extends ConvenienceRenderer {
     }
 
     public emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, " * ", "/**", " */");
+        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
     }
 
     public emitBlock(line: Sourcelike, f: () => void): void {

--- a/packages/quicktype-core/src/language/Java.ts
+++ b/packages/quicktype-core/src/language/Java.ts
@@ -577,9 +577,7 @@ export class JavaRenderer extends ConvenienceRenderer {
         // FIXME: Why is this necessary?
         this.ensureBlankLine();
         if (!this._haveEmittedLeadingComments && this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
             this.ensureBlankLine();
             this._haveEmittedLeadingComments = true;
         }

--- a/packages/quicktype-core/src/language/Java.ts
+++ b/packages/quicktype-core/src/language/Java.ts
@@ -603,7 +603,7 @@ export class JavaRenderer extends ConvenienceRenderer {
     }
 
     public emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
+        this.emitCommentLines(lines, { lineStart: " * ", beforeComment: "/**", afterComment: " */" });
     }
 
     public emitBlock(line: Sourcelike, f: () => void): void {

--- a/packages/quicktype-core/src/language/Java.ts
+++ b/packages/quicktype-core/src/language/Java.ts
@@ -195,7 +195,10 @@ export function javaNameStyle(
 }
 
 abstract class JavaDateTimeProvider {
-    constructor(protected readonly _renderer: JavaRenderer, protected readonly _className: string) {}
+    constructor(
+        protected readonly _renderer: JavaRenderer,
+        protected readonly _className: string
+    ) {}
     abstract keywords: string[];
 
     abstract dateTimeImports: string[];
@@ -574,7 +577,9 @@ export class JavaRenderer extends ConvenienceRenderer {
         // FIXME: Why is this necessary?
         this.ensureBlankLine();
         if (!this._haveEmittedLeadingComments && this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
             this.ensureBlankLine();
             this._haveEmittedLeadingComments = true;
         }

--- a/packages/quicktype-core/src/language/JavaScript.ts
+++ b/packages/quicktype-core/src/language/JavaScript.ts
@@ -164,7 +164,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, " * ", "/**", " */");
+        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
     }
 
     typeMapTypeFor(t: Type): Sourcelike {

--- a/packages/quicktype-core/src/language/JavaScript.ts
+++ b/packages/quicktype-core/src/language/JavaScript.ts
@@ -164,7 +164,7 @@ export class JavaScriptRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
+        this.emitCommentLines(lines, { lineStart: " * ", beforeComment: "/**", afterComment: " */" });
     }
 
     typeMapTypeFor(t: Type): Sourcelike {

--- a/packages/quicktype-core/src/language/JavaScript.ts
+++ b/packages/quicktype-core/src/language/JavaScript.ts
@@ -554,9 +554,7 @@ function r(name${stringAnnotation}) {
 
     protected emitSourceStructure() {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else {
             this.emitUsageComments();
         }

--- a/packages/quicktype-core/src/language/JavaScript.ts
+++ b/packages/quicktype-core/src/language/JavaScript.ts
@@ -554,7 +554,9 @@ function r(name${stringAnnotation}) {
 
     protected emitSourceStructure() {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else {
             this.emitUsageComments();
         }

--- a/packages/quicktype-core/src/language/JavaScriptPropTypes.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes.ts
@@ -180,7 +180,7 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
                 "  input: MyShape",
                 "};"
             ],
-            "// "
+            { lineStart: "// " }
         );
     }
 

--- a/packages/quicktype-core/src/language/JavaScriptPropTypes.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes.ts
@@ -291,7 +291,9 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
 
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else {
             this.emitUsageComments();
         }

--- a/packages/quicktype-core/src/language/JavaScriptPropTypes.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes.ts
@@ -291,9 +291,7 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
 
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else {
             this.emitUsageComments();
         }

--- a/packages/quicktype-core/src/language/Kotlin.ts
+++ b/packages/quicktype-core/src/language/Kotlin.ts
@@ -292,7 +292,9 @@ export class KotlinRenderer extends ConvenienceRenderer {
 
     protected emitHeader(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else {
             this.emitUsageHeader();
         }

--- a/packages/quicktype-core/src/language/Kotlin.ts
+++ b/packages/quicktype-core/src/language/Kotlin.ts
@@ -236,7 +236,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
+        this.emitCommentLines(lines, { lineStart: " * ", beforeComment: "/**", afterComment: " */" });
     }
 
     protected emitBlock(line: Sourcelike, f: () => void, delimiter: "curly" | "paren" | "lambda" = "curly"): void {

--- a/packages/quicktype-core/src/language/Kotlin.ts
+++ b/packages/quicktype-core/src/language/Kotlin.ts
@@ -236,7 +236,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, " * ", "/**", " */");
+        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
     }
 
     protected emitBlock(line: Sourcelike, f: () => void, delimiter: "curly" | "paren" | "lambda" = "curly"): void {

--- a/packages/quicktype-core/src/language/Kotlin.ts
+++ b/packages/quicktype-core/src/language/Kotlin.ts
@@ -292,9 +292,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
 
     protected emitHeader(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else {
             this.emitUsageHeader();
         }

--- a/packages/quicktype-core/src/language/Objective-C.ts
+++ b/packages/quicktype-core/src/language/Objective-C.ts
@@ -912,9 +912,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
             this.startFile(filename, "h");
 
             if (this.leadingComments !== undefined) {
-                if (Array.isArray(this.leadingComments)) {
-                    this.emitCommentLines(this.leadingComments);
-                }
+                this.emitComments(this.leadingComments);
             } else if (!this._options.justTypes) {
                 this.emitCommentLines(["To parse this JSON:", ""]);
                 this.emitLine("//   NSError *error;");

--- a/packages/quicktype-core/src/language/Objective-C.ts
+++ b/packages/quicktype-core/src/language/Objective-C.ts
@@ -290,7 +290,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, "/// ");
+        this.emitCommentLines(lines, { lineStart: "/// " });
     }
 
     protected emitBlock(line: Sourcelike, f: () => void): void {

--- a/packages/quicktype-core/src/language/Objective-C.ts
+++ b/packages/quicktype-core/src/language/Objective-C.ts
@@ -912,7 +912,9 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
             this.startFile(filename, "h");
 
             if (this.leadingComments !== undefined) {
-                this.emitCommentLines(this.leadingComments);
+                if (Array.isArray(this.leadingComments)) {
+                    this.emitCommentLines(this.leadingComments);
+                }
             } else if (!this._options.justTypes) {
                 this.emitCommentLines(["To parse this JSON:", ""]);
                 this.emitLine("//   NSError *error;");

--- a/packages/quicktype-core/src/language/Php.ts
+++ b/packages/quicktype-core/src/language/Php.ts
@@ -246,7 +246,7 @@ export class PhpRenderer extends ConvenienceRenderer {
     }
 
     public emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
+        this.emitCommentLines(lines, { lineStart: " * ", beforeComment: "/**", afterComment: " */" });
     }
 
     public emitBlock(line: Sourcelike, f: () => void): void {

--- a/packages/quicktype-core/src/language/Php.ts
+++ b/packages/quicktype-core/src/language/Php.ts
@@ -229,7 +229,9 @@ export class PhpRenderer extends ConvenienceRenderer {
     protected startFile(_basename: Sourcelike): void {
         this.ensureBlankLine();
         if (!this._haveEmittedLeadingComments && this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
             this.ensureBlankLine();
             this._haveEmittedLeadingComments = true;
         }

--- a/packages/quicktype-core/src/language/Php.ts
+++ b/packages/quicktype-core/src/language/Php.ts
@@ -246,7 +246,7 @@ export class PhpRenderer extends ConvenienceRenderer {
     }
 
     public emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, " * ", "/**", " */");
+        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
     }
 
     public emitBlock(line: Sourcelike, f: () => void): void {

--- a/packages/quicktype-core/src/language/Php.ts
+++ b/packages/quicktype-core/src/language/Php.ts
@@ -229,9 +229,7 @@ export class PhpRenderer extends ConvenienceRenderer {
     protected startFile(_basename: Sourcelike): void {
         this.ensureBlankLine();
         if (!this._haveEmittedLeadingComments && this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
             this.ensureBlankLine();
             this._haveEmittedLeadingComments = true;
         }

--- a/packages/quicktype-core/src/language/Pike.ts
+++ b/packages/quicktype-core/src/language/Pike.ts
@@ -269,7 +269,7 @@ export class PikeRenderer extends ConvenienceRenderer {
                 "and will likely throw an error, if the JSON string does not",
                 "match the expected interface, even if the JSON itself is valid."
             ],
-            "// "
+            { lineStart: "// " }
         );
     }
 

--- a/packages/quicktype-core/src/language/Python.ts
+++ b/packages/quicktype-core/src/language/Python.ts
@@ -287,7 +287,7 @@ export class PythonRenderer extends ConvenienceRenderer {
             this.emitCommentLines(lines, {
                 firstLineStart: '"""',
                 lineStart: "",
-                afterLine: '"""'
+                afterComment: '"""'
             });
         }
     }

--- a/packages/quicktype-core/src/language/Python.ts
+++ b/packages/quicktype-core/src/language/Python.ts
@@ -284,7 +284,11 @@ export class PythonRenderer extends ConvenienceRenderer {
             }, lines[0]);
             this.emitLine('"""', docstring, '"""');
         } else {
-            this.emitCommentLines(lines, "", undefined, '"""', '"""');
+            this.emitCommentLines(lines, {
+                firstLineStart: '"""',
+                lineStart: "",
+                afterLine: '"""'
+            });
         }
     }
 

--- a/packages/quicktype-core/src/language/Python.ts
+++ b/packages/quicktype-core/src/language/Python.ts
@@ -509,9 +509,7 @@ export class PythonRenderer extends ConvenienceRenderer {
         const supportLines = this.gatherSource(() => this.emitSupportCode());
 
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         }
         this.ensureBlankLine();
         this.emitImports();

--- a/packages/quicktype-core/src/language/Python.ts
+++ b/packages/quicktype-core/src/language/Python.ts
@@ -282,7 +282,7 @@ export class PythonRenderer extends ConvenienceRenderer {
 
                 return content;
             }, lines[0]);
-            this.emitLine('"""', docstring, '"""');
+            this.emitComments([{ customLines: [docstring], lineStart: '"""', lineEnd: '"""' }]);
         } else {
             this.emitCommentLines(lines, {
                 firstLineStart: '"""',

--- a/packages/quicktype-core/src/language/Python.ts
+++ b/packages/quicktype-core/src/language/Python.ts
@@ -509,7 +509,9 @@ export class PythonRenderer extends ConvenienceRenderer {
         const supportLines = this.gatherSource(() => this.emitSupportCode());
 
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         }
         this.ensureBlankLine();
         this.emitImports();

--- a/packages/quicktype-core/src/language/Rust.ts
+++ b/packages/quicktype-core/src/language/Rust.ts
@@ -481,7 +481,9 @@ export class RustRenderer extends ConvenienceRenderer {
 
     protected emitLeadingComments(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
             return;
         }
 

--- a/packages/quicktype-core/src/language/Rust.ts
+++ b/packages/quicktype-core/src/language/Rust.ts
@@ -481,9 +481,7 @@ export class RustRenderer extends ConvenienceRenderer {
 
     protected emitLeadingComments(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
             return;
         }
 

--- a/packages/quicktype-core/src/language/Scala3.ts
+++ b/packages/quicktype-core/src/language/Scala3.ts
@@ -13,20 +13,10 @@ import {
     isNumeric,
     legalizeCharacters,
     splitIntoWords
-
 } from "../support/Strings";
 import { assertNever } from "../support/Support";
 import { TargetLanguage } from "../TargetLanguage";
-import {
-    ArrayType,
-    ClassProperty,
-    ClassType,
-    EnumType,
-    MapType,
-    ObjectType,
-    Type,
-    UnionType
-} from "../Type";
+import { ArrayType, ClassProperty, ClassType, EnumType, MapType, ObjectType, Type, UnionType } from "../Type";
 import { matchType, nullableFromUnion, removeNullFromUnion } from "../TypeUtils";
 import { RenderContext } from "../Renderer";
 
@@ -37,13 +27,16 @@ export enum Framework {
 }
 
 export const scala3Options = {
-    framework: new EnumOption("framework", "Serialization framework",
+    framework: new EnumOption(
+        "framework",
+        "Serialization framework",
         [
             ["just-types", Framework.None],
             ["circe", Framework.Circe],
-            ["upickle", Framework.Upickle],
-        ]
-        , undefined),
+            ["upickle", Framework.Upickle]
+        ],
+        undefined
+    ),
     packageName: new StringOption("package", "Package", "PACKAGE", "quicktype")
 };
 
@@ -135,13 +128,17 @@ const keywords = [
     "Enum"
 ];
 
-
 /**
  * Check if given parameter name should be wrapped in a backtick
  * @param paramName
  */
 const shouldAddBacktick = (paramName: string): boolean => {
-    return keywords.some(s => paramName === s) || invalidSymbols.some(s => paramName.includes(s)) || !isNaN(+parseFloat(paramName)) || !isNaN(parseInt(paramName.charAt(0)));
+    return (
+        keywords.some(s => paramName === s) ||
+        invalidSymbols.some(s => paramName.includes(s)) ||
+        !isNaN(+parseFloat(paramName)) ||
+        !isNaN(parseInt(paramName.charAt(0)))
+    );
 };
 
 const wrapOption = (s: string, optional: boolean): string => {
@@ -248,10 +245,10 @@ export class Scala3Renderer extends ConvenienceRenderer {
             delimiter === "curly"
                 ? ["{", "}"]
                 : delimiter === "paren"
-                    ? ["(", ")"]
-                    : delimiter === "none"
-                        ? ["", ""]
-                        : ["{", "})"];
+                ? ["(", ")"]
+                : delimiter === "none"
+                ? ["", ""]
+                : ["{", "})"];
         this.emitLine(line, " ", open);
         this.indent(f);
         this.emitLine(close);
@@ -308,7 +305,9 @@ export class Scala3Renderer extends ConvenienceRenderer {
 
     protected emitHeader(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else {
             this.emitUsageHeader();
         }
@@ -393,7 +392,7 @@ export class Scala3Renderer extends ConvenienceRenderer {
     }
 
     protected emitClassDefinitionMethods() {
-      this.emitLine(")");
+        this.emitLine(")");
     }
 
     protected emitEnumDefinition(e: EnumType, enumName: Name): void {
@@ -403,19 +402,25 @@ export class Scala3Renderer extends ConvenienceRenderer {
             ["enum ", enumName, " : "],
             () => {
                 let count = e.cases.size;
-                if (count > 0) { this.emitItem("\t case ") };
+                if (count > 0) {
+                    this.emitItem("\t case ");
+                }
                 this.forEachEnumCase(e, "none", (name, jsonName) => {
                     if (!(jsonName == "")) {
                         const backticks =
                             shouldAddBacktick(jsonName) ||
                             jsonName.includes(" ") ||
-                            !isNaN(parseInt(jsonName.charAt(0)))
-                        if (backticks) { this.emitItem("`") }
+                            !isNaN(parseInt(jsonName.charAt(0)));
+                        if (backticks) {
+                            this.emitItem("`");
+                        }
                         this.emitItemOnce([name]);
-                        if (backticks) { this.emitItem("`") }
+                        if (backticks) {
+                            this.emitItem("`");
+                        }
                         if (--count > 0) this.emitItem([","]);
                     } else {
-                        --count
+                        --count;
                     }
                 });
             },
@@ -433,7 +438,7 @@ export class Scala3Renderer extends ConvenienceRenderer {
         this.emitDescription(this.descriptionForType(u));
 
         const [maybeNull, nonNulls] = removeNullFromUnion(u, sortBy);
-        const theTypes: Array<Sourcelike> = []
+        const theTypes: Array<Sourcelike> = [];
         this.forEachUnionMember(u, nonNulls, "none", null, (_, t) => {
             theTypes.push(this.scalaType(t));
         });
@@ -470,7 +475,6 @@ export class Scala3Renderer extends ConvenienceRenderer {
 }
 
 export class UpickleRenderer extends Scala3Renderer {
-
     protected emitClassDefinitionMethods() {
         this.emitLine(") derives ReadWriter ");
     }
@@ -481,14 +485,14 @@ export class UpickleRenderer extends Scala3Renderer {
         this.emitLine("import upickle.default.*");
         this.ensureBlankLine();
     }
-
 }
 
 export class Smithy4sRenderer extends Scala3Renderer {
-
     protected emitHeader(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else {
             this.emitUsageHeader();
         }
@@ -513,8 +517,6 @@ export class Smithy4sRenderer extends Scala3Renderer {
         this.emitLine("structure ", className, "{}");
     }
 
-
-
     protected emitEnumDefinition(e: EnumType, enumName: Name): void {
         this.emitDescription(this.descriptionForType(e));
 
@@ -522,30 +524,26 @@ export class Smithy4sRenderer extends Scala3Renderer {
         this.emitItem(["enum ", enumName, " { "]);
         let count = e.cases.size;
         this.forEachEnumCase(e, "none", (name, jsonName) => {
-            // if (!(jsonName == "")) { 
+            // if (!(jsonName == "")) {
             /*                 const backticks = 
                                 shouldAddBacktick(jsonName) || 
                                 jsonName.includes(" ") || 
                                 !isNaN(parseInt(jsonName.charAt(0)))
                             if (backticks) {this.emitItem("`")} else  */
             this.emitLine();
-            this.emitItem([name, " = \"", jsonName, "\""]);
+            this.emitItem([name, ' = "', jsonName, '"']);
             //                if (backticks) {this.emitItem("`")}
             if (--count > 0) this.emitItem([","]);
             //} else {
             //--count
-            //} 
+            //}
         });
         this.ensureBlankLine();
         this.emitItem(["}"]);
-
     }
-
 }
 
-
 export class CirceRenderer extends Scala3Renderer {
-
     seenUnionTypes: Array<string> = [];
 
     protected circeEncoderForType(t: Type, _ = false, noOptional = false, paramName: string = ""): Sourcelike {
@@ -602,15 +600,14 @@ export class CirceRenderer extends Scala3Renderer {
                                 jsonName.includes(" ") || 
                                 !isNaN(parseInt(jsonName.charAt(0)))
                             if (backticks) {this.emitItem("`")} else  */
-            this.emitItem(["\"", jsonName, "\""]);
+            this.emitItem(['"', jsonName, '"']);
             //                if (backticks) {this.emitItem("`")}
             if (--count > 0) this.emitItem([" | "]);
             //} else {
             //--count
-            //} 
+            //}
         });
         this.ensureBlankLine();
-
     }
 
     protected emitHeader(): void {
@@ -622,25 +619,45 @@ export class CirceRenderer extends Scala3Renderer {
         this.emitLine("import cats.syntax.functor._");
         this.ensureBlankLine();
 
-        this.emitLine("// For serialising string unions")
-        this.emitLine("given [A <: Singleton](using A <:< String): Decoder[A] = Decoder.decodeString.emapTry(x => Try(x.asInstanceOf[A])) ");
-        this.emitLine("given [A <: Singleton](using ev: A <:< String): Encoder[A] = Encoder.encodeString.contramap(ev) ");
+        this.emitLine("// For serialising string unions");
+        this.emitLine(
+            "given [A <: Singleton](using A <:< String): Decoder[A] = Decoder.decodeString.emapTry(x => Try(x.asInstanceOf[A])) "
+        );
+        this.emitLine(
+            "given [A <: Singleton](using ev: A <:< String): Encoder[A] = Encoder.encodeString.contramap(ev) "
+        );
         this.ensureBlankLine();
-        this.emitLine("// If a union has a null in, then we'll need this too... ")
+        this.emitLine("// If a union has a null in, then we'll need this too... ");
         this.emitLine("type NullValue = None.type");
     }
 
     protected emitTopLevelArray(t: ArrayType, name: Name): void {
         super.emitTopLevelArray(t, name);
         const elementType = this.scalaType(t.items);
-        this.emitLine(["given (using ev : ", elementType, "): Encoder[Map[String,", elementType, "]] = Encoder.encodeMap[String, ", elementType, "]"]);
+        this.emitLine([
+            "given (using ev : ",
+            elementType,
+            "): Encoder[Map[String,",
+            elementType,
+            "]] = Encoder.encodeMap[String, ",
+            elementType,
+            "]"
+        ]);
     }
 
     protected emitTopLevelMap(t: MapType, name: Name): void {
         super.emitTopLevelMap(t, name);
         const elementType = this.scalaType(t.values);
         this.ensureBlankLine();
-        this.emitLine(["given (using ev : ", elementType, "): Encoder[Map[String, ", elementType, "]] = Encoder.encodeMap[String, ", elementType, "]"]);
+        this.emitLine([
+            "given (using ev : ",
+            elementType,
+            "): Encoder[Map[String, ",
+            elementType,
+            "]] = Encoder.encodeMap[String, ",
+            elementType,
+            "]"
+        ]);
     }
 
     protected emitUnionDefinition(u: UnionType, unionName: Name): void {
@@ -653,7 +670,7 @@ export class CirceRenderer extends Scala3Renderer {
         this.emitDescription(this.descriptionForType(u));
 
         const [maybeNull, nonNulls] = removeNullFromUnion(u, sortBy);
-        const theTypes: Array<Sourcelike> = []
+        const theTypes: Array<Sourcelike> = [];
         this.forEachUnionMember(u, nonNulls, "none", null, (_, t) => {
             theTypes.push(this.scalaType(t));
         });
@@ -670,38 +687,43 @@ export class CirceRenderer extends Scala3Renderer {
         this.ensureBlankLine();
         if (!this.seenUnionTypes.some(y => y === thisUnionType)) {
             this.seenUnionTypes.push(thisUnionType);
-            const sourceLikeTypes: Array<[Sourcelike, Type]> = []
+            const sourceLikeTypes: Array<[Sourcelike, Type]> = [];
             this.forEachUnionMember(u, nonNulls, "none", null, (_, t) => {
                 sourceLikeTypes.push([this.scalaType(t), t]);
-
             });
             if (maybeNull !== null) {
                 sourceLikeTypes.push([this.nameForUnionMember(u, maybeNull), maybeNull]);
             }
 
-            this.emitLine(["given Decoder[", unionName, "] = {"])
+            this.emitLine(["given Decoder[", unionName, "] = {"]);
             this.indent(() => {
-                this.emitLine(["List[Decoder[", unionName, "]]("])
+                this.emitLine(["List[Decoder[", unionName, "]]("]);
                 this.indent(() => {
-                    sourceLikeTypes.forEach((t) => {
+                    sourceLikeTypes.forEach(t => {
                         this.emitLine(["Decoder[", t[0], "].widen,"]);
                     });
-                })
-                this.emitLine(").reduceLeft(_ or _)")
-            }
-            )
-            this.emitLine(["}"])
+                });
+                this.emitLine(").reduceLeft(_ or _)");
+            });
+            this.emitLine(["}"]);
 
             this.ensureBlankLine();
 
-            this.emitLine(["given Encoder[", unionName, "] = Encoder.instance {"])
+            this.emitLine(["given Encoder[", unionName, "] = Encoder.instance {"]);
             this.indent(() => {
                 sourceLikeTypes.forEach((t, i) => {
                     const paramTemp = `enc${i.toString()}`;
-                    this.emitLine(["case ", paramTemp, " : ", t[0], " => ", this.circeEncoderForType(t[1], false, false, paramTemp)]);
+                    this.emitLine([
+                        "case ",
+                        paramTemp,
+                        " : ",
+                        t[0],
+                        " => ",
+                        this.circeEncoderForType(t[1], false, false, paramTemp)
+                    ]);
                 });
-            })
-            this.emitLine("}")
+            });
+            this.emitLine("}");
         }
     }
 }
@@ -741,4 +763,3 @@ export class Scala3TargetLanguage extends TargetLanguage {
         }
     }
 }
-

--- a/packages/quicktype-core/src/language/Scala3.ts
+++ b/packages/quicktype-core/src/language/Scala3.ts
@@ -233,7 +233,7 @@ export class Scala3Renderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, " * ", "/**", " */");
+        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
     }
 
     protected emitBlock(

--- a/packages/quicktype-core/src/language/Scala3.ts
+++ b/packages/quicktype-core/src/language/Scala3.ts
@@ -305,9 +305,7 @@ export class Scala3Renderer extends ConvenienceRenderer {
 
     protected emitHeader(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else {
             this.emitUsageHeader();
         }
@@ -490,9 +488,7 @@ export class UpickleRenderer extends Scala3Renderer {
 export class Smithy4sRenderer extends Scala3Renderer {
     protected emitHeader(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else {
             this.emitUsageHeader();
         }

--- a/packages/quicktype-core/src/language/Scala3.ts
+++ b/packages/quicktype-core/src/language/Scala3.ts
@@ -233,7 +233,7 @@ export class Scala3Renderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
+        this.emitCommentLines(lines, { lineStart: " * ", beforeComment: "/**", afterComment: " */" });
     }
 
     protected emitBlock(

--- a/packages/quicktype-core/src/language/Smithy4s.ts
+++ b/packages/quicktype-core/src/language/Smithy4s.ts
@@ -268,9 +268,7 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
 
     protected emitHeader(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else {
             this.emitUsageHeader();
         }

--- a/packages/quicktype-core/src/language/Smithy4s.ts
+++ b/packages/quicktype-core/src/language/Smithy4s.ts
@@ -13,20 +13,10 @@ import {
     isNumeric,
     legalizeCharacters,
     splitIntoWords
-
 } from "../support/Strings";
 import { assertNever } from "../support/Support";
 import { TargetLanguage } from "../TargetLanguage";
-import {
-    ArrayType,
-    ClassProperty,
-    ClassType,
-    EnumType,
-    MapType,
-    ObjectType,
-    Type,
-    UnionType
-} from "../Type";
+import { ArrayType, ClassProperty, ClassType, EnumType, MapType, ObjectType, Type, UnionType } from "../Type";
 import { matchCompoundType, matchType, nullableFromUnion, removeNullFromUnion } from "../TypeUtils";
 import { RenderContext } from "../Renderer";
 
@@ -35,11 +25,7 @@ export enum Framework {
 }
 
 export const SmithyOptions = {
-    framework: new EnumOption("framework", "Serialization framework",
-        [
-            ["just-types", Framework.None]
-        ]
-        , undefined),
+    framework: new EnumOption("framework", "Serialization framework", [["just-types", Framework.None]], undefined),
     packageName: new StringOption("package", "Package", "PACKAGE", "quicktype")
 };
 
@@ -50,7 +36,7 @@ const invalidSymbols = [
     "+",
     "!",
     "@",
-    "#",    
+    "#",
     "%",
     "^",
     "&",
@@ -74,9 +60,9 @@ const invalidSymbols = [
 const keywords = [
     "abstract",
     "case",
-    "catch",        
+    "catch",
     "do",
-    "else",    
+    "else",
     "export",
     "false",
     "final",
@@ -86,7 +72,7 @@ const keywords = [
     "if",
     "implicit",
     "import",
-    "new",     
+    "new",
     "override",
     "package",
     "private",
@@ -99,7 +85,7 @@ const keywords = [
     "throw",
     "trait",
     "try",
-    "true",    
+    "true",
     "val",
     "var",
     "while",
@@ -121,13 +107,17 @@ const keywords = [
     "Enum"
 ];
 
-
 /**
  * Check if given parameter name should be wrapped in a backtick
  * @param paramName
  */
 const shouldAddBacktick = (paramName: string): boolean => {
-    return keywords.some(s => paramName === s) || invalidSymbols.some(s => paramName.includes(s)) || !isNaN(parseFloat(paramName)) || !isNaN(parseInt(paramName.charAt(0)));
+    return (
+        keywords.some(s => paramName === s) ||
+        invalidSymbols.some(s => paramName.includes(s)) ||
+        !isNaN(parseFloat(paramName)) ||
+        !isNaN(parseInt(paramName.charAt(0)))
+    );
 };
 
 function isPartCharacter(codePoint: number): boolean {
@@ -215,10 +205,10 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
             delimiter === "curly"
                 ? ["{", "}"]
                 : delimiter === "paren"
-                    ? ["(", ")"]
-                    : delimiter === "none"
-                        ? ["", ""]
-                        : ["{", "})"];
+                ? ["(", ")"]
+                : delimiter === "none"
+                ? ["", ""]
+                : ["{", "})"];
         this.emitLine(line, " ", open);
         this.indent(f);
         this.emitLine(close);
@@ -236,11 +226,11 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
     }
 
     protected emitArrayType(_: ArrayType, smithyType: Sourcelike): void {
-        this.emitLine([ "list " , smithyType , " { member : ",  "}"  ])
+        this.emitLine(["list ", smithyType, " { member : ", "}"]);
     }
 
     protected mapType(mapType: MapType, _ = false): Sourcelike {
-        return mapType.getCombinedName().toString() + "Map"
+        return mapType.getCombinedName().toString() + "Map";
         //return [this.scalaType(mapType.values, withIssues), "Map"];
     }
 
@@ -265,14 +255,12 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
             unionType => {
                 const nullable = nullableFromUnion(unionType);
                 if (nullable !== null) {
-                    return [this.scalaType(nullable, withIssues)];                    
+                    return [this.scalaType(nullable, withIssues)];
                 }
                 return this.nameForNamedType(unionType);
             }
         );
     }
-
-
 
     protected emitUsageHeader(): void {
         // To be overridden
@@ -280,17 +268,19 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
 
     protected emitHeader(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else {
             this.emitUsageHeader();
         }
 
         this.ensureBlankLine();
-        this.emitLine("$version: \"2\"");
-        this.emitLine("namespace ", this._scalaOptions.packageName);        
+        this.emitLine('$version: "2"');
+        this.emitLine("namespace ", this._scalaOptions.packageName);
         this.ensureBlankLine();
-        
-        this.emitLine("document NullValue");        
+
+        this.emitLine("document NullValue");
         this.ensureBlankLine();
     }
 
@@ -330,7 +320,6 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
         this.indent(() => {
             let count = c.getProperties().size;
             let first = true;
-            
 
             this.forEachClassProperty(c, "none", (_, jsonName, p) => {
                 const nullable = p.type.kind === "union" && nullableFromUnion(p.type as UnionType) !== null;
@@ -338,9 +327,9 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
                 const last = --count === 0;
                 const meta: Array<() => void> = [];
 
-                const laterType = p.type.kind === "array" || p.type.kind === "map"
-                if(laterType) {
-                    emitLater.push(p)
+                const laterType = p.type.kind === "array" || p.type.kind === "map";
+                if (laterType) {
+                    emitLater.push(p);
                 }
 
                 const description = this.descriptionForClassProperty(c, jsonName);
@@ -362,7 +351,7 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
                     nameWithBackticks,
                     " : ",
                     scalaType(p),
-                    
+
                     last ? "" : ","
                 );
 
@@ -372,29 +361,41 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
 
                 first = false;
             });
-        });        
+        });
         this.emitClassDefinitionMethods(emitLater);
     }
 
-    protected emitClassDefinitionMethods( arrayTypes : ClassProperty[] ) {
+    protected emitClassDefinitionMethods(arrayTypes: ClassProperty[]) {
         this.emitLine("}");
-        arrayTypes.forEach (p  => { 
-                function ignore<T extends Type>(_: T): void {
-                    return;
-                }                
-                matchCompoundType(p.type, 
-                    at => {
-                        this.emitLine([ "list ",  this.scalaType(at, true) , "{ member: ", this.scalaType(at.items, true), "}" ])},
-                    ignore,
-                    mt =>{                         
-                        this.emitLine([ "map ",  this.scalaType(mt, true) , "{ key: String , value: ", this.scalaType(mt.values, true), "}" ])
-                    },
-                    ignore, 
-                    ignore)
-                
+        arrayTypes.forEach(p => {
+            function ignore<T extends Type>(_: T): void {
+                return;
             }
-        )
-
+            matchCompoundType(
+                p.type,
+                at => {
+                    this.emitLine([
+                        "list ",
+                        this.scalaType(at, true),
+                        "{ member: ",
+                        this.scalaType(at.items, true),
+                        "}"
+                    ]);
+                },
+                ignore,
+                mt => {
+                    this.emitLine([
+                        "map ",
+                        this.scalaType(mt, true),
+                        "{ key: String , value: ",
+                        this.scalaType(mt.values, true),
+                        "}"
+                    ]);
+                },
+                ignore,
+                ignore
+            );
+        });
     }
 
     protected emitEnumDefinition(e: EnumType, enumName: Name): void {
@@ -404,28 +405,26 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
         this.emitItem(["enum ", enumName, " { "]);
         let count = e.cases.size;
 
-        
-            this.forEachEnumCase(e, "none", (name, jsonName) => {
-                // if (!(jsonName == "")) { 
-                /*                 const backticks = 
+        this.forEachEnumCase(e, "none", (name, jsonName) => {
+            // if (!(jsonName == "")) {
+            /*                 const backticks = 
                                     shouldAddBacktick(jsonName) || 
                                     jsonName.includes(" ") || 
                                     !isNaN(parseInt(jsonName.charAt(0)))
                                 if (backticks) {this.emitItem("`")} else  */
-                this.emitLine();
-                
-                    this.emitItem([name, " = \"", jsonName, "\""]);
-                
-                //                if (backticks) {this.emitItem("`")}
-                if (--count > 0) this.emitItem([","]);
-                //} else {
-                //--count
-                //} 
-            });
-        
+            this.emitLine();
+
+            this.emitItem([name, ' = "', jsonName, '"']);
+
+            //                if (backticks) {this.emitItem("`")}
+            if (--count > 0) this.emitItem([","]);
+            //} else {
+            //--count
+            //}
+        });
+
         this.ensureBlankLine();
         this.emitItem(["}"]);
-
     }
 
     protected emitUnionDefinition(u: UnionType, unionName: Name): void {
@@ -437,15 +436,14 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
 
         const emitLater: Array<Type> = [];
 
-
         this.emitDescription(this.descriptionForType(u));
 
         const [maybeNull, nonNulls] = removeNullFromUnion(u, sortBy);
-        const theTypes: Array<Sourcelike> = []
+        const theTypes: Array<Sourcelike> = [];
         this.forEachUnionMember(u, nonNulls, "none", null, (_, t) => {
-            const laterType = t.kind === "array" || t.kind === "map"
-            if(laterType) {
-                emitLater.push(t)
+            const laterType = t.kind === "array" || t.kind === "map";
+            if (laterType) {
+                emitLater.push(t);
             }
             theTypes.push(this.scalaType(t));
         });
@@ -456,29 +454,41 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
         this.emitLine(["@untagged union ", unionName, " { "]);
         this.indent(() => {
             theTypes.forEach((t, i) => {
-                this.emitLine([String.fromCharCode(i+65), " : ", t]);
+                this.emitLine([String.fromCharCode(i + 65), " : ", t]);
             });
         });
-        this.emitLine("}")
+        this.emitLine("}");
         this.ensureBlankLine();
 
-        emitLater.forEach (p  => { 
+        emitLater.forEach(p => {
             function ignore<T extends Type>(_: T): void {
                 return;
-            }            
-            matchCompoundType(p, 
-                at => {                    
-                    this.emitLine([ "list ",  this.scalaType(at, true) , "{ member: ", this.scalaType(at.items, true), "}" ])},
-                ignore,
-                mt =>{                     
-                    this.emitLine([ "map ",  this.scalaType(mt, true) , "{ key: String , value: ", this.scalaType(mt.values, true), "}" ])
+            }
+            matchCompoundType(
+                p,
+                at => {
+                    this.emitLine([
+                        "list ",
+                        this.scalaType(at, true),
+                        "{ member: ",
+                        this.scalaType(at.items, true),
+                        "}"
+                    ]);
                 },
-                ignore, 
-                ignore)
-            
-        }
-    )
-        
+                ignore,
+                mt => {
+                    this.emitLine([
+                        "map ",
+                        this.scalaType(mt, true),
+                        "{ key: String , value: ",
+                        this.scalaType(mt.values, true),
+                        "}"
+                    ]);
+                },
+                ignore,
+                ignore
+            );
+        });
     }
 
     protected emitSourceStructure(): void {
@@ -501,7 +511,6 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
         );
     }
 }
-
 
 export class SmithyTargetLanguage extends TargetLanguage {
     constructor() {
@@ -534,4 +543,3 @@ export class SmithyTargetLanguage extends TargetLanguage {
         }
     }
 }
-

--- a/packages/quicktype-core/src/language/Smithy4s.ts
+++ b/packages/quicktype-core/src/language/Smithy4s.ts
@@ -193,7 +193,7 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
+        this.emitCommentLines(lines, { lineStart: " * ", beforeComment: "/**", afterComment: " */" });
     }
 
     protected emitBlock(

--- a/packages/quicktype-core/src/language/Smithy4s.ts
+++ b/packages/quicktype-core/src/language/Smithy4s.ts
@@ -193,7 +193,7 @@ export class Smithy4sRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, " * ", "/**", " */");
+        this.emitCommentLines(lines, { lineStart: " * ", beforeLine: "/**", afterLine: " */" });
     }
 
     protected emitBlock(

--- a/packages/quicktype-core/src/language/Swift.ts
+++ b/packages/quicktype-core/src/language/Swift.ts
@@ -485,7 +485,9 @@ export class SwiftRenderer extends ConvenienceRenderer {
 
     private renderHeader(type: Type, name: Name): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else if (!this._options.justTypes) {
             if (this._options.multiFileOutput) {
                 this.emitLineOnce(
@@ -536,7 +538,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
             this.emitLineOnce("import Alamofire");
         }
         if (this._options.optionalEnums) {
-            this.emitLineOnce("import OptionallyDecodable // https://github.com/idrougge/OptionallyDecodable");    
+            this.emitLineOnce("import OptionallyDecodable // https://github.com/idrougge/OptionallyDecodable");
         }
         this.ensureBlankLine();
     }
@@ -574,7 +576,10 @@ export class SwiftRenderer extends ConvenienceRenderer {
         return protocols;
     }
 
-    private getProtocolString(kind: "struct" | "class" | "enum", baseClass: string | undefined = undefined): Sourcelike {
+    private getProtocolString(
+        kind: "struct" | "class" | "enum",
+        baseClass: string | undefined = undefined
+    ): Sourcelike {
         let protocols = this.getProtocolsArray(kind);
         if (baseClass) {
             protocols.unshift(baseClass);
@@ -1416,7 +1421,6 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
         if (!this._options.justTypes) {
             this.emitSupportFunctions4();
         }
-
     }
 
     private emitAlamofireExtension() {

--- a/packages/quicktype-core/src/language/Swift.ts
+++ b/packages/quicktype-core/src/language/Swift.ts
@@ -485,9 +485,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
 
     private renderHeader(type: Type, name: Name): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else if (!this._options.justTypes) {
             if (this._options.multiFileOutput) {
                 this.emitLineOnce(

--- a/packages/quicktype-core/src/language/Swift.ts
+++ b/packages/quicktype-core/src/language/Swift.ts
@@ -374,7 +374,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
     }
 
     protected emitDescriptionBlock(lines: Sourcelike[]): void {
-        this.emitCommentLines(lines, "/// ");
+        this.emitCommentLines(lines, { lineStart: "/// " });
     }
 
     private emitBlock(line: Sourcelike, f: () => void): void {

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema.ts
@@ -235,7 +235,9 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
 
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         }
 
         this.emitImports();

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema.ts
@@ -235,9 +235,7 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
 
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         }
 
         this.emitImports();

--- a/packages/quicktype-core/src/language/TypeScriptZod.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod.ts
@@ -230,9 +230,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
 
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         }
 
         this.emitImports();

--- a/packages/quicktype-core/src/language/TypeScriptZod.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod.ts
@@ -230,7 +230,9 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
 
     protected emitSourceStructure(): void {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         }
 
         this.emitImports();

--- a/packages/quicktype-core/src/language/ruby/index.ts
+++ b/packages/quicktype-core/src/language/ruby/index.ts
@@ -620,9 +620,7 @@ export class RubyRenderer extends ConvenienceRenderer {
 
     protected emitSourceStructure() {
         if (this.leadingComments !== undefined) {
-            if (Array.isArray(this.leadingComments)) {
-                this.emitCommentLines(this.leadingComments);
-            }
+            this.emitComments(this.leadingComments);
         } else if (!this._options.justTypes) {
             this.emitLine("# This code may look unusually verbose for Ruby (and it is), but");
             this.emitLine("# it performs some subtle and complex validation of JSON data.");

--- a/packages/quicktype-core/src/language/ruby/index.ts
+++ b/packages/quicktype-core/src/language/ruby/index.ts
@@ -620,7 +620,9 @@ export class RubyRenderer extends ConvenienceRenderer {
 
     protected emitSourceStructure() {
         if (this.leadingComments !== undefined) {
-            this.emitCommentLines(this.leadingComments);
+            if (Array.isArray(this.leadingComments)) {
+                this.emitCommentLines(this.leadingComments);
+            }
         } else if (!this._options.justTypes) {
             this.emitLine("# This code may look unusually verbose for Ruby (and it is), but");
             this.emitLine("# it performs some subtle and complex validation of JSON data.");

--- a/packages/quicktype-core/src/support/Comments.ts
+++ b/packages/quicktype-core/src/support/Comments.ts
@@ -1,0 +1,12 @@
+type DescriptionBlockCommentConfig = { descriptionBlock: string[] };
+type InlineCommentConfig = { lines: string[] };
+type CustomCommentConfig = {
+    lineStart?: string;
+    beforeLine?: string;
+    afterLine?: string;
+    firstLineStart?: string;
+};
+
+type CommentConfig = DescriptionBlockCommentConfig | InlineCommentConfig | CustomCommentConfig;
+
+export type LeadingComments = string[] | CommentConfig;

--- a/packages/quicktype-core/src/support/Comments.ts
+++ b/packages/quicktype-core/src/support/Comments.ts
@@ -1,3 +1,5 @@
+import { Sourcelike } from "../Source";
+
 export type CommentOptions = {
     lineStart?: string;
     lineEnd?: string;
@@ -6,10 +8,10 @@ export type CommentOptions = {
     firstLineStart?: string;
 };
 
-type DescriptionBlockCommentConfig = { descriptionBlock: string[] };
-type InlineCommentConfig = { lines: string[] };
+type DescriptionBlockCommentConfig = { descriptionBlock: Sourcelike[] };
+type InlineCommentConfig = { lines: Sourcelike[] };
 type CustomCommentConfig = CommentOptions & {
-    customLines: string[];
+    customLines: Sourcelike[];
 };
 
 export type CommentConfig = DescriptionBlockCommentConfig | InlineCommentConfig | CustomCommentConfig;

--- a/packages/quicktype-core/src/support/Comments.ts
+++ b/packages/quicktype-core/src/support/Comments.ts
@@ -1,12 +1,18 @@
 type DescriptionBlockCommentConfig = { descriptionBlock: string[] };
 type InlineCommentConfig = { lines: string[] };
 type CustomCommentConfig = {
+    customLines: string[];
     lineStart?: string;
+    lineEnd?: string;
     beforeLine?: string;
     afterLine?: string;
     firstLineStart?: string;
 };
 
-type CommentConfig = DescriptionBlockCommentConfig | InlineCommentConfig | CustomCommentConfig;
+export type CommentConfig = DescriptionBlockCommentConfig | InlineCommentConfig | CustomCommentConfig;
 
-export type LeadingComments = string[] | CommentConfig;
+export type Comment = string | CommentConfig;
+
+export const isStringComment = (comment: Comment): comment is string => {
+    return typeof comment === "string";
+};

--- a/packages/quicktype-core/src/support/Comments.ts
+++ b/packages/quicktype-core/src/support/Comments.ts
@@ -1,12 +1,15 @@
-type DescriptionBlockCommentConfig = { descriptionBlock: string[] };
-type InlineCommentConfig = { lines: string[] };
-type CustomCommentConfig = {
-    customLines: string[];
+export type CommentOptions = {
     lineStart?: string;
     lineEnd?: string;
     beforeLine?: string;
     afterLine?: string;
     firstLineStart?: string;
+};
+
+type DescriptionBlockCommentConfig = { descriptionBlock: string[] };
+type InlineCommentConfig = { lines: string[] };
+type CustomCommentConfig = CommentOptions & {
+    customLines: string[];
 };
 
 export type CommentConfig = DescriptionBlockCommentConfig | InlineCommentConfig | CustomCommentConfig;

--- a/packages/quicktype-core/src/support/Comments.ts
+++ b/packages/quicktype-core/src/support/Comments.ts
@@ -1,8 +1,8 @@
 export type CommentOptions = {
     lineStart?: string;
     lineEnd?: string;
-    beforeLine?: string;
-    afterLine?: string;
+    beforeComment?: string;
+    afterComment?: string;
     firstLineStart?: string;
 };
 


### PR DESCRIPTION
Fixes #2332 

### Summary
Updates comment types and allows `leadingComments` to support multiple comment types, adds `emitComments` method in ConvenienceRenderer

### Changes
- Added types for different styles of comments (inline, description block, custom)
- Updated leadingComments references to use new type
- Updated all leadingComments logic in all relevant languages
- Added `emitComments` method in ConvenienceRenderer to handle different comment styles
- Updated `emitCommentLines` method to take object as param instead of list args
- Added `lineEnd` param to `emitCommentLines`
- renamed `beforeLine` to `beforeComment` and `afterLine` to `afterComment`

This change is backwards-compatible for all external/standard use cases as it preserves the existing `string[]` type for `leadingComments` _but_ it will break custom renderers that call `emitCommentLines` directly