### PR TITLE
CI Fix - Updated Newtonsoft.Json csharp library to 13.0.3

### DIFF
--- a/test/fixtures/csharp/test.csproj
+++ b/test/fixtures/csharp/test.csproj
@@ -4,6 +4,6 @@
     <TargetFramework>netcoreapp6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Due to [breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/dotnet-restore-audit) The `jsonString` at `/test/utils.ts:237` contains error message value like following, which causes `JSON.parse(jsonString)` to throw error

```
/Users/xxxxx/proj/quicktype/test/runs/schema-csharp-390aed/test.csproj : warning NU1903: Package 'Newtonsoft.Json' 10.0.3 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr
```

Simply updating the library to newer version solved the issue for now, but in future similar issue can happen again if new security issue is found.