### PR TITLE
fix: Go time import bug

### DIFF
--- a/packages/quicktype-core/src/language/Golang.ts
+++ b/packages/quicktype-core/src/language/Golang.ts
@@ -307,7 +307,7 @@ export class GoRenderer extends ConvenienceRenderer {
 
         this.emitPackageDefinitons(
             false,
-            usedTypes.has("time.Time") || usedTypes.has("*,time.Time") ? new Set<string>(["time"]) : undefined
+            usedTypes.has("time.Time") || usedTypes.has("*,time.Time") || usedTypes.has("[],time.Time") ? new Set<string>(["time"]) : undefined
         );
         this.emitDescription(this.descriptionForType(c));
         this.emitStruct(className, columns);


### PR DESCRIPTION
fixes: [#2519](https://github.com/glideapps/quicktype/issues/2519)

If a json schema only has date-time referenced as an item of an array the generated Go code will not have the import for the time package. This adds an additional case to force time package imports

Changes:
* Added additional clause for time imports