### PR TITLE
fix: Bug with misplaced Go time imports

### DIFF
--- a/packages/quicktype-core/src/language/Golang.ts
+++ b/packages/quicktype-core/src/language/Golang.ts
@@ -307,7 +307,9 @@ export class GoRenderer extends ConvenienceRenderer {
 
         this.emitPackageDefinitons(
             false,
-            usedTypes.has("time.Time") || usedTypes.has("*,time.Time") || usedTypes.has("[],time.Time") ? new Set<string>(["time"]) : undefined
+            usedTypes.has("time.Time") || usedTypes.has("*,time.Time") || usedTypes.has("[],time.Time")
+                ? new Set<string>(["time"])
+                : undefined
         );
         this.emitDescription(this.descriptionForType(c));
         this.emitStruct(className, columns);
@@ -648,6 +650,7 @@ func marshalUnion(pi *int64, pf *float64, pb *bool, ps *string, haveArray bool, 
         const mapping: Map<string, string> = new Map();
         mapping.set("time.Time", "time");
         mapping.set("*,time.Time", "time");
+        mapping.set("[],time.Time", "time");
 
         this.forEachClassProperty(c, "none", (_name, _jsonName, p) => {
             const goType = this.propertyGoType(p);


### PR DESCRIPTION
fixes: [#2530](https://github.com/glideapps/quicktype/issues/2530)

My previous fix forced generated Go code to add time imports for []time.Time types, however, the change was missing an additional update included in this fix which will ensure that the import takes place at the top of the file (otherwise it would encounter a syntax error)

Changes:
* formatted a line
* Added additional clause for time imports

Reproduction to fix bug:

Schema:
```json
{
    "type": "object",
    "properties": {
        "timeRange": {
            "type": "array",
            "items": {
                "type": "string",
                "format": "date-time"
            }
        }
    }
}
```

Generated Code:
```go
// This file was generated from JSON Schema using quicktype, do not modify it directly.
// To parse and unparse this JSON data, add this code to your project and do:
//
//    models, err := UnmarshalModels(bytes)
//    bytes, err = models.Marshal()

package generated

import "time"

import "encoding/json"

func UnmarshalModels(data []byte) (Models, error) {
	var r Models
	err := json.Unmarshal(data, &r)
	return r, err
}

func (r *Models) Marshal() ([]byte, error) {
	return json.Marshal(r)
}

type Models struct {
	TimeRange []time.Time `json:"timeRange,omitempty"`
}
```

Notice: time import is where it should be, fixing  [#2530](https://github.com/glideapps/quicktype/issues/2530)