### PR TITLE
Add readonly option for TypeScript Language

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptFlow.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow.ts
@@ -28,7 +28,7 @@ export const tsFlowOptions = Object.assign({}, javaScriptOptions, {
         "Use string instead of enum for string enums with single value",
         false
     ),
-    preferReadonly: new BooleanOption("prefer-readonly", "Use readonly type members", false)
+    readonly: new BooleanOption("readonly", "Use readonly type members", false)
 });
 
 const tsFlowTypeAnnotations = {
@@ -54,7 +54,7 @@ export abstract class TypeScriptFlowBaseTargetLanguage extends JavaScriptTargetL
             tsFlowOptions.preferUnions,
             tsFlowOptions.preferTypes,
             tsFlowOptions.preferConstValues,
-            tsFlowOptions.preferReadonly
+            tsFlowOptions.readonly
         ];
     }
 
@@ -173,7 +173,7 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
             let propertyName: Sourcelike = name;
             propertyName = modifySource(quotePropertyName, name);
 
-            if (this._tsFlowOptions.preferReadonly) {
+            if (this._tsFlowOptions.readonly) {
                 propertyName = modifySource(_propertyName => "readonly " + _propertyName, propertyName);
             }
 

--- a/packages/quicktype-core/src/language/TypeScriptFlow.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow.ts
@@ -53,7 +53,8 @@ export abstract class TypeScriptFlowBaseTargetLanguage extends JavaScriptTargetL
             tsFlowOptions.rawType,
             tsFlowOptions.preferUnions,
             tsFlowOptions.preferTypes,
-            tsFlowOptions.preferConstValues
+            tsFlowOptions.preferConstValues,
+            tsFlowOptions.preferReadonly
         ];
     }
 

--- a/packages/quicktype-core/src/language/TypeScriptFlow.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow.ts
@@ -28,11 +28,8 @@ export const tsFlowOptions = Object.assign({}, javaScriptOptions, {
         "Use string instead of enum for string enums with single value",
         false
     ),
-    preferReadonly: new BooleanOption(
-        "prefer-readonly-interface",
-        "Use readonly interface members",
-        false
-    )
+    // TODO: add snapshot unit tests for cli option
+    preferReadonly: new BooleanOption("prefer-readonly-interface", "Use readonly type members", false)
 });
 
 const tsFlowTypeAnnotations = {
@@ -173,12 +170,12 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
         this.emitPropertyTable(c, (name, _jsonName, p) => {
             const t = p.type;
 
-						let propertyName: Sourcelike = name;
-						propertyName = modifySource(quotePropertyName, name);
+            let propertyName: Sourcelike = name;
+            propertyName = modifySource(quotePropertyName, name);
 
-						if(this._tsFlowOptions.preferReadonly) {
-							propertyName = 'readonly ' + propertyName;
-						}
+            if (this._tsFlowOptions.preferReadonly) {
+                propertyName = "readonly " + propertyName;
+            }
 
             return [
                 [propertyName, p.isOptional ? "?" : "", ": "],

--- a/packages/quicktype-core/src/language/TypeScriptFlow.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow.ts
@@ -28,8 +28,7 @@ export const tsFlowOptions = Object.assign({}, javaScriptOptions, {
         "Use string instead of enum for string enums with single value",
         false
     ),
-    // TODO: add snapshot unit tests for cli option
-    preferReadonly: new BooleanOption("prefer-readonly-interface", "Use readonly type members", false)
+    preferReadonly: new BooleanOption("prefer-readonly", "Use readonly type members", false)
 });
 
 const tsFlowTypeAnnotations = {

--- a/packages/quicktype-core/src/language/TypeScriptFlow.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow.ts
@@ -174,7 +174,7 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
             propertyName = modifySource(quotePropertyName, name);
 
             if (this._tsFlowOptions.preferReadonly) {
-                propertyName = "readonly " + propertyName;
+                propertyName = modifySource(_propertyName => "readonly " + _propertyName, propertyName);
             }
 
             return [

--- a/packages/quicktype-core/src/language/TypeScriptFlow.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow.ts
@@ -27,6 +27,11 @@ export const tsFlowOptions = Object.assign({}, javaScriptOptions, {
         "prefer-const-values",
         "Use string instead of enum for string enums with single value",
         false
+    ),
+    preferReadonly: new BooleanOption(
+        "prefer-readonly-interface",
+        "Use readonly interface members",
+        false
     )
 });
 
@@ -167,8 +172,16 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
     protected emitClassBlockBody(c: ClassType): void {
         this.emitPropertyTable(c, (name, _jsonName, p) => {
             const t = p.type;
+
+						let propertyName: Sourcelike = name;
+						propertyName = modifySource(quotePropertyName, name);
+
+						if(this._tsFlowOptions.preferReadonly) {
+							propertyName = 'readonly ' + propertyName;
+						}
+
             return [
-                [modifySource(quotePropertyName, name), p.isOptional ? "?" : "", ": "],
+                [propertyName, p.isOptional ? "?" : "", ": "],
                 [this.sourceFor(t).source, ";"]
             ];
         });

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -785,7 +785,7 @@ export const TypeScriptLanguage: Language = {
         ["pokedex.json", { "prefer-types": "true" }],
         { "acronym-style": "pascal" },
         { converters: "all-objects" },
-        { "prefer-readonly": "true" }
+        { readonly: "true" }
     ],
     sourceFiles: ["src/language/TypeScript.ts"]
 };

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -784,7 +784,8 @@ export const TypeScriptLanguage: Language = {
         { "declare-unions": "true" },
         ["pokedex.json", { "prefer-types": "true" }],
         { "acronym-style": "pascal" },
-        { converters: "all-objects" }
+        { converters: "all-objects" },
+        { "prefer-readonly": "true" }
     ],
     sourceFiles: ["src/language/TypeScript.ts"]
 };


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Adds a `'prefer-readonly'` option to TypeScript output.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2280 

## Previous Behaviour / Output
<!--- Provide an example of what was happening before your change -->
```ts
export interface TopLevel {
    age:     number;
    country: Country;
    females: number;
    males:   number;
    total:   number;
    year:    number;
}
```

## New Behaviour / Output
<!--- Provide an example of what now happens after your change -->
```ts
export interface TopLevel {
    readonly age:     number;
    readonly country: Country;
    readonly females: number;
    readonly males:   number;
    readonly total:   number;
    readonly year:    number;
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran, including any new unit tests --->
Added to test suite under `quickTestRendererOptions`


## Screenshots (if appropriate):
N/a