### PR TITLE
chore: Add .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+test/runs
+test/inputs


### PR DESCRIPTION
Adds a .prettierignore to prevent formatting test inputs and outputs