### PR TITLE
chore(Smithy): Remove unused Smithy4sRenderer

### DIFF
--- a/packages/quicktype-core/src/language/Scala3.ts
+++ b/packages/quicktype-core/src/language/Scala3.ts
@@ -245,10 +245,10 @@ export class Scala3Renderer extends ConvenienceRenderer {
             delimiter === "curly"
                 ? ["{", "}"]
                 : delimiter === "paren"
-                  ? ["(", ")"]
-                  : delimiter === "none"
-                    ? ["", ""]
-                    : ["{", "})"];
+                ? ["(", ")"]
+                : delimiter === "none"
+                ? ["", ""]
+                : ["{", "})"];
         this.emitLine(line, " ", open);
         this.indent(f);
         this.emitLine(close);
@@ -482,60 +482,6 @@ export class UpickleRenderer extends Scala3Renderer {
 
         this.emitLine("import upickle.default.*");
         this.ensureBlankLine();
-    }
-}
-
-export class Smithy4sRenderer extends Scala3Renderer {
-    protected emitHeader(): void {
-        if (this.leadingComments !== undefined) {
-            this.emitComments(this.leadingComments);
-        } else {
-            this.emitUsageHeader();
-        }
-
-        this.ensureBlankLine();
-        this.emitLine("namespace ", this._scalaOptions.packageName);
-        this.ensureBlankLine();
-    }
-
-    protected emitTopLevelArray(t: ArrayType, name: Name): void {
-        const elementType = this.scalaType(t.items);
-        this.emitLine(["list ", name, " { member : ", elementType, "}"]);
-    }
-
-    protected emitTopLevelMap(t: MapType, name: Name): void {
-        const elementType = this.scalaType(t.values);
-        this.emitLine(["map ", name, " { map[ key : String , value : ", elementType, "}"]);
-    }
-
-    protected emitEmptyClassDefinition(c: ClassType, className: Name): void {
-        this.emitDescription(this.descriptionForType(c));
-        this.emitLine("structure ", className, "{}");
-    }
-
-    protected emitEnumDefinition(e: EnumType, enumName: Name): void {
-        this.emitDescription(this.descriptionForType(e));
-
-        this.ensureBlankLine();
-        this.emitItem(["enum ", enumName, " { "]);
-        let count = e.cases.size;
-        this.forEachEnumCase(e, "none", (name, jsonName) => {
-            // if (!(jsonName == "")) {
-            /*                 const backticks = 
-                                shouldAddBacktick(jsonName) || 
-                                jsonName.includes(" ") || 
-                                !isNaN(parseInt(jsonName.charAt(0)))
-                            if (backticks) {this.emitItem("`")} else  */
-            this.emitLine();
-            this.emitItem([name, ' = "', jsonName, '"']);
-            //                if (backticks) {this.emitItem("`")}
-            if (--count > 0) this.emitItem([","]);
-            //} else {
-            //--count
-            //}
-        });
-        this.ensureBlankLine();
-        this.emitItem(["}"]);
     }
 }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Removes an unused Renderer class (`Scala3.ts > Smithy4sRenderer`) caused by rebase merge conflicts from #2189

The actual Renderer class for Smithy4s lives in `Smithy4s.ts` 

## Previous Behaviour / Output

<!--- Provide an example of what was happening before your change -->
N/a

## New Behaviour / Output

<!--- Provide an example of what now happens after your change -->
N/a

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran, including any new unit tests --->
N/a

## Screenshots (if appropriate):
