### PR TITLE
fix(Python): update to_float output for Python

### DIFF
--- a/packages/quicktype-core/src/language/Python.ts
+++ b/packages/quicktype-core/src/language/Python.ts
@@ -712,7 +712,7 @@ export class JSONPythonRenderer extends PythonRenderer {
 
     protected emitToFloatConverter(): void {
         this.emitBlock(["def to_float(", this.typingDecl("x", "Any"), ")", this.typeHint(" -> float"), ":"], () => {
-            this.emitLine("assert isinstance(x, float)");
+            this.emitLine("assert isinstance(x, (int, float))");
             this.emitLine("return x");
         });
     }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Allows for int types in `to_float` for Python output

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #2533 

## Previous Behaviour / Output

<!--- Provide an example of what was happening before your change -->

existing `to_float` output:
```python
def to_float(x: Any) -> float:
    assert isinstance(x, float)
    return x
```

## New Behaviour / Output

<!--- Provide an example of what now happens after your change -->

new`to_float` output:
```python
def to_float(x: Any) -> float:
    assert isinstance(x, (int, float))
    return x
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran, including any new unit tests --->

## Screenshots (if appropriate):
N/a
