### PR TITLE
fix(ts-input): Replace topLevelName for TypeScript input if first type is export default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
             ],
             "dependencies": {
                 "@glideapps/ts-necessities": "^2.1.3",
-                "@types/readable-stream": "^4.0.10",
                 "chalk": "^4.1.2",
                 "collection-utils": "^1.0.1",
                 "command-line-args": "^5.2.1",
@@ -261,6 +260,7 @@
             "version": "4.0.10",
             "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.10.tgz",
             "integrity": "sha512-AbUKBjcC8SHmImNi4yK2bbjogQlkFSg7shZCcicxPQapniOlajG8GCc39lvXzCWX4lLRRs7DM3VAeSlqmEVZUA==",
+            "dev": true,
             "dependencies": {
                 "@types/node": "*",
                 "safe-buffer": "~5.1.1"
@@ -2675,6 +2675,7 @@
             "version": "4.0.10",
             "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.10.tgz",
             "integrity": "sha512-AbUKBjcC8SHmImNi4yK2bbjogQlkFSg7shZCcicxPQapniOlajG8GCc39lvXzCWX4lLRRs7DM3VAeSlqmEVZUA==",
+            "dev": true,
             "requires": {
                 "@types/node": "*",
                 "safe-buffer": "~5.1.1"

--- a/packages/quicktype-typescript-input/src/index.ts
+++ b/packages/quicktype-typescript-input/src/index.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import { PartialArgs, generateSchema } from "@mark.probst/typescript-json-schema";
+import { PartialArgs, generateSchema } from "typescript-json-schema";
 
 import { defined, JSONSchemaSourceData, messageError } from "quicktype-core";
 
@@ -35,7 +35,24 @@ export function schemaForTypeScriptSources(sourceFileNames: string[]): JSONSchem
 
     const schema = generateSchema(program, "*", settings);
     const uris: string[] = [];
-    let topLevelName: string | undefined = undefined;
+    let topLevelName: string = "";
+
+    // if there is a type that is `export default`, swap the corresponding ref
+    if (schema?.definitions?.default) {
+        const defaultDefinition = schema?.definitions?.default;
+        const matchingDefaultName = Object.entries(schema?.definitions ?? {}).find(
+            ([_name, definition]) => (definition as Record<string, unknown>)["$ref"] === "#/definitions/default"
+        )?.[0];
+
+        if (matchingDefaultName) {
+            topLevelName = matchingDefaultName;
+            (defaultDefinition as Record<string, unknown>).title = topLevelName;
+
+            schema.definitions[matchingDefaultName] = defaultDefinition;
+            schema.definitions.default = { $ref: `#/definitions/${matchingDefaultName}` };
+        }
+    }
+
     if (schema !== null && typeof schema === "object" && typeof schema.definitions === "object") {
         for (const name of Object.getOwnPropertyNames(schema.definitions)) {
             const definition = schema.definitions[name];
@@ -59,31 +76,18 @@ export function schemaForTypeScriptSources(sourceFileNames: string[]): JSONSchem
 
             uris.push(`#/definitions/${name}`);
 
-            if (topLevelName === undefined) {
+            if (!topLevelName) {
                 if (typeof definition.title === "string") {
                     topLevelName = definition.title;
                 } else {
                     topLevelName = name;
                 }
-            } else {
-                topLevelName = "";
             }
         }
     }
     if (uris.length === 0) {
         uris.push("#/definitions/");
     }
-    if (topLevelName === undefined) {
-        topLevelName = "";
-    }
-    if (topLevelName === "default") {
-        const matchingDefaultName = Object.entries(schema?.definitions ?? {}).find(
-            ([_name, definition]) => (definition as Record<string, unknown>)["$ref"] === "#/definitions/default"
-        )?.[0];
 
-        if (matchingDefaultName) {
-            topLevelName = matchingDefaultName;
-        }
-    }
     return { schema: JSON.stringify(schema), name: topLevelName, uris, isConverted: true };
 }

--- a/packages/quicktype-typescript-input/src/index.ts
+++ b/packages/quicktype-typescript-input/src/index.ts
@@ -1,5 +1,5 @@
 import * as ts from "typescript";
-import { PartialArgs, generateSchema } from "typescript-json-schema";
+import { PartialArgs, generateSchema } from "@mark.probst/typescript-json-schema";
 
 import { defined, JSONSchemaSourceData, messageError } from "quicktype-core";
 

--- a/packages/quicktype-typescript-input/src/index.ts
+++ b/packages/quicktype-typescript-input/src/index.ts
@@ -76,5 +76,14 @@ export function schemaForTypeScriptSources(sourceFileNames: string[]): JSONSchem
     if (topLevelName === undefined) {
         topLevelName = "";
     }
+    if (topLevelName === "default") {
+        const matchingDefaultName = Object.entries(schema?.definitions ?? {}).find(
+            ([name, definition]) => (definition as Record<string, unknown>)["$ref"] === "#/definitions/default"
+        )?.[0];
+
+        if (matchingDefaultName) {
+            topLevelName = matchingDefaultName;
+        }
+    }
     return { schema: JSON.stringify(schema), name: topLevelName, uris, isConverted: true };
 }

--- a/packages/quicktype-typescript-input/src/index.ts
+++ b/packages/quicktype-typescript-input/src/index.ts
@@ -78,7 +78,7 @@ export function schemaForTypeScriptSources(sourceFileNames: string[]): JSONSchem
     }
     if (topLevelName === "default") {
         const matchingDefaultName = Object.entries(schema?.definitions ?? {}).find(
-            ([name, definition]) => (definition as Record<string, unknown>)["$ref"] === "#/definitions/default"
+            ([_name, definition]) => (definition as Record<string, unknown>)["$ref"] === "#/definitions/default"
         )?.[0];
 
         if (matchingDefaultName) {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Fixes an issue with type naming for TypeScript input where the name ends up as `default` if the first type in the file is `export default`.
Replaces the `topLevelName` with the name from the corresponding ref type

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1295 

## Input File

```ts
/** #TopLevel */
export default class AddressBook {
  /**
   * A dictionary of Contacts, indexed by unique ID
   */
  contacts: { [id: string]: Contact };
}

class Contact {
  firstName: string;
  lastName?: string;
  
  birthday?: Date;
  title?: "Mr." | "Mrs." | "Ms." | "Prof.";
  
  emails: string[];
  phones: PhoneNumber[];
  
  /** @TJS-type integer */
  highScore: number;
}

/**
 * A Contact's phone number.
 */
class PhoneNumber {
    number: string;
    
    /** An optional label (e.g. "mobile") */
    label?: string;
}
```

## Previous Behaviour / Output

<!--- Provide an example of what was happening before your change -->

```dart
import 'dart:convert';

class Default {
    Map<String, Contact> contacts;

    Default({
        this.contacts,
    });

    factory Default.fromJson(String str) => Default.fromMap(json.decode(str));

    String toJson() => json.encode(toMap());

    factory Default.fromMap(Map<String, dynamic> json) => new Default(
        contacts: new Map.from(json["contacts"]).map((k, v) => new MapEntry<String, Contact>(k, Contact.fromMap(v))),
    );

    Map<String, dynamic> toMap() => {
        "contacts": new Map.from(contacts).map((k, v) => new MapEntry<String, dynamic>(k, v.toMap())),
    };
}
```

## New Behaviour / Output

<!--- Provide an example of what now happens after your change -->

```dart
import 'dart:convert';

AddressBook addressBookFromJson(String str) => AddressBook.fromJson(json.decode(str));

String addressBookToJson(AddressBook data) => json.encode(data.toJson());

class AddressBook {
    
    ///A dictionary of Contacts, indexed by unique ID
    Map<String, Contact> contacts;

    AddressBook({
        required this.contacts,
    });

    factory AddressBook.fromJson(Map<String, dynamic> json) => AddressBook(
        contacts: Map.from(json["contacts"]).map((k, v) => MapEntry<String, Contact>(k, Contact.fromJson(v))),
    );

    Map<String, dynamic> toJson() => {
        "contacts": Map.from(contacts).map((k, v) => MapEntry<String, dynamic>(k, v.toJson())),
    };
}
```

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran, including any new unit tests --->

TBD on how we should test `quicktype-typescript-input`

## Screenshots (if appropriate):
