### PR TITLE
Fix unicode-properties import

### DIFF
--- a/packages/quicktype-core/src/language/CSharp.ts
+++ b/packages/quicktype-core/src/language/CSharp.ts
@@ -51,7 +51,7 @@ import {
 } from "../Transformers";
 import { RenderContext } from "../Renderer";
 import { minMaxLengthForType, minMaxValueForType } from "../attributes/Constraints";
-import unicode from "unicode-properties";
+import * as unicode from "unicode-properties";
 
 export enum Framework {
     Newtonsoft,

--- a/packages/quicktype-core/src/language/Elixir.ts
+++ b/packages/quicktype-core/src/language/Elixir.ts
@@ -1,4 +1,4 @@
-import unicode from "unicode-properties";
+import * as unicode from "unicode-properties";
 
 import { Sourcelike } from "../Source";
 import { Namer, Name } from "../Naming";

--- a/packages/quicktype-core/src/language/Objective-C.ts
+++ b/packages/quicktype-core/src/language/Objective-C.ts
@@ -23,7 +23,7 @@ import { StringOption, BooleanOption, EnumOption, Option, getOptionValues, Optio
 import { assert, defined } from "../support/Support";
 import { RenderContext } from "../Renderer";
 
-import unicode from "unicode-properties";
+import * as unicode from "unicode-properties";
 
 export type MemoryAttribute = "assign" | "strong" | "copy";
 export type OutputFeatures = { interface: boolean; implementation: boolean };

--- a/packages/quicktype-core/src/language/Python.ts
+++ b/packages/quicktype-core/src/language/Python.ts
@@ -48,7 +48,7 @@ import {
     iterableFirst
 } from "collection-utils";
 
-import unicode from "unicode-properties";
+import * as unicode from "unicode-properties";
 
 const forbiddenTypeNames = [
     "Any",

--- a/packages/quicktype-core/src/language/ruby/index.ts
+++ b/packages/quicktype-core/src/language/ruby/index.ts
@@ -1,4 +1,4 @@
-import unicode from "unicode-properties";
+import * as unicode from "unicode-properties";
 
 import { Sourcelike, modifySource } from "../../Source";
 import { Namer, Name } from "../../Naming";

--- a/packages/quicktype-core/src/support/Strings.ts
+++ b/packages/quicktype-core/src/support/Strings.ts
@@ -10,7 +10,7 @@ export type NamingStyle =
     | "pascal-upper-acronyms"
     | "camel-upper-acronyms";
 
-import unicode from "unicode-properties";
+import * as unicode from "unicode-properties";
 
 function computeAsciiMap(mapper: (codePoint: number) => string): {
     charStringMap: string[];


### PR DESCRIPTION
Getting a related crash here when using `quicktype-core` in web app.