### PR TITLE
refactor: update fetch import for node v21+ compatibility

### DIFF
--- a/packages/quicktype-core/src/input/io/NodeIO.ts
+++ b/packages/quicktype-core/src/input/io/NodeIO.ts
@@ -6,7 +6,8 @@ import { defined, exceptionToString } from "@glideapps/ts-necessities";
 import { messageError, panic } from "../../index";
 
 const isURL = require("is-url");
-import fetch from "cross-fetch";
+
+const fetch = (global as any).fetch ?? require("cross-fetch").default;
 
 interface HttpHeaders {
     [key: string]: string;


### PR DESCRIPTION
## Description

- Use global fetch first, fallback to cross-fetch if needed
- Addresses deprecation warnings due to unresolved issues in cross-fetch, node-fetch, and whatwg-url libraries
- Ensures compatibility with environments running node.js v21+ where punycode module is deprecated

## Related Issue

I've been following those issues on **node-fetch** https://github.com/node-fetch/node-fetch/pull/1793
And on **cross-fetch** https://github.com/lquixada/cross-fetch/issues/177

Both seems stale, so I hope that we can fix `quicktype-core` in the meantime. I've used the solution recommended into the `cross-fetch` issue toward conditional import and using native node fetch if available.

## Motivation and Context

We're using `quicktype-core` in some of our tools, one of them being a cli tool, every-time a command is ran the deprecation coming from `quicktype-code` `cross-fetch` dependency shows up on node >=v21.

## Previous Behaviour / Output

```
(node:6629) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

## New Behaviour / Output

No warning output.

## How Has This Been Tested?

1. Build and pack the `quicktype-core` package locally with the change
2. Change my project `quicktype-core` dependency to point to the local builded package `tgz` and install
3. Used `FetchingJSONSchemaStore` in node scripts to trigger the fetch behaviour with node versions `16.20.1`, `18.20.2` and `21.7.3`
4. Build my project cli tool, and run it over with node versions `v16.20.2`, `v18.20.2`, `v21.7.3` expected behaviour occurs and the warning is gone.

## Screenshots (if appropriate):
