### PR TITLE
chore: Remove DeepSource Integration

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,7 +1,0 @@
-version = 1
-
-[[analyzers]]
-name = "javascript"
-
-[[transformers]]
-name = "prettier"


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Removes `deepsource.toml` from repo, following pending disconnect from DeepSource integration

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Since we're opting out of using DeepSource as a code analyser, we no longer need the config file
