### PR TITLE
fix: Resolve ReadableStream types issue in test suite

### DIFF
--- a/packages/quicktype-core/src/input/io/NodeIO.ts
+++ b/packages/quicktype-core/src/input/io/NodeIO.ts
@@ -1,14 +1,12 @@
 import * as fs from "fs";
 import { Readable } from "readable-stream";
-import { Readable as NodeReadable } from "stream";
 import { isNode } from "browser-or-node";
 import { getStream } from "./get-stream";
 import { defined, exceptionToString } from "@glideapps/ts-necessities";
 import { messageError, panic } from "../../index";
 
 const isURL = require("is-url");
-
-const fetch = (global as any).fetch ?? require("cross-fetch").default;
+import fetch from "cross-fetch";
 
 interface HttpHeaders {
     [key: string]: string;
@@ -42,13 +40,8 @@ export async function readableFromFileOrURL(fileOrURL: string, httpHeaders?: str
             const response = await fetch(fileOrURL, {
                 headers: parseHeaders(httpHeaders)
             });
-            const maybeWebReadable = defined(response.body)!;
 
-            if (!maybeWebReadable.once) {
-                // if the `once` function does not exist, this is likely a web [ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream) instead of a node one
-                return NodeReadable.fromWeb(maybeWebReadable) as Readable;
-            }
-            return maybeWebReadable as Readable;
+            return defined(response.body) as unknown as Readable;
         } else if (isNode) {
             if (fileOrURL === "-") {
                 // Cast node readable to isomorphic readable from readable-stream

--- a/packages/quicktype-core/src/input/io/NodeIO.ts
+++ b/packages/quicktype-core/src/input/io/NodeIO.ts
@@ -45,6 +45,7 @@ export async function readableFromFileOrURL(fileOrURL: string, httpHeaders?: str
             const maybeWebReadable = defined(response.body)!;
 
             if (!maybeWebReadable.once) {
+                // if the `once` function does not exist, this is likely a web [ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream) instead of a node one
                 return NodeReadable.fromWeb(maybeWebReadable) as Readable;
             }
             return maybeWebReadable as Readable;

--- a/packages/quicktype-core/src/input/io/NodeIO.ts
+++ b/packages/quicktype-core/src/input/io/NodeIO.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import { Readable } from "readable-stream";
+import { Readable as NodeReadable } from "stream";
 import { isNode } from "browser-or-node";
 import { getStream } from "./get-stream";
 import { defined, exceptionToString } from "@glideapps/ts-necessities";
@@ -41,7 +42,12 @@ export async function readableFromFileOrURL(fileOrURL: string, httpHeaders?: str
             const response = await fetch(fileOrURL, {
                 headers: parseHeaders(httpHeaders)
             });
-            return defined(response.body) as unknown as Readable;
+            const maybeWebReadable = defined(response.body)!;
+
+            if (!maybeWebReadable.once) {
+                return NodeReadable.fromWeb(maybeWebReadable) as Readable;
+            }
+            return maybeWebReadable as Readable;
         } else if (isNode) {
             if (fileOrURL === "-") {
                 // Cast node readable to isomorphic readable from readable-stream

--- a/packages/quicktype-core/src/input/io/NodeIO.ts
+++ b/packages/quicktype-core/src/input/io/NodeIO.ts
@@ -45,7 +45,9 @@ export async function readableFromFileOrURL(fileOrURL: string, httpHeaders?: str
             const maybeWebReadable = defined(response.body)!;
 
             if (!maybeWebReadable.once) {
-                // if the `once` function does not exist, this is likely a web [ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream) instead of a node one
+                // FIXME: hack for CI, this does not occur in general usage
+                // result of #2573
+                // retuns a web [ReadableStream](https://developer.mozilla.org/docs/Web/API/ReadableStream) instead of a node one in CI only
                 return NodeReadable.fromWeb(maybeWebReadable) as Readable;
             }
             return maybeWebReadable as Readable;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Related to #2573.
GH Actions CI uses a browser fetch instead of Node-based fetch so the `response.body` will return as [`WebStreams.ReadableStream`](https://developer.mozilla.org/docs/Web/API/ReadableStream) instead of [`NodeJS.ReadableStream`](https://nodejs.org/api/stream.html#class-streamreadable) from `cross-fetch`.

Only allows CI to use `cross-fetch` instead.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves a types issue occurring in GH CI Pipeline

## Previous Behaviour / Output

<!--- Provide an example of what was happening before your change -->
N/a

## New Behaviour / Output

<!--- Provide an example of what now happens after your change -->
N/aa

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran, including any new unit tests --->
- [x] Test Suite passes

## Screenshots (if appropriate):
