### PR TITLE
chore: remove unused types devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -897,16 +897,6 @@
             "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
             "dev": true
         },
-        "node_modules/@types/js-base64": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@types/js-base64/-/js-base64-3.3.1.tgz",
-            "integrity": "sha512-Zw33oQNAvDdAN9b0IE5stH0y2MylYvtU7VVTKEJPxhyM2q57CVaNJhtJW258ah24NRtaiA23tptUmVn3dmTKpw==",
-            "deprecated": "This is a stub types definition. js-base64 provides its own type definitions, so you do not need this installed.",
-            "dev": true,
-            "dependencies": {
-                "js-base64": "*"
-            }
-        },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1020,16 +1010,6 @@
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz",
             "integrity": "sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==",
             "dev": true
-        },
-        "node_modules/@types/yaml": {
-            "version": "1.9.7",
-            "resolved": "https://registry.npmjs.org/@types/yaml/-/yaml-1.9.7.tgz",
-            "integrity": "sha512-8WMXRDD1D+wCohjfslHDgICd2JtMATZU8CkhH8LVJqcJs6dyYj5TGptzP8wApbmEullGBSsCEzzap73DQ1HJaA==",
-            "deprecated": "This is a stub types definition. yaml provides its own type definitions, so you do not need this installed.",
-            "dev": true,
-            "dependencies": {
-                "yaml": "*"
-            }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "7.6.0",
@@ -6883,13 +6863,11 @@
             },
             "devDependencies": {
                 "@types/browser-or-node": "^1.3.2",
-                "@types/js-base64": "^3.3.1",
                 "@types/node": "18.19.31",
                 "@types/pako": "^1.0.0",
                 "@types/pluralize": "0.0.30",
                 "@types/readable-stream": "4.0.10",
                 "@types/unicode-properties": "^1.3.0",
-                "@types/yaml": "^1.9.7",
                 "tslint": "^6.1.3",
                 "typescript": "4.9.5"
             }
@@ -7583,15 +7561,6 @@
             "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
             "dev": true
         },
-        "@types/js-base64": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@types/js-base64/-/js-base64-3.3.1.tgz",
-            "integrity": "sha512-Zw33oQNAvDdAN9b0IE5stH0y2MylYvtU7VVTKEJPxhyM2q57CVaNJhtJW258ah24NRtaiA23tptUmVn3dmTKpw==",
-            "dev": true,
-            "requires": {
-                "js-base64": "*"
-            }
-        },
         "@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -7705,15 +7674,6 @@
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.88.0.tgz",
             "integrity": "sha512-rWY+Bs6j/f1lvr8jqZTyp5arRMfovdxolcqGi+//+cPDOh8SBvzXH90e7BiSXct5HJ9HGW6jATchbRTpTJpEkw==",
             "dev": true
-        },
-        "@types/yaml": {
-            "version": "1.9.7",
-            "resolved": "https://registry.npmjs.org/@types/yaml/-/yaml-1.9.7.tgz",
-            "integrity": "sha512-8WMXRDD1D+wCohjfslHDgICd2JtMATZU8CkhH8LVJqcJs6dyYj5TGptzP8wApbmEullGBSsCEzzap73DQ1HJaA==",
-            "dev": true,
-            "requires": {
-                "yaml": "*"
-            }
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "7.6.0",
@@ -10884,14 +10844,12 @@
             "requires": {
                 "@glideapps/ts-necessities": "2.2.3",
                 "@types/browser-or-node": "^1.3.2",
-                "@types/js-base64": "^3.3.1",
                 "@types/node": "18.19.31",
                 "@types/pako": "^1.0.0",
                 "@types/pluralize": "0.0.30",
                 "@types/readable-stream": "4.0.10",
                 "@types/unicode-properties": "^1.3.0",
                 "@types/urijs": "^1.19.25",
-                "@types/yaml": "^1.9.7",
                 "browser-or-node": "^3.0.0",
                 "collection-utils": "^1.0.1",
                 "cross-fetch": "^4.0.0",

--- a/packages/quicktype-core/package.json
+++ b/packages/quicktype-core/package.json
@@ -30,13 +30,11 @@
     },
     "devDependencies": {
         "@types/browser-or-node": "^1.3.2",
-        "@types/js-base64": "^3.3.1",
         "@types/node": "18.19.31",
         "@types/pako": "^1.0.0",
         "@types/pluralize": "0.0.30",
         "@types/readable-stream": "4.0.10",
         "@types/unicode-properties": "^1.3.0",
-        "@types/yaml": "^1.9.7",
         "tslint": "^6.1.3",
         "typescript": "4.9.5"
     },


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Removes `@types/yaml` and `@types/js-base64` as types are now included in the base packages

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Resolves this warning on build:
```
Run npm ci
npm WARN deprecated @types/js-base64@3.3.1: This is a stub types definition. js-base64 provides its own type definitions, so you do not need this installed.
npm WARN deprecated @types/yaml@1.9.7: This is a stub types definition. yaml provides its own type definitions, so you do not need this installed.
```

## Previous Behaviour / Output

<!--- Provide an example of what was happening before your change -->
N/a

## New Behaviour / Output

<!--- Provide an example of what now happens after your change -->
N/a

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran, including any new unit tests --->

## Screenshots (if appropriate):
