### PR TITLE
fix: update `dist/index.js` to `dist/src/index.js`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "typescript": "4.9.5"
             },
             "bin": {
-                "quicktype": "dist/index.js"
+                "quicktype": "dist/src/index.js"
             },
             "devDependencies": {
                 "@tsconfig/node18": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "quicktype",
     "version": "23.0.0",
     "license": "Apache-2.0",
-    "main": "dist/index.js",
+    "main": "dist/src/index.js",
     "types": "dist/index.d.ts",
     "repository": "https://github.com/quicktype/quicktype",
     "engines": {
@@ -14,7 +14,7 @@
         "test": "script/test",
         "start": "script/watch",
         "clean": "rm -rf dist node_modules *~ packages/*/{dist,node_modules,out}",
-        "debug": "node --inspect-brk --max-old-space-size=4096 ./dist/index.js",
+        "debug": "node --inspect-brk --max-old-space-size=4096 ./dist/src/index.js",
         "lint": "eslint src/** packages/*/src/**",
         "lint:fix": "eslint --fix src/** packages/*/src/**"
     },
@@ -77,5 +77,5 @@
     "files": [
         "dist"
     ],
-    "bin": "dist/index.js"
+    "bin": "dist/src/index.js"
 }

--- a/packages/quicktype-core/package.json
+++ b/packages/quicktype-core/package.json
@@ -3,7 +3,7 @@
     "version": "18.0.15",
     "description": "The quicktype engine as a library",
     "license": "Apache-2.0",
-    "main": "dist/index.js",
+    "main": "dist/src/index.js",
     "types": "dist/index.d.ts",
     "repository": "https://github.com/quicktype/quicktype",
     "scripts": {

--- a/packages/quicktype-graphql-input/package.json
+++ b/packages/quicktype-graphql-input/package.json
@@ -3,7 +3,7 @@
     "version": "18.0.15",
     "package": "Package for using GraphQL as an input language to quicktype",
     "license": "Apache-2.0",
-    "main": "dist/index.js",
+    "main": "dist/src/index.js",
     "types": "dist/index.d.ts",
     "repository": "https://github.com/quicktype/quicktype",
     "scripts": {

--- a/packages/quicktype-typescript-input/package.json
+++ b/packages/quicktype-typescript-input/package.json
@@ -3,7 +3,7 @@
     "version": "18.0.15",
     "description": "Package for using TypeScript as an input language to quicktype",
     "license": "Apache-2.0",
-    "main": "dist/index.js",
+    "main": "dist/src/index.js",
     "types": "dist/index.d.ts",
     "repository": "https://github.com/quicktype/quicktype",
     "scripts": {

--- a/script/quicktype
+++ b/script/quicktype
@@ -10,7 +10,10 @@
 SCRIPTDIR=$(dirname "$0")
 BASEDIR="$SCRIPTDIR/.."
 
-if [ x"$SKIP_BUILD" = x ] ; then
-    ( cd "$BASEDIR" ; npm run build &>/dev/null )
+if [ x"$SKIP_BUILD" = x ]; then
+    (
+        cd "$BASEDIR"
+        npm run build &>/dev/null
+    )
 fi
-node --stack_trace_limit=100 --max-old-space-size=4096 "$BASEDIR/dist/index.js" "$@"
+node --stack_trace_limit=100 --max-old-space-size=4096 "$BASEDIR/dist/src/index.js" "$@"


### PR DESCRIPTION
## Description

per https://github.com/glideapps/quicktype/pull/2558, the dist file layout got changed (see #2593)

## Related Issue

- #2593
- https://github.com/Homebrew/homebrew-core/pull/171524


## How Has This Been Tested?

Run local build. 

## Screenshots (if appropriate):
