### PR TITLE
fix: Restores old build output by removing package.json import

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     },
     "scripts": {
         "pub": "script/publish.sh",
-        "build": "npm run build --workspaces --if-present && tsc",
+        "build": "npm run clean && npm run build --workspaces --if-present && tsc",
         "test": "script/test",
         "start": "script/watch",
-        "clean": "rm -rf dist node_modules *~ packages/*/{dist,node_modules,out}",
+        "clean": "rm -rf dist *~ packages/*/{dist,out}",
         "debug": "node --inspect-brk --max-old-space-size=4096 ./dist/index.js",
         "lint": "eslint src/** packages/*/src/**",
         "lint:fix": "eslint --fix src/** packages/*/src/**"

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,12 +49,13 @@ import {
 import { GraphQLInput } from "quicktype-graphql-input";
 import { schemaForTypeScriptSources } from "quicktype-typescript-input";
 
-import packageJSON from "../package.json";
-
 import { CompressedJSONFromStream } from "./CompressedJSONFromStream";
 import { introspectServer } from "./GraphQLIntrospection";
 import { type GraphQLTypeSource, type JSONTypeSource, type SchemaTypeSource, type TypeSource } from "./TypeSource";
 import { urlsFromURLGrammar } from "./URLGrammar";
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+const packageJSON = require("../package.json");
 
 const wordWrap: (s: string) => string = _wordwrap(90);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,7 @@
         "noUnusedParameters": true,
         "noFallthroughCasesInSwitch": true,
         "outDir": "dist",
-        "baseUrl": "src",
-        "resolveJsonModule": true
+        "baseUrl": "src"
     },
     "include": ["src"]
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Reverts the package.json import from `import` to `require`
Removes `resolveJsonModules` from `tsconfig.json`

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #2593 

By including `resolveJsonModules: true` and using `import` for the `package.json` in the `index.ts` for the cli dir, we ended up introducing an extra level into the build output as including the json import hoisted the `src` dir into `dist`.

Fixed by restoring the previous code and ignoring the lint error.
Will follow-up with a new PR to get the version text in a different manner

## Previous Behaviour / Output

<!--- Provide an example of what was happening before your change -->

Old dist output:
![image](https://github.com/glideapps/quicktype/assets/10782902/6a45cb4b-097a-4802-b9a5-51370224228b)


## New Behaviour / Output

<!--- Provide an example of what now happens after your change -->

Current output:
![image](https://github.com/glideapps/quicktype/assets/10782902/d28609fd-200f-4334-996b-c8a8385a0fc0)


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran, including any new unit tests --->

- [x] Check that build succeeds and that the `src` dir is not in the build output

## Screenshots (if appropriate):
