### PR TITLE
feat(python): add --pydantic-base-model option

### DIFF
--- a/packages/quicktype-core/src/language/Python/language.ts
+++ b/packages/quicktype-core/src/language/Python/language.ts
@@ -27,12 +27,18 @@ export const pythonOptions = {
         "3.6"
     ),
     justTypes: new BooleanOption("just-types", "Classes only", false),
-    nicePropertyNames: new BooleanOption("nice-property-names", "Transform property names to be Pythonic", true)
+    nicePropertyNames: new BooleanOption("nice-property-names", "Transform property names to be Pythonic", true),
+    pydanticBaseModel: new BooleanOption("pydantic-base-model", "Uses pydantic BaseModel", false)
 };
 
 export class PythonTargetLanguage extends TargetLanguage {
     protected getOptions(): Array<Option<FixMeOptionsAnyType>> {
-        return [pythonOptions.features, pythonOptions.justTypes, pythonOptions.nicePropertyNames];
+        return [
+            pythonOptions.features,
+            pythonOptions.justTypes,
+            pythonOptions.nicePropertyNames,
+            pythonOptions.pydanticBaseModel
+        ];
     }
 
     public get stringTypeMapping(): StringTypeMapping {


### PR DESCRIPTION
## Description

Adds a python option `pydantic-base-model`, which will generate classes inheriting pydantic's [BaseModel](https://docs.pydantic.dev/latest/concepts/models/). 

## Related Issue

https://github.com/glideapps/quicktype/issues/1474

## Motivation and Context

[Pydantic](https://docs.pydantic.dev/latest/) is a commonly used python module for defining schemas and dataclasses with validation. It is used in [FastApi](https://fastapi.tiangolo.com/). It is a nice alternative to the builtin `dataclasses` module.

## Previous Behaviour / Output

Quicktype generates standard classes or dataclasses (3.7+) for python

## New Behaviour / Output

With the `--pydantic-base-model` option, it generates pydantic BaseModel classes

## How Has This Been Tested?

Built and generated python from a schema, with and without `--pydantic-base-model` option. 

Without the option included `from dataclasses import dataclass` and `@dataclass`

With the option instead included `from pydantic import BaseModel` and `class Example(BaseModel)`

## Screenshots (if appropriate):
