### PR TITLE
chore(repo): Allow running test pr workflow for release branches

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -3,6 +3,7 @@ on:
     pull_request:
         branches:
             - master
+            - 'release/**'
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Enables test-pr workflow for `release/**` branches