### PR TITLE
feat: expose various emit functions to subclasses

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -231,7 +231,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
             });
     }
 
-    private emitPatternMatches(
+    protected emitPatternMatches(
         types: Type[],
         name: Sourcelike,
         parentName: Sourcelike,
@@ -548,7 +548,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
         );
     }
 
-    private emitBlock(source: Sourcelike, emit: () => void): void {
+    protected emitBlock(source: Sourcelike, emit: () => void): void {
         this.emitLine(source);
         this.indent(emit);
         this.emitLine("end");
@@ -562,7 +562,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
         });
     }
 
-    private emitModule(c: ClassType, moduleName: Name): void {
+    protected emitModule(c: ClassType, moduleName: Name): void {
         this.emitBlock(["defmodule ", this.nameWithNamespace(moduleName), " do"], () => {
             const structDescription = this.descriptionForType(c) ?? [];
             const attributeDescriptions: Sourcelike[][] = [];
@@ -750,7 +750,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
         return true;
     }
 
-    private emitEnum(e: EnumType, enumName: Name): void {
+    protected emitEnum(e: EnumType, enumName: Name): void {
         this.emitBlock(["defmodule ", this.nameWithNamespace(enumName), " do"], () => {
             this.emitDescription(this.descriptionForType(e));
             this.emitLine("@valid_enum_members [");
@@ -809,7 +809,7 @@ end`);
         });
     }
 
-    private emitUnion(_u: UnionType, _unionName: Name): void {
+    protected emitUnion(_u: UnionType, _unionName: Name): void {
         return;
     }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
This change makes the various Elixir `emit` functions `protected` instead of `private`, so that they can be overridden in customized code generators.

## Related Issue

https://github.com/glideapps/quicktype/issues/2657

## Motivation and Context

Allow these functions to be overridden in subclasses.

## Previous Behaviour / Output

N/A

## New Behaviour / Output

N/A

## How Has This Been Tested?

`FIXTURE=Elixir npm test`

## Screenshots (if appropriate):

N/A