### PR TITLE
feat(typescript-effect-schema): support effect@^3.10.0

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -76,7 +76,7 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
 
     protected emitImports(): void {
         this.ensureBlankLine();
-        this.emitLine(this.importStatement("* as S", '"@effect/schema/Schema"'));
+        this.emitLine(this.importStatement("{Schema as S}", '"effect"'));
     }
 
     private typeMapTypeForProperty(p: ClassProperty): Sourcelike {
@@ -104,7 +104,7 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
             _stringType => "S.String",
             arrayType => ["S.Array(", this.typeMapTypeFor(arrayType.items, false), ")"],
             _classType => panic("Should already be handled."),
-            _mapType => ["S.Record(S.String, ", this.typeMapTypeFor(_mapType.values, false), ")"],
+            _mapType => ["S.Record({key: S.String, value: ", this.typeMapTypeFor(_mapType.values, false), "})"],
             _enumType => panic("Should already be handled."),
             unionType => {
                 const children = Array.from(unionType.getChildren()).map((type: Type) =>

--- a/test/fixtures/typescript-effect-schema/main.ts
+++ b/test/fixtures/typescript-effect-schema/main.ts
@@ -1,7 +1,7 @@
 import * as TopLevel from "./TopLevel";
 import fs from "fs";
 import process from "process";
-import * as Schema from "@effect/schema/Schema";
+import {Schema} from "effect";
 
 const sample = process.argv[2];
 const json = fs.readFileSync(sample);

--- a/test/fixtures/typescript-effect-schema/package-lock.json
+++ b/test/fixtures/typescript-effect-schema/package-lock.json
@@ -9,20 +9,11 @@
             "version": "0.1.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@effect/schema": "^0.66.5"
+                "effect": "^3.10.0"
             },
             "devDependencies": {
                 "tsx": "^3.12.2",
                 "typescript": "^5.4.0"
-            }
-        },
-        "node_modules/@effect/schema": {
-            "version": "0.66.5",
-            "resolved": "https://registry.npmjs.org/@effect/schema/-/schema-0.66.5.tgz",
-            "integrity": "sha512-xfu5161JyrfAS1Ruwv0RXd4QFiCALbm3iu9nlW9N9K+52wbS0WdO6XUekPZ9V/O7LN+XmlIh5Y9xhJaIWCZ/gw==",
-            "peerDependencies": {
-                "effect": "^3.0.3",
-                "fast-check": "^3.13.2"
             }
         },
         "node_modules/@esbuild/android-arm": {
@@ -384,10 +375,13 @@
             "dev": true
         },
         "node_modules/effect": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/effect/-/effect-3.0.3.tgz",
-            "integrity": "sha512-mgG+FoWrM4sny8OxDFWCpq+6LwGf9cK/JztVhxZQeZM9ZMXY+lKbdMEQmemNYce0QVAz2+YqUKwhKzOidwbZzg==",
-            "peer": true
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/effect/-/effect-3.10.1.tgz",
+            "integrity": "sha512-Ny0I3WvGykUnlgmQVkNVbkXHE/pPTWVwmnYfpVZYyLlpe53LVyWViY9+a/7iS/Rqml0xUwJoXx5HK6ksK09Y2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-check": "^3.21.0"
+            }
         },
         "node_modules/esbuild": {
             "version": "0.18.20",
@@ -427,9 +421,9 @@
             }
         },
         "node_modules/fast-check": {
-            "version": "3.17.2",
-            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.17.2.tgz",
-            "integrity": "sha512-+3DPTxtxABLgmmVpYxrash3DHoq0cMa1jjLYNp3qqokKKhqVEaS4lbnaDKqWU5Dd6C2pEudPPBAEEQ9nUou9OQ==",
+            "version": "3.22.0",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.22.0.tgz",
+            "integrity": "sha512-8HKz3qXqnHYp/VCNn2qfjHdAdcI8zcSqOyX64GOMukp7SL2bfzfeDKjSd+UyECtejccaZv3LcvZTm9YDD22iCQ==",
             "funding": [
                 {
                     "type": "individual",
@@ -440,7 +434,7 @@
                     "url": "https://opencollective.com/fast-check"
                 }
             ],
-            "peer": true,
+            "license": "MIT",
             "dependencies": {
                 "pure-rand": "^6.1.0"
             },
@@ -487,8 +481,7 @@
                     "type": "opencollective",
                     "url": "https://opencollective.com/fast-check"
                 }
-            ],
-            "peer": true
+            ]
         },
         "node_modules/resolve-pkg-maps": {
             "version": "1.0.0",

--- a/test/fixtures/typescript-effect-schema/package.json
+++ b/test/fixtures/typescript-effect-schema/package.json
@@ -13,6 +13,6 @@
         "typescript": "^5.4.0"
     },
     "dependencies": {
-        "@effect/schema": "^0.66.5"
+        "effect": "^3.10.0"
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of the feature in the Title above -->

## Context (-, typescript-effect-schema)

<!-- What input format and what target output language would this affect ? -->

Input Format: -
Output Language: typescript-effect-schema

## Description

With the [effect v3.10.0 release](https://effect.website/blog/effect-3.10#effectschema-moved-to-effectschema), effect-schema became a stable version within the core `effect` package and `@effect/schema` should not be used anymore as newer effect versions are incompatible with it.

It already had the issue with the `Schema.Record` API moving from `Schema.Record(key, value)` to `Schema.Record({key, value})` this PR addresses that one as well

## Current Behaviour / Output

quicktype currently supports the usage of `@effect/schema@0.x` to generate the schemas which is deprecated as now effect/schema is part of the core `effect` library.

```typescript
import * as S from "@effect/schema/Schema"
// ...
S.Record(S.String, S.Number)
```

## Proposed Behaviour / Output

```typescript
import {Schema as S} from "effect"
// only other api change is how records are done:
S.Record({ key: S.String, value: S.Number })
```

## Solution

Changed import to use `effect` instead of `@effect/schema` for the imports and fixed the behaviour of Records

## Alternatives

No Alternatives

## Context

-
