### PR TITLE
Fix Runtime `punycode` Deprecation Error (#2662)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8487,7 +8487,6 @@
         },
         "node_modules/punycode": {
             "version": "2.3.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -9904,8 +9903,15 @@
             }
         },
         "node_modules/tr46": {
-            "version": "0.0.3",
-            "license": "MIT"
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+            "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+            "dependencies": {
+                "punycode": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/ts-api-utils": {
             "version": "1.3.0",
@@ -10445,19 +10451,27 @@
             "dev": true
         },
         "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "license": "BSD-2-Clause"
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/whatwg-fetch": {
             "version": "3.6.2",
             "license": "MIT"
         },
         "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "license": "MIT",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+            "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
             "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+                "tr46": "^4.1.1",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,13 @@
         "ts-node": "^10.9.2",
         "watch": "^1.0.2"
     },
+    "overrides": {
+        "cross-fetch": {
+            "node-fetch": {
+                "whatwg-url": "^13.0.0"
+            }
+        }
+    },
     "files": [
         "dist"
     ],

--- a/packages/quicktype-core/package.json
+++ b/packages/quicktype-core/package.json
@@ -38,6 +38,13 @@
         "@types/wordwrap": "^1.0.3",
         "typescript": "4.9.5"
     },
+    "overrides": {
+        "cross-fetch": {
+            "node-fetch": {
+                "whatwg-url": "^13.0.0"
+            }
+        }
+    },
     "files": [
         "dist"
     ],


### PR DESCRIPTION
Addresses #2662.

After the builtin `punycode` implementation was deprecated, `quicktype` now crashes at runtime from a deprecation error. This fix temporarily overrides `whatwg-url` to version `^13.0.0`, the earliest version that properly uses a userspace `punycode` implementation. 

`whatwg-url` is a dependency of `node-fetch 2.x` which is a dependency of `cross-fetch`. In the future, updating `cross-fetch` should fix the issue without having to override `whatwg-url` once [this issue](https://github.com/lquixada/cross-fetch/issues/177) is addressed.

Also, further work should be done to update `@vscode/vsce`, `eslint-config-canonical`, and `ajv` These are dev dependencies, so they should not affect runtime, but are still prone to the `punycode` error.