### PR TITLE
Adds .NET 8 C# version and expands nullable types (#1632)

### DIFF
--- a/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
@@ -125,7 +125,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
     protected nullableCSType(t: Type, follow: (t: Type) => Type = followTargetType, withIssues = false): Sourcelike {
         t = followTargetType(t);
         const csType = this.csType(t, follow, withIssues);
-        if (isValueType(t)) {
+        if (isValueType(t) || this._csOptions.version >= 8) {
             return [csType, "?"];
         } else {
             return csType;

--- a/packages/quicktype-core/src/language/CSharp/language.ts
+++ b/packages/quicktype-core/src/language/CSharp/language.ts
@@ -16,7 +16,7 @@ export enum Framework {
     SystemTextJson = "SystemTextJson"
 }
 
-export type Version = 5 | 6;
+export type Version = 5 | 6 | 8;
 export interface OutputFeatures {
     attributes: boolean;
     helpers: boolean;
@@ -55,7 +55,8 @@ export const cSharpOptions = {
         "C# version",
         [
             ["5", 5],
-            ["6", 6]
+            ["6", 6],
+            ["8", 8]
         ],
         "6",
         "secondary"


### PR DESCRIPTION
## Description

Relaxes nullability check for .NET 8+ targeting.  .NET 8 introduced nullable reference types, thereby removing the restriction that only value types can be made nullable.

## Related Issue

(https://github.com/glideapps/quicktype/issues/1632)

## Motivation and Context

Specifically when using System.Text.Json, the new nullable ignore attribute does not trigger Roslyn warning CS8601, leading to potential runtime null reference exceptions.

## Previous Behaviour / Output

Previously, reference types such as `string` would not include the `?` nullability indicator.

## New Behaviour / Output

Now, all C# types (reference and value) will include `?` when optional, since the serialized data may contain null values for those properties per the specification.

## How Has This Been Tested?

Ran before and after examples in a Docker environment.

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/9d0baa2b-8d45-4b41-af9f-709dfc7237d1)
