### PR TITLE
C#: Adds option to enable nullable reference types (#1632)

### DIFF
--- a/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
@@ -125,7 +125,7 @@ export class CSharpRenderer extends ConvenienceRenderer {
     protected nullableCSType(t: Type, follow: (t: Type) => Type = followTargetType, withIssues = false): Sourcelike {
         t = followTargetType(t);
         const csType = this.csType(t, follow, withIssues);
-        if (isValueType(t)) {
+        if (isValueType(t) || this._csOptions.nullable) {
             return [csType, "?"];
         } else {
             return csType;

--- a/packages/quicktype-core/src/language/CSharp/language.ts
+++ b/packages/quicktype-core/src/language/CSharp/language.ts
@@ -61,6 +61,7 @@ export const cSharpOptions = {
         "secondary"
     ),
     virtual: new BooleanOption("virtual", "Generate virtual properties", false),
+    nullable: new BooleanOption("nullable", "Generate nullable reference types for optional properties", false),
     typeForAny: new EnumOption<CSharpTypeForAny>(
         "any-type",
         'Type to use for "any"',
@@ -120,6 +121,7 @@ export class CSharpTargetLanguage extends TargetLanguage {
             cSharpOptions.useDecimal,
             cSharpOptions.typeForAny,
             cSharpOptions.virtual,
+            cSharpOptions.nullable,
             cSharpOptions.features,
             cSharpOptions.baseclass,
             cSharpOptions.checkRequired,


### PR DESCRIPTION
## Description
Added a `--nullable` option to use the `?` specifier for value and reference types.

## Related Issue
(https://github.com/glideapps/quicktype/issues/1632)

## Motivation and Context
Specifically when using System.Text.Json, the new nullable ignore attribute does not trigger Roslyn warning CS8601, leading to potential runtime null reference exceptions.

## Previous Behaviour / Output
Previously, reference types such as string would not include the `?` nullable indicator.

## New Behaviour / Output
Now, all C# types (reference and value) will include ? when optional, since the serialized data may contain null values for those properties per the specification.

## How Has This Been Tested?
Ran before and after examples in a Docker environment.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/a31ffcd3-6b7b-4709-8e54-418aab40ff59)
