### PR TITLE
chore: Update typescript to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "quicktype",
-    "version": "23.0.0",
+    "version": "23.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "quicktype",
-            "version": "23.0.0",
+            "version": "23.1.0",
             "license": "Apache-2.0",
             "workspaces": [
                 "./packages/quicktype-core",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "readable-stream": "^4.5.2",
                 "stream-json": "1.8.0",
                 "string-to-stream": "^3.0.1",
-                "typescript": "4.9.5"
+                "typescript": "~5.8.3"
             },
             "bin": {
                 "quicktype": "dist/index.js"
@@ -10143,14 +10143,16 @@
             "license": "MIT"
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/typical": {
@@ -10870,6 +10872,20 @@
                 "node": ">=4"
             }
         },
+        "packages/quicktype-core/node_modules/typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
         "packages/quicktype-graphql-input": {
             "version": "18.0.15",
             "license": "Apache-2.0",
@@ -10882,6 +10898,20 @@
                 "@types/graphql": "^0.11.7",
                 "@types/node": "18.19.31",
                 "typescript": "4.9.5"
+            }
+        },
+        "packages/quicktype-graphql-input/node_modules/typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
             }
         },
         "packages/quicktype-typescript-input": {
@@ -10956,6 +10986,19 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+            }
+        },
+        "packages/quicktype-typescript-input/node_modules/typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
             }
         },
         "packages/quicktype-typescript-input/node_modules/yaml": {
@@ -11202,18 +11245,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "packages/quicktype-vscode/node_modules/typescript": {
-            "version": "5.4.5",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
             }
         },
         "packages/quicktype-vscode/node_modules/unicode-properties": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10892,7 +10892,7 @@
             "dependencies": {
                 "@mark.probst/typescript-json-schema": "0.55.0",
                 "quicktype-core": "file:../quicktype-core",
-                "typescript": "~5.8.3"
+                "typescript": "4.9.5"
             },
             "devDependencies": {
                 "@types/node": "18.19.31"
@@ -10958,6 +10958,19 @@
                 "safe-buffer": "~5.1.1",
                 "string_decoder": "~1.1.1",
                 "util-deprecate": "~1.0.1"
+            }
+        },
+        "packages/quicktype-typescript-input/node_modules/typescript": {
+            "version": "4.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
             }
         },
         "packages/quicktype-typescript-input/node_modules/yaml": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10862,7 +10862,7 @@
                 "@types/unicode-properties": "^1.3.0",
                 "@types/urijs": "^1.19.25",
                 "@types/wordwrap": "^1.0.3",
-                "typescript": "4.9.5"
+                "typescript": "~5.8.3"
             }
         },
         "packages/quicktype-core/node_modules/pluralize": {
@@ -10870,20 +10870,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "packages/quicktype-core/node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
             }
         },
         "packages/quicktype-graphql-input": {
@@ -10897,21 +10883,7 @@
             "devDependencies": {
                 "@types/graphql": "^0.11.7",
                 "@types/node": "18.19.31",
-                "typescript": "4.9.5"
-            }
-        },
-        "packages/quicktype-graphql-input/node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
+                "typescript": "~5.8.3"
             }
         },
         "packages/quicktype-typescript-input": {
@@ -10920,7 +10892,7 @@
             "dependencies": {
                 "@mark.probst/typescript-json-schema": "0.55.0",
                 "quicktype-core": "file:../quicktype-core",
-                "typescript": "4.9.5"
+                "typescript": "~5.8.3"
             },
             "devDependencies": {
                 "@types/node": "18.19.31"
@@ -10988,19 +10960,6 @@
                 "util-deprecate": "~1.0.1"
             }
         },
-        "packages/quicktype-typescript-input/node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        },
         "packages/quicktype-typescript-input/node_modules/yaml": {
             "version": "1.10.2",
             "license": "ISC",
@@ -11026,7 +10985,7 @@
                 "node-persist": "^4.0.1",
                 "quicktype-core": "file:../quicktype-core",
                 "quicktype-typescript-input": "file:../quicktype-typescript-input",
-                "typescript": "^5.3.3",
+                "typescript": "~5.8.3",
                 "unicode-properties": "github:quicktype/unicode-properties#dist"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "readable-stream": "^4.5.2",
         "stream-json": "1.8.0",
         "string-to-stream": "^3.0.1",
-        "typescript": "4.9.5"
+        "typescript": "~5.8.3"
     },
     "devDependencies": {
         "@tsconfig/node18": "^1.0.1",

--- a/packages/quicktype-core/package.json
+++ b/packages/quicktype-core/package.json
@@ -36,7 +36,7 @@
         "@types/unicode-properties": "^1.3.0",
         "@types/urijs": "^1.19.25",
         "@types/wordwrap": "^1.0.3",
-        "typescript": "4.9.5"
+        "typescript": "~5.8.3"
     },
     "files": [
         "dist"

--- a/packages/quicktype-core/src/Inference.ts
+++ b/packages/quicktype-core/src/Inference.ts
@@ -1,0 +1,91 @@
+import type { TransformedStringTypeKind } from "./Type";
+
+export interface InferenceFlag {
+    description: string;
+    explanation: string;
+    negationDescription: string;
+    order: number;
+    stringType?: TransformedStringTypeKind;
+}
+
+export const inferenceFlagsObject = {
+    /** Whether to infer map types from JSON data */
+    inferMaps: {
+        description: "Detect maps",
+        negationDescription: "Don't infer maps, always use classes",
+        explanation: "Infer maps when object keys look like map keys.",
+        order: 1
+    },
+    /** Whether to infer enum types from JSON data */
+    inferEnums: {
+        description: "Detect enums",
+        negationDescription: "Don't infer enums, always use strings",
+        explanation: "If string values occur within a relatively small domain,\ninfer them as enum values.",
+        order: 2
+    },
+    /** Whether to convert UUID strings to UUID objects */
+    inferUuids: {
+        description: "Detect UUIDs",
+        negationDescription: "Don't convert UUIDs to UUID objects",
+        explanation: "Detect UUIDs like '123e4567-e89b-12d3-a456-426655440000' (partial support).",
+        stringType: "uuid" as TransformedStringTypeKind,
+        order: 3
+    },
+    /** Whether to assume that JSON strings that look like dates are dates */
+    inferDateTimes: {
+        description: "Detect dates & times",
+        negationDescription: "Don't infer dates or times",
+        explanation: "Infer dates from strings (partial support).",
+        stringType: "date-time" as TransformedStringTypeKind,
+        order: 4
+    },
+    /** Whether to convert stringified integers to integers */
+    inferIntegerStrings: {
+        description: "Detect integers in strings",
+        negationDescription: "Don't convert stringified integers to integers",
+        explanation: 'Automatically convert stringified integers to integers.\nFor example, "1" is converted to 1.',
+        stringType: "integer-string" as TransformedStringTypeKind,
+        order: 5
+    },
+    /** Whether to convert stringified booleans to boolean values */
+    inferBooleanStrings: {
+        description: "Detect booleans in strings",
+        negationDescription: "Don't convert stringified booleans to booleans",
+        explanation:
+            'Automatically convert stringified booleans to booleans.\nFor example, "true" is converted to true.',
+        stringType: "bool-string" as TransformedStringTypeKind,
+        order: 6
+    },
+    /** Combine similar classes.  This doesn't apply to classes from a schema, only from inference. */
+    combineClasses: {
+        description: "Merge similar classes",
+        negationDescription: "Don't combine similar classes",
+        explanation:
+            "Combine classes with significantly overlapping properties,\ntreating contingent properties as nullable.",
+        order: 7
+    },
+    /** Whether to treat $ref as references within JSON */
+    ignoreJsonRefs: {
+        description: "Don't treat $ref as a reference in JSON",
+        negationDescription: "Treat $ref as a reference in JSON",
+        explanation:
+            "Like in JSON Schema, allow objects like\n'{ $ref: \"#/foo/bar\" }' to refer\nto another part of the input.",
+        order: 8
+    }
+};
+export type InferenceFlagName = keyof typeof inferenceFlagsObject;
+export const inferenceFlagNames = Object.getOwnPropertyNames(inferenceFlagsObject) as InferenceFlagName[];
+export const inferenceFlags: { [F in InferenceFlagName]: InferenceFlag } = inferenceFlagsObject;
+
+export type InferenceFlags = { [F in InferenceFlagName]: boolean };
+
+function makeDefaultInferenceFlags(): InferenceFlags {
+    const flags = {} as InferenceFlags;
+    for (const flag of inferenceFlagNames) {
+        flags[flag] = true;
+    }
+
+    return flags;
+}
+
+export const defaultInferenceFlags = makeDefaultInferenceFlags();

--- a/packages/quicktype-core/src/RendererOptions/index.ts
+++ b/packages/quicktype-core/src/RendererOptions/index.ts
@@ -1,6 +1,6 @@
 import { messageError } from "../Messages";
 import { assert } from "../support/Support";
-import { type FixMeOptionsType, type NoInfer } from "../types";
+import { type FixMeOptionsType } from "../types";
 
 import type { OptionDefinition, OptionKind, OptionValues } from "./types";
 

--- a/packages/quicktype-core/src/Run.ts
+++ b/packages/quicktype-core/src/Run.ts
@@ -1,13 +1,10 @@
 import { mapFirst } from "collection-utils";
 
 import { initTypeNames } from "./attributes/TypeNames";
-import { gatherNames } from "./GatherNames";
 import { InputData } from "./input/Inputs";
 import * as targetLanguages from "./language/All";
 import type { RendererOptions } from "./language/options.types";
 import type { LanguageName } from "./language/types";
-import { makeTransformations } from "./MakeTransformations";
-import { messageError } from "./Messages";
 import { combineClasses } from "./rewrites/CombineClasses";
 import { expandStrings } from "./rewrites/ExpandStrings";
 import { flattenStrings } from "./rewrites/FlattenStrings";
@@ -15,14 +12,18 @@ import { flattenUnions } from "./rewrites/FlattenUnions";
 import { inferMaps } from "./rewrites/InferMaps";
 import { replaceObjectType } from "./rewrites/ReplaceObjectType";
 import { resolveIntersections } from "./rewrites/ResolveIntersections";
-import { type Annotation, type Location, type SerializedRenderResult, type Span } from "./Source";
 import { type Comment } from "./support/Comments";
 import { assert } from "./support/Support";
+
+import { gatherNames } from "./GatherNames";
+import { defaultInferenceFlags, inferenceFlagNames, inferenceFlags, InferenceFlags } from "./Inference";
+import { makeTransformations } from "./MakeTransformations";
+import { messageError } from "./Messages";
+import { type Annotation, type Location, type SerializedRenderResult, type Span } from "./Source";
 import { type MultiFileRenderResult, type TargetLanguage } from "./TargetLanguage";
-import { type TransformedStringTypeKind } from "./Type";
 import { type StringTypeMapping, TypeBuilder } from "./TypeBuilder";
 import { type TypeGraph, noneToAny, optionalToNullable, removeIndirectionIntersections } from "./TypeGraph";
-import { type FixMeOptionsType } from "./types";
+import type { FixMeOptionsType } from "./types";
 
 export function getTargetLanguage(nameOrInstance: LanguageName | TargetLanguage): TargetLanguage {
     if (typeof nameOrInstance === "object") {
@@ -36,85 +37,6 @@ export function getTargetLanguage(nameOrInstance: LanguageName | TargetLanguage)
 
     return messageError("DriverUnknownOutputLanguage", { lang: nameOrInstance });
 }
-
-export interface InferenceFlag {
-    description: string;
-    explanation: string;
-    negationDescription: string;
-    order: number;
-    stringType?: TransformedStringTypeKind;
-}
-
-export const inferenceFlagsObject = {
-    /** Whether to infer map types from JSON data */
-    inferMaps: {
-        description: "Detect maps",
-        negationDescription: "Don't infer maps, always use classes",
-        explanation: "Infer maps when object keys look like map keys.",
-        order: 1
-    },
-    /** Whether to infer enum types from JSON data */
-    inferEnums: {
-        description: "Detect enums",
-        negationDescription: "Don't infer enums, always use strings",
-        explanation: "If string values occur within a relatively small domain,\ninfer them as enum values.",
-        order: 2
-    },
-    /** Whether to convert UUID strings to UUID objects */
-    inferUuids: {
-        description: "Detect UUIDs",
-        negationDescription: "Don't convert UUIDs to UUID objects",
-        explanation: "Detect UUIDs like '123e4567-e89b-12d3-a456-426655440000' (partial support).",
-        stringType: "uuid" as TransformedStringTypeKind,
-        order: 3
-    },
-    /** Whether to assume that JSON strings that look like dates are dates */
-    inferDateTimes: {
-        description: "Detect dates & times",
-        negationDescription: "Don't infer dates or times",
-        explanation: "Infer dates from strings (partial support).",
-        stringType: "date-time" as TransformedStringTypeKind,
-        order: 4
-    },
-    /** Whether to convert stringified integers to integers */
-    inferIntegerStrings: {
-        description: "Detect integers in strings",
-        negationDescription: "Don't convert stringified integers to integers",
-        explanation: 'Automatically convert stringified integers to integers.\nFor example, "1" is converted to 1.',
-        stringType: "integer-string" as TransformedStringTypeKind,
-        order: 5
-    },
-    /** Whether to convert stringified booleans to boolean values */
-    inferBooleanStrings: {
-        description: "Detect booleans in strings",
-        negationDescription: "Don't convert stringified booleans to booleans",
-        explanation:
-            'Automatically convert stringified booleans to booleans.\nFor example, "true" is converted to true.',
-        stringType: "bool-string" as TransformedStringTypeKind,
-        order: 6
-    },
-    /** Combine similar classes.  This doesn't apply to classes from a schema, only from inference. */
-    combineClasses: {
-        description: "Merge similar classes",
-        negationDescription: "Don't combine similar classes",
-        explanation:
-            "Combine classes with significantly overlapping properties,\ntreating contingent properties as nullable.",
-        order: 7
-    },
-    /** Whether to treat $ref as references within JSON */
-    ignoreJsonRefs: {
-        description: "Don't treat $ref as a reference in JSON",
-        negationDescription: "Treat $ref as a reference in JSON",
-        explanation:
-            "Like in JSON Schema, allow objects like\n'{ $ref: \"#/foo/bar\" }' to refer\nto another part of the input.",
-        order: 8
-    }
-};
-export type InferenceFlagName = keyof typeof inferenceFlagsObject;
-export const inferenceFlagNames = Object.getOwnPropertyNames(inferenceFlagsObject) as InferenceFlagName[];
-export const inferenceFlags: { [F in InferenceFlagName]: InferenceFlag } = inferenceFlagsObject;
-
-export type InferenceFlags = { [F in InferenceFlagName]: boolean };
 
 /**
  * The options type for the main quicktype entry points,
@@ -210,17 +132,6 @@ interface GraphInputs {
     targetLanguage: TargetLanguage;
     typeBuilder: TypeBuilder;
 }
-
-function makeDefaultInferenceFlags(): InferenceFlags {
-    const flags = {} as InferenceFlags;
-    for (const flag of inferenceFlagNames) {
-        flags[flag] = true;
-    }
-
-    return flags;
-}
-
-export const defaultInferenceFlags = makeDefaultInferenceFlags();
 
 class Run implements RunContext {
     private readonly _options: Options;

--- a/packages/quicktype-core/src/index.ts
+++ b/packages/quicktype-core/src/index.ts
@@ -7,7 +7,7 @@ export {
     combineRenderResults,
     type RunContext
 } from "./Run";
-export{
+export {
 	inferenceFlags,
 	inferenceFlagNames,
 	defaultInferenceFlags,

--- a/packages/quicktype-core/src/index.ts
+++ b/packages/quicktype-core/src/index.ts
@@ -5,14 +5,16 @@ export {
     quicktypeMultiFileSync,
     quicktype,
     combineRenderResults,
-    inferenceFlags,
-    inferenceFlagNames,
-    defaultInferenceFlags,
-    inferenceFlagsObject,
-    type InferenceFlags,
-    type InferenceFlagName,
     type RunContext
 } from "./Run";
+export{
+	inferenceFlags,
+	inferenceFlagNames,
+	defaultInferenceFlags,
+	inferenceFlagsObject,
+	type InferenceFlags,
+	type InferenceFlagName,
+} from "./Inference";
 export { CompressedJSON, type Value } from "./input/CompressedJSON";
 export { type Input, InputData, JSONInput, type JSONSourceData, jsonInputForTargetLanguage } from "./input/Inputs";
 export { JSONSchemaInput, type JSONSchemaSourceData } from "./input/JSONSchemaInput";

--- a/packages/quicktype-core/src/input/JSONSchemaInput.ts
+++ b/packages/quicktype-core/src/input/JSONSchemaInput.ts
@@ -954,9 +954,7 @@ async function addTypesInSchema(
 
         const includeObject = enumArray === undefined && !isConst && (typeSet === undefined || typeSet.has("object"));
         const includeArray = enumArray === undefined && !isConst && (typeSet === undefined || typeSet.has("array"));
-        const needStringEnum =
-            includedTypes.has("string") &&
-            enumArray?.find(x => typeof x === "string") !== undefined;
+        const needStringEnum = includedTypes.has("string") && enumArray?.find(x => typeof x === "string") !== undefined;
         const needUnion =
             typeSet !== undefined ||
             schema.properties !== undefined ||

--- a/packages/quicktype-core/src/input/io/get-stream/buffer-stream.ts
+++ b/packages/quicktype-core/src/input/io/get-stream/buffer-stream.ts
@@ -4,7 +4,7 @@ import { PassThrough } from "readable-stream";
 import { type Options } from "./index";
 
 export interface BufferedPassThrough extends PassThrough {
-	getBufferedValue: () => Buffer | string | any[];
+	getBufferedValue: () => any;
 	getBufferedLength: () => number;
 
 	// for compat with _Readable.Writable

--- a/packages/quicktype-core/src/input/io/get-stream/buffer-stream.ts
+++ b/packages/quicktype-core/src/input/io/get-stream/buffer-stream.ts
@@ -1,7 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { PassThrough } from "readable-stream";
 
-import { type Options } from ".";
+import { type Options } from "./index";
+
+export interface BufferedPassThrough extends PassThrough {
+	getBufferedValue: () => Buffer | string | any[];
+	getBufferedLength: () => number;
+
+	// for compat with _Readable.Writable
+	readonly writableObjectMode: never;
+}
 
 export default function bufferStream(opts: Options) {
     opts = Object.assign({}, opts);
@@ -12,10 +20,8 @@ export default function bufferStream(opts: Options) {
     let objectMode = false;
 
     if (array) {
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         objectMode = !(encoding || buffer);
     } else {
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         encoding = encoding || "utf8";
     }
 
@@ -27,10 +33,10 @@ export default function bufferStream(opts: Options) {
     const ret: any[] = [];
     const stream = new PassThrough({
         objectMode
-    }) as any;
+    }) as BufferedPassThrough;
 
     if (encoding) {
-        stream.setEncoding(encoding);
+        stream.setEncoding(encoding as BufferEncoding);
     }
 
     stream.on("data", (chunk: any) => {

--- a/packages/quicktype-core/src/input/io/get-stream/index.ts
+++ b/packages/quicktype-core/src/input/io/get-stream/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { type Readable } from "readable-stream";
 
-import bufferStream from "./buffer-stream";
+import bufferStream, { type BufferedPassThrough } from "./buffer-stream";
 
 export interface Options {
     array?: boolean;
@@ -17,7 +17,7 @@ export async function getStream(inputStream: Readable, opts: Options = {}) {
     opts = Object.assign({ maxBuffer: Infinity }, opts);
 
     const maxBuffer = opts.maxBuffer ?? Infinity;
-    let stream: any;
+    let stream: BufferedPassThrough;
     let clean;
 
     const p = new Promise((resolve, reject) => {

--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -44,6 +44,8 @@ export class CJSONRenderer extends ConvenienceRenderer {
 
     protected readonly enumeratorNamingStyle: NamingStyle; /* Enum naming style */
 
+		private includes:string[];
+
     /**
      * Constructor
      * @param targetLanguage: target language
@@ -63,6 +65,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
         this.enumeratorNamingStyle = _options.enumeratorNamingStyle;
         this.memberNameStyle = makeNameStyle(_options.memberNamingStyle, legalizeName);
         this.forbiddenGlobalNames = [];
+				this.includes = [];
         for (const type of numberEnumValues(GlobalNames)) {
             const genName = this.namedTypeNameStyle(GlobalNames[type]);
             this.forbiddenGlobalNames.push(genName);
@@ -265,27 +268,25 @@ export class CJSONRenderer extends ConvenienceRenderer {
      * Function called to create a multiple header files with types and generators
      */
     protected emitMultiSourceStructure(): void {
-        /* Array of includes */
-        let includes: string[];
 
         /* Create each file */
         this.forEachNamedType(
             "leading-and-interposing",
             (classType: ClassType, _name: Name) => {
-                this.emitClass(classType, includes);
+                this.emitClass(classType);
             },
             (enumType, _name) => {
-                this.emitEnum(enumType, includes);
+                this.emitEnum(enumType);
             },
             (unionType, _name) => {
-                this.emitUnion(unionType, includes);
+                this.emitUnion(unionType);
             }
         );
 
         /* Create top level file */
         this.forEachTopLevel(
             "leading",
-            (type: Type, className: Name) => this.emitTopLevel(type, className, includes),
+            (type: Type, className: Name) => this.emitTopLevel(type, className, this.includes),
             type => this.namedTypeToNameForTopLevel(type) === undefined
         );
     }
@@ -293,13 +294,12 @@ export class CJSONRenderer extends ConvenienceRenderer {
     /**
      * Function called to create an enum header files with types and generators
      * @param enumType: enum type
-     * @param includes: Array of includes
      */
-    protected emitEnum(enumType: EnumType, includes: string[]): void {
+    protected emitEnum(enumType: EnumType): void {
         /* Create file */
         const enumName = this.nameForNamedType(enumType);
         const filename = this.sourcelikeToString(enumName).concat(".h");
-        includes.push(filename);
+        this.includes.push(filename);
         this.startFile(filename);
 
         /* Create includes */
@@ -421,13 +421,12 @@ export class CJSONRenderer extends ConvenienceRenderer {
     /**
      * Function called to create a union header files with types and generators
      * @param unionType: union type
-     * @param includes: Array of includes
      */
-    protected emitUnion(unionType: UnionType, includes: string[]): void {
+    protected emitUnion(unionType: UnionType): void {
         /* Create file */
         const unionName = this.nameForNamedType(unionType);
         const filename = this.sourcelikeToString(unionName).concat(".h");
-        includes.push(filename);
+        this.includes.push(filename);
         this.startFile(filename);
 
         /* Create includes */
@@ -1324,13 +1323,12 @@ export class CJSONRenderer extends ConvenienceRenderer {
     /**
      * Function called to create a class header files with types and generators
      * @param classType: class type
-     * @param includes: Array of includes
      */
-    protected emitClass(classType: ClassType, includes: string[]): void {
+    protected emitClass(classType: ClassType): void {
         /* Create file */
         const className = this.nameForNamedType(classType);
         const filename = this.sourcelikeToString(className).concat(".h");
-        includes.push(filename);
+        this.includes.push(filename);
         this.startFile(filename);
 
         /* Create includes */

--- a/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/CSharpRenderer.ts
@@ -10,7 +10,12 @@ import { assert } from "../../support/Support";
 import { type TargetLanguage } from "../../TargetLanguage";
 import { followTargetType } from "../../Transformers";
 import { type ClassProperty, type ClassType, type EnumType, type Type, type UnionType } from "../../Type";
-import { directlyReachableSingleNamedType, matchType, nullableFromUnion, removeNullFromUnion } from "../../Type/TypeUtils";
+import {
+    directlyReachableSingleNamedType,
+    matchType,
+    nullableFromUnion,
+    removeNullFromUnion
+} from "../../Type/TypeUtils";
 
 import { type cSharpOptions } from "./language";
 import {

--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
@@ -31,7 +31,7 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
 
     protected sourceFor(t: Type): MultiWord {
         if (this._tsFlowOptions.preferConstValues && t.kind === "enum" && t instanceof EnumType && t.cases.size === 1) {
-            const item = t.cases.values().next().value;
+            const item = t.cases.values().next().value ?? '';
             return singleWord(`"${utf16StringEscape(item)}"`);
         }
 

--- a/packages/quicktype-core/src/support/Support.ts
+++ b/packages/quicktype-core/src/support/Support.ts
@@ -6,7 +6,7 @@ import { type JSONSchema } from "../input/JSONSchemaStore";
 import { messageError } from "../Messages";
 
 export interface StringMap {
-    [name: string]: unknown;
+    [name: string]: any;
 }
 
 export function isStringMap(x: unknown): x is StringMap;

--- a/packages/quicktype-core/src/support/Support.ts
+++ b/packages/quicktype-core/src/support/Support.ts
@@ -6,8 +6,7 @@ import { type JSONSchema } from "../input/JSONSchemaStore";
 import { messageError } from "../Messages";
 
 export interface StringMap {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [name: string]: any;
+    [name: string]: unknown;
 }
 
 export function isStringMap(x: unknown): x is StringMap;

--- a/packages/quicktype-core/src/types.ts
+++ b/packages/quicktype-core/src/types.ts
@@ -5,5 +5,3 @@ export * from "./language/options.types";
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export type FixMeOptionsType = Record<string, any>;
 
-// FIXME: Remove this post TS5.4
-export type NoInfer<T> = [T][T extends any ? 0 : never];

--- a/packages/quicktype-graphql-input/package.json
+++ b/packages/quicktype-graphql-input/package.json
@@ -18,7 +18,7 @@
     "devDependencies": {
         "@types/node": "18.19.31",
         "@types/graphql": "^0.11.7",
-        "typescript": "4.9.5"
+        "typescript": "~5.8.3"
     },
     "files": [
         "dist"

--- a/packages/quicktype-typescript-input/package.json
+++ b/packages/quicktype-typescript-input/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "quicktype-core": "file:../quicktype-core",
-        "typescript": "~5.8.3",
+        "typescript": "4.9.5",
         "@mark.probst/typescript-json-schema": "0.55.0"
     },
     "devDependencies": {

--- a/packages/quicktype-typescript-input/package.json
+++ b/packages/quicktype-typescript-input/package.json
@@ -12,7 +12,7 @@
     },
     "dependencies": {
         "quicktype-core": "file:../quicktype-core",
-        "typescript": "4.9.5",
+        "typescript": "~5.8.3",
         "@mark.probst/typescript-json-schema": "0.55.0"
     },
     "devDependencies": {

--- a/packages/quicktype-typescript-input/src/index.ts
+++ b/packages/quicktype-typescript-input/src/index.ts
@@ -20,7 +20,7 @@ const compilerOptions: ts.CompilerOptions = {
     rootDir: "."
 };
 
-// FIXME: We're stringifying and then parsing this schema again.  Just pass around
+// FIXME: We're stringifying and then parsing this schema again. Just pass around
 // the schema directly.
 export function schemaForTypeScriptSources(sourceFileNames: string[]): JSONSchemaSourceData {
     const program = ts.createProgram(sourceFileNames, compilerOptions);
@@ -32,6 +32,7 @@ export function schemaForTypeScriptSources(sourceFileNames: string[]): JSONSchem
         });
     }
 
+		// @ts-expect-error type mismatch between typescript version of this package and @mark.probst/typescript-json-schema
     const schema = generateSchema(program, "*", settings);
     const uris: string[] = [];
     let topLevelName = "";

--- a/packages/quicktype-typescript-input/src/index.ts
+++ b/packages/quicktype-typescript-input/src/index.ts
@@ -32,7 +32,7 @@ export function schemaForTypeScriptSources(sourceFileNames: string[]): JSONSchem
         });
     }
 
-		// @ts-expect-error type mismatch between typescript version of this package and @mark.probst/typescript-json-schema
+    // this breaks after upgrading to TS 5+
     const schema = generateSchema(program, "*", settings);
     const uris: string[] = [];
     let topLevelName = "";

--- a/packages/quicktype-vscode/package.json
+++ b/packages/quicktype-vscode/package.json
@@ -154,7 +154,7 @@
         "@vscode/test-electron": "^2.3.9",
         "@vscode/vsce": "^2.25.0",
         "eslint": "^8.56.0",
-        "typescript": "^5.3.3",
+        "typescript": "~5.8.3",
         "node-persist": "^4.0.1",
         "quicktype-core": "file:../quicktype-core",
         "quicktype-typescript-input": "file:../quicktype-typescript-input",

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -337,7 +337,7 @@ class JSONFixture extends LanguageFixture {
             _.find(prioritySamples, p => p.endsWith(`/priority/combinations${n}.json`))
         );
         if (combinationInputs.some(p => p === undefined)) {
-            return failWith("priority/combinations[1234].json samples not found", prioritySamples);
+            return failWith("priority/combinations[1234].json samples not found", { prioritySamples });
         }
         if (sources.length === 0 && !ONLY_OUTPUT) {
             const quickTestSamples = _.chain(this.language.quickTestRendererOptions)
@@ -348,7 +348,7 @@ class JSONFixture extends LanguageFixture {
                             p.endsWith(`/${filename}`)
                         );
                         if (input === undefined) {
-                            return failWith(`quick-test sample ${filename} not found`, qt);
+                            return failWith(`quick-test sample ${filename} not found`, { qt });
                         }
                         return [
                             {
@@ -771,7 +771,7 @@ class CommandSuccessfulLanguageFixture extends LanguageFixture {
             _.find(prioritySamples, p => p.endsWith(`/priority/combinations${n}.json`))
         );
         if (combinationInputs.some(p => p === undefined)) {
-            return failWith("priority/combinations[1234].json samples not found", prioritySamples);
+            return failWith("priority/combinations[1234].json samples not found", { prioritySamples });
         }
         if (sources.length === 0 && !ONLY_OUTPUT) {
             const quickTestSamples = _.chain(this.language.quickTestRendererOptions)
@@ -782,7 +782,7 @@ class CommandSuccessfulLanguageFixture extends LanguageFixture {
                             p.endsWith(`/${filename}`)
                         );
                         if (input === undefined) {
-                            return failWith(`quick-test sample ${filename} not found`, qt);
+                            return failWith(`quick-test sample ${filename} not found`, { qt });
                         }
                         return [
                             {

--- a/test/lib/multicore.ts
+++ b/test/lib/multicore.ts
@@ -75,12 +75,12 @@ export async function inParallel<Item, Result, Acc>(args: ParallelArgs<Item, Res
 
         // master sends a { fixtureName, sample } to run
         process.on("message", async ({ item, i }) => {
-            (process.send as any)({
+            process.send?.({
                 result: await map(item, i)
             });
         });
 
         // Ask master for work
-        (process.send as any)("ready");
+        process.send?.("ready");
     }
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -10,7 +10,7 @@ import * as languages from "./languages";
 import deepEquals from "./lib/deepEquals";
 
 import chalk from "chalk";
-const strictDeepEquals: (x: any, y: any) => boolean = require("deep-equal");
+const strictDeepEquals: (x: unknown, y: unknown) => boolean = require("deep-equal");
 
 const DEBUG = process.env.DEBUG !== undefined;
 const ASSUME_STRINGS_EQUAL = process.env.ASSUME_STRINGS_EQUAL !== undefined;
@@ -22,7 +22,7 @@ export function debug<T>(x: T): T {
     return x;
 }
 
-export function failWith(message: string, obj: { [key: string]: any }): never {
+export function failWith(message: string, obj: Record<string, unknown>): never {
     obj.cwd = process.cwd();
     console.error(chalk.red(message));
     console.error(chalk.red(JSON.stringify(obj, null, "  ")));
@@ -56,7 +56,7 @@ export function exec(
     if (env === undefined) {
         env = process.env;
     }
-    const result = shell.exec(s, { silent: !DEBUG, env }) as any;
+    const result = shell.exec(s, { silent: !DEBUG, env });
 
     if (result.code !== 0) {
         const failureObj = {


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- Updates packages to TS 5.8+
- Removes old `NoInfer` type shim
- Fixes misc `any` types
- Moves inference flags map and types to own file
- Strongly types inference flags
- Refactors CJSON `includes` array as class member instead of passed ref

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Previous Behaviour / Output

<!--- Provide an example of what was happening before your change -->

## New Behaviour / Output

<!--- Provide an example of what now happens after your change -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran, including any new unit tests --->

## Screenshots (if appropriate):
