### PR TITLE
Fix fetch with build-time substitution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4484,7 +4484,6 @@
         },
         "node_modules/punycode": {
             "version": "2.3.1",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -5328,8 +5327,16 @@
             }
         },
         "node_modules/tr46": {
-            "version": "0.0.3",
-            "license": "MIT"
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+            "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/ts-api-utils": {
             "version": "1.3.0",
@@ -5578,19 +5585,29 @@
             }
         },
         "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "license": "BSD-2-Clause"
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/whatwg-fetch": {
             "version": "3.6.2",
             "license": "MIT"
         },
         "node_modules/whatwg-url": {
-            "version": "5.0.0",
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+            "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
             "license": "MIT",
             "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
+                "tr46": "^4.1.1",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -689,10 +689,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "18.19.31",
+            "version": "22.14.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+            "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@types/node-persist": {
@@ -5469,7 +5471,9 @@
             "license": "MIT"
         },
         "node_modules/undici-types": {
-            "version": "5.26.5",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "license": "MIT"
         },
         "node_modules/unicode-properties": {
@@ -5902,7 +5906,7 @@
             "devDependencies": {
                 "@types/browser-or-node": "^1.3.2",
                 "@types/is-url": "^1.2.32",
-                "@types/node": "18.19.31",
+                "@types/node": "~22.14.0",
                 "@types/pako": "^1.0.0",
                 "@types/pluralize": "0.0.30",
                 "@types/readable-stream": "4.0.10",
@@ -5929,7 +5933,7 @@
             },
             "devDependencies": {
                 "@types/graphql": "^0.11.7",
-                "@types/node": "18.19.31",
+                "@types/node": "~22.14.0",
                 "typescript": "~5.8.3"
             }
         },
@@ -5942,7 +5946,7 @@
                 "typescript": "4.9.5"
             },
             "devDependencies": {
-                "@types/node": "18.19.31"
+                "@types/node": "~22.14.0"
             }
         },
         "packages/quicktype-typescript-input/node_modules/@glideapps/ts-necessities": {
@@ -6032,7 +6036,7 @@
             "version": "23.0.122",
             "devDependencies": {
                 "@types/mocha": "^10.0.6",
-                "@types/node": "18.x",
+                "@types/node": "~22.14.0",
                 "@types/node-persist": "^3.1.8",
                 "@types/readable-stream": "^4.0.10",
                 "@types/vscode": "^1.87.0",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,13 @@
         "ts-node": "^10.9.2",
         "watch": "^1.0.2"
     },
+    "overrides": {
+        "cross-fetch": {
+            "node-fetch": {
+                "whatwg-url": "^13.0.0"
+            }
+        }
+    },
     "files": ["dist"],
     "bin": "dist/index.js"
 }

--- a/packages/quicktype-core/env.sh
+++ b/packages/quicktype-core/env.sh
@@ -2,10 +2,7 @@
 
 if [[ $CI ]]
 then
-	echo 'FROG 1'
-	# grep -rl '$fetch' src | xargs sed -i '' -e 's/$fetch/$fetch.ci/g'
-else
-	echo 'FROG 2'
+	grep -rl '$fetch' src | xargs sed -i '' -e 's/$fetch/$fetch.ci/g'
 fi
 
 exit 0

--- a/packages/quicktype-core/env.sh
+++ b/packages/quicktype-core/env.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [[ $CI ]]
+then
+	echo 'FROG 1'
+	# grep -rl '$fetch' src | xargs sed -i '' -e 's/$fetch/$fetch.ci/g'
+else
+	echo 'FROG 2'
+fi
+
+exit 0

--- a/packages/quicktype-core/package.json
+++ b/packages/quicktype-core/package.json
@@ -8,7 +8,7 @@
     "repository": "https://github.com/quicktype/quicktype",
     "scripts": {
         "clean": "rm -rf dist node_modules *~",
-        "build": "tsc"
+        "build": "./env.sh && tsc"
     },
     "dependencies": {
         "@glideapps/ts-necessities": "2.2.3",

--- a/packages/quicktype-core/package.json
+++ b/packages/quicktype-core/package.json
@@ -38,6 +38,13 @@
         "@types/wordwrap": "^1.0.3",
         "typescript": "~5.8.3"
     },
+    "overrides": {
+        "cross-fetch": {
+            "node-fetch": {
+                "whatwg-url": "^13.0.0"
+            }
+        }
+    },
     "files": ["dist"],
     "browser": {
         "fs": false

--- a/packages/quicktype-core/package.json
+++ b/packages/quicktype-core/package.json
@@ -29,7 +29,7 @@
     "devDependencies": {
         "@types/browser-or-node": "^1.3.2",
         "@types/is-url": "^1.2.32",
-        "@types/node": "18.19.31",
+        "@types/node": "~22.14.0",
         "@types/pako": "^1.0.0",
         "@types/pluralize": "0.0.30",
         "@types/readable-stream": "4.0.10",

--- a/packages/quicktype-core/src/input/io/$fetch.ci.ts
+++ b/packages/quicktype-core/src/input/io/$fetch.ci.ts
@@ -1,1 +1,3 @@
+console.info("=== RUNNING IN CI, USE FETCH.CI ===");
+
 export const fetch = require("cross-fetch").default;

--- a/packages/quicktype-core/src/input/io/$fetch.ci.ts
+++ b/packages/quicktype-core/src/input/io/$fetch.ci.ts
@@ -1,0 +1,1 @@
+export const fetch = require("cross-fetch").default;

--- a/packages/quicktype-core/src/input/io/$fetch.ts
+++ b/packages/quicktype-core/src/input/io/$fetch.ts
@@ -1,0 +1,11 @@
+import type CrossFetch from "cross-fetch";
+
+let fetch: typeof CrossFetch;
+
+try {
+    fetch = global.fetch ?? require("cross-fetch").default;
+} catch {
+    fetch = require("cross-fetch").default;
+}
+
+export { fetch };

--- a/packages/quicktype-core/src/input/io/NodeIO.ts
+++ b/packages/quicktype-core/src/input/io/NodeIO.ts
@@ -49,7 +49,9 @@ export async function readableFromFileOrURL(
             });
 
             return defined(response.body) as unknown as Readable;
-        } else if (isNode) {
+        }
+
+        if (isNode) {
             if (fileOrURL === "-") {
                 // Cast node readable to isomorphic readable from readable-stream
                 return process.stdin as unknown as Readable;

--- a/packages/quicktype-core/src/input/io/NodeIO.ts
+++ b/packages/quicktype-core/src/input/io/NodeIO.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "node:fs";
 
 import { defined, exceptionToString } from "@glideapps/ts-necessities";
 import { isNode } from "browser-or-node";
@@ -10,11 +10,7 @@ import { panic } from "../../support/Support";
 
 import { getStream } from "./get-stream";
 
-// We need to use cross-fetch in CI or if fetch is not available in the global scope
-// We use a dynamic import to avoid punycode deprecated dependency warning on node > 20
-const fetch = process.env.CI
-    ? require("cross-fetch").default
-    : ((global as any).fetch ?? require("cross-fetch").default);
+import { fetch } from "./$fetch";
 
 interface HttpHeaders {
     [key: string]: string;
@@ -25,10 +21,7 @@ function parseHeaders(httpHeaders?: string[]): HttpHeaders {
         return {};
     }
 
-    return httpHeaders.reduce((
-        result: HttpHeaders,
-        httpHeader: string,
-    ) => {
+    return httpHeaders.reduce((result: HttpHeaders, httpHeader: string) => {
         if (httpHeader !== undefined && httpHeader.length > 0) {
             const split = httpHeader.indexOf(":");
 

--- a/packages/quicktype-graphql-input/package.json
+++ b/packages/quicktype-graphql-input/package.json
@@ -16,7 +16,7 @@
         "graphql": "^0.11.7"
     },
     "devDependencies": {
-        "@types/node": "18.19.31",
+        "@types/node": "~22.14.0",
         "@types/graphql": "^0.11.7",
         "typescript": "~5.8.3"
     },

--- a/packages/quicktype-typescript-input/package.json
+++ b/packages/quicktype-typescript-input/package.json
@@ -16,7 +16,7 @@
         "@mark.probst/typescript-json-schema": "0.55.0"
     },
     "devDependencies": {
-        "@types/node": "18.19.31"
+        "@types/node": "~22.14.0"
     },
     "files": ["dist"]
 }

--- a/packages/quicktype-vscode/package.json
+++ b/packages/quicktype-vscode/package.json
@@ -139,7 +139,7 @@
     },
     "devDependencies": {
         "@types/mocha": "^10.0.6",
-        "@types/node": "18.x",
+        "@types/node": "~22.14.0",
         "@types/node-persist": "^3.1.8",
         "@types/readable-stream": "^4.0.10",
         "@types/vscode": "^1.87.0",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Replaces the cross-fetch import for NodeIO with an imported module that is substituted as build time for CI, also adds a try catch

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Follow up to #2587
Fixes #2662 
Obsoletes #2673 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Previous Behaviour / Output

<!--- Provide an example of what was happening before your change -->

```ts
// We need to use cross-fetch in CI or if fetch is not available in the global scope
// We use a dynamic import to avoid punycode deprecated dependency warning on node > 20
const fetch = process.env.CI
    ? require("cross-fetch").default
    : ((global as any).fetch ?? require("cross-fetch").default);
```

## New Behaviour / Output

<!--- Provide an example of what now happens after your change -->

```ts
import { fetch } from '$fetch'; // <-- replaced with '$fetch.ci' in CI env
```

<img width="526" alt="image" src="https://github.com/user-attachments/assets/3674f9cc-0c6e-4767-bef4-25b4371c725a" />


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran, including any new unit tests --->

## Screenshots (if appropriate):
