### PR TITLE
fix: Extend OptionDefinition from command-line-args, fix positional arg bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5930,6 +5930,7 @@
                 "@types/unicode-properties": "^1.3.0",
                 "@types/urijs": "^1.19.25",
                 "@types/wordwrap": "^1.0.3",
+                "command-line-args": "^5.2.1",
                 "typescript": "~5.8.3"
             }
         },

--- a/packages/quicktype-core/package.json
+++ b/packages/quicktype-core/package.json
@@ -36,6 +36,7 @@
         "@types/unicode-properties": "^1.3.0",
         "@types/urijs": "^1.19.25",
         "@types/wordwrap": "^1.0.3",
+        "command-line-args": "^5.2.1",
         "typescript": "~5.8.3"
     },
     "overrides": {

--- a/packages/quicktype-core/src/RendererOptions/types.ts
+++ b/packages/quicktype-core/src/RendererOptions/types.ts
@@ -1,4 +1,5 @@
 import type { EnumOption, Option } from "./index";
+import type { OptionDefinition as CommandLineArgsOptionDefinition } from "command-line-args";
 
 /**
  * Primary options show up in the web UI in the "Language" settings tab,
@@ -6,16 +7,16 @@ import type { EnumOption, Option } from "./index";
  * CLI is only for cli
  */
 export type OptionKind = "primary" | "secondary" | "cli";
+export type OptionType = "string" | "boolean" | "enum";
 
-export interface OptionDefinition<Name extends string = string, T = unknown> {
+export interface OptionDefinition<Name extends string = string, T = unknown>
+    extends CommandLineArgsOptionDefinition {
     /** Option Name */
     name: Name;
-    /** Option Alias for CLI */
-    alias?: string;
     /** Option Description */
     description: string;
     /** Category of Option */
-    optionType: "string" | "boolean" | "enum";
+    optionType: OptionType;
     /** Default Value for Option */
     defaultValue?: T;
     /** Enum only, map of possible keys and values */

--- a/src/index.ts
+++ b/src/index.ts
@@ -726,7 +726,13 @@ function parseOptions(
 ): Partial<CLIOptions> {
     let opts: commandLineArgs.CommandLineOptions;
     try {
-        opts = commandLineArgs(definitions, { argv, partial });
+        opts = commandLineArgs(
+            definitions.map((def) => ({
+                ...def,
+                type: def.optionType === "boolean" ? Boolean : String,
+            })),
+            { argv, partial },
+        );
     } catch (e) {
         assert(!partial, "Partial option parsing should not have failed");
         return messageError("DriverCLIOptionParsingFailed", {

--- a/src/index.ts
+++ b/src/index.ts
@@ -455,6 +455,7 @@ function makeOptionDefinitions(
             typeLabel: "FILE|URL|DIRECTORY",
             description: "The file, url, or data directory to type.",
             kind: "cli",
+            defaultOption: true,
         },
         {
             name: "src-urls",


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

- extend `OptionDefinition` type from `command-line-args`
- fix positional args bug with defaultOption
- add map from `optionType` to `type`

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #2753 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Previous Behaviour / Output

<!--- Provide an example of what was happening before your change -->

<img width="569" alt="image" src="https://github.com/user-attachments/assets/36b22b04-9e12-41b7-9d3f-f11512f83f76" />


## New Behaviour / Output

<!--- Provide an example of what now happens after your change -->

<img width="575" alt="image" src="https://github.com/user-attachments/assets/175c0ddb-e139-466b-ba80-e1299cb51ac2" />


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran, including any new unit tests --->

Tested with manual CLI runs locally, will add CLI testing to CI soon

## Screenshots (if appropriate):
