### PR TITLE
fix(swift): scope JSON helpers to standalone output

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -719,7 +719,9 @@ export class SwiftRenderer extends ConvenienceRenderer {
     }
 
     private emitNewEncoderDecoder(): void {
-        this.emitBlock("func newJSONDecoder() -> JSONDecoder", () => {
+        const access = this._options.multiFileOutput ? "" : "fileprivate ";
+
+        this.emitBlock([access, "func newJSONDecoder() -> JSONDecoder"], () => {
             this.emitLine("let decoder = JSONDecoder()");
             if (!this._options.linux) {
                 this.emitBlock(
@@ -754,7 +756,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
             this.emitLine("return decoder");
         });
         this.ensureBlankLine();
-        this.emitBlock("func newJSONEncoder() -> JSONEncoder", () => {
+        this.emitBlock([access, "func newJSONEncoder() -> JSONEncoder"], () => {
             this.emitLine("let encoder = JSONEncoder()");
             if (!this._options.linux) {
                 this.emitBlock(

--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -289,11 +289,18 @@ export class SwiftRenderer extends ConvenienceRenderer {
                         "(json)",
                     );
                 } else {
+                    const decoder =
+                        this._options.convenienceInitializers ||
+                        this._options.alamofire
+                            ? "newJSONDecoder()"
+                            : "JSONDecoder()";
                     this.emitLine(
                         "//   let ",
                         modifySource(camelCase, name),
                         " = ",
-                        "try? newJSONDecoder().decode(",
+                        "try? ",
+                        decoder,
+                        ".decode(",
                         name,
                         ".self, from: jsonData)",
                     );

--- a/test/unit/swift-helper-visibility.test.ts
+++ b/test/unit/swift-helper-visibility.test.ts
@@ -53,4 +53,31 @@ describe("Swift JSON helper visibility", () => {
             "fileprivate func newJSONDecoder()",
         );
     });
+
+    test("uses JSONDecoder when multi-file output has no helpers", async () => {
+        const result = await quicktypeMultiFile({
+            inputData: await inputData(),
+            lang: "swift",
+            rendererOptions: {
+                "multi-file-output": true,
+                initializers: false,
+            },
+        });
+        const model = Array.from(result).find(
+            ([filename]) => filename === "TopLevel.swift",
+        );
+        const support = Array.from(result).find(
+            ([filename]) => filename === "JSONSchemaSupport.swift",
+        );
+
+        expect(model?.[1].lines.join("\n")).toContain(
+            "try? JSONDecoder().decode(TopLevel.self, from: jsonData)",
+        );
+        expect(model?.[1].lines.join("\n")).not.toContain(
+            "newJSONDecoder().decode",
+        );
+        expect(support?.[1].lines.join("\n")).not.toContain(
+            "func newJSONDecoder()",
+        );
+    });
 });

--- a/test/unit/swift-helper-visibility.test.ts
+++ b/test/unit/swift-helper-visibility.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+    quicktypeMultiFile,
+} from "../../packages/quicktype-core/src/index.js";
+
+async function inputData(): Promise<InputData> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({
+        name: "TopLevel",
+        schema: JSON.stringify({
+            type: "object",
+            properties: { value: { type: "string" } },
+            required: ["value"],
+        }),
+    });
+
+    const result = new InputData();
+    result.addInput(schemaInput);
+    return result;
+}
+
+describe("Swift JSON helper visibility", () => {
+    test("keeps helpers file-private in standalone output", async () => {
+        const result = await quicktype({
+            inputData: await inputData(),
+            lang: "swift",
+        });
+        const output = result.lines.join("\n");
+
+        expect(output).toContain("fileprivate func newJSONDecoder()");
+        expect(output).toContain("fileprivate func newJSONEncoder()");
+    });
+
+    test("keeps helpers visible to multi-file model output", async () => {
+        const result = await quicktypeMultiFile({
+            inputData: await inputData(),
+            lang: "swift",
+            rendererOptions: { "multi-file-output": true },
+        });
+        const support = Array.from(result).find(
+            ([filename]) => filename === "JSONSchemaSupport.swift",
+        );
+
+        expect(support).toBeDefined();
+        expect(support?.[1].lines.join("\n")).toContain(
+            "func newJSONDecoder()",
+        );
+        expect(support?.[1].lines.join("\n")).not.toContain(
+            "fileprivate func newJSONDecoder()",
+        );
+    });
+});


### PR DESCRIPTION
Closes #3093

Swift standalone output can contain duplicate module-level `newJSONDecoder` and `newJSONEncoder` declarations when several generated files are compiled together. The original single-file fix used `fileprivate`, but the helpers were later moved to `JSONSchemaSupport.swift` for multi-file output and changed back to internal visibility.

This makes the visibility conditional:
- standalone output: `fileprivate`
- `--multi-file-output`: internal visibility in `JSONSchemaSupport.swift`

Added regression coverage for both rendering modes. Verified the unit tests, build, and Swift type-checking for generated standalone and multi-file output.