### PR TITLE
feat(typescript-zod): preserve named object unions

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/language.ts
@@ -51,6 +51,10 @@ export class TypeScriptZodTargetLanguage extends TargetLanguage<
         return true;
     }
 
+    public get supportsUnionsWithMultipleObjectTypes(): boolean {
+        return true;
+    }
+
     protected makeRenderer<Lang extends LanguageName = "typescript-zod">(
         renderContext: RenderContext,
         untypedOptionValues: RendererOptions<Lang>,

--- a/test/unit/named-class-union.test.ts
+++ b/test/unit/named-class-union.test.ts
@@ -67,7 +67,7 @@ function schemaWithReusedRef(): object {
 }
 
 async function generate(
-    lang: "python" | "typescript",
+    lang: "python" | "typescript" | "typescript-zod",
     operation: "oneOf" | "anyOf" = "oneOf",
     schema: object = schemaWithUnion(operation),
 ): Promise<string> {
@@ -112,6 +112,14 @@ describe("named class unions (issue #1646)", () => {
         expect(output).toContain("mixed: Optional[MixedClass] = None");
         expect(output).toContain("foo: Optional[str] = None");
         expect(output).toContain("baz: Optional[str] = None");
+    });
+
+    test("TypeScript Zod preserves the named alternatives", async () => {
+        const output = await generate("typescript-zod");
+
+        expect(output).toContain("export const FooSchema = z.object({");
+        expect(output).toContain("export const BarSchema = z.object({");
+        expect(output).toContain('"op": z.union([FooSchema, BarSchema])');
     });
 
     test("languages that do not opt in keep the existing behavior", async () => {


### PR DESCRIPTION
## Description

Enables `supportsUnionsWithMultipleObjectTypes` for the TypeScript Zod target and extends the named-object-union regression test to cover Zod output.

## Related Issue

Depends on #3061, which fixes #1646. This is intentionally a stacked draft PR.

## Motivation and Context

#3061 adds guarded support for explicitly named, disjoint object alternatives. TypeScript Zod can represent those alternatives directly with `z.union`, so it can safely opt in without renderer changes.

## Previous Behaviour / Output

Zod received the merged optional-properties object produced by the core union-flattening pass. Distinct alternatives such as `Foo` and `Bar` were not retained as separate schemas.

## New Behaviour / Output

The generated Zod output preserves both schemas and references them from the containing schema:

```ts
export const FooSchema = z.object({ "foo": z.string() });
export const BarSchema = z.object({ "bar": z.string() });
export const ContainerSchema = z.object({
    "op": z.union([FooSchema, BarSchema]),
});
```

The Zod fixture also rejects an invalid union member.

## How Has This Been Tested?

Tested locally with Node.js 24.18.0:

- `npm run build`
- `npm run test:unit`
- `QUICKTEST=true FIXTURE=schema-typescript-zod npm run test:fixtures -- test/inputs/schema/named-class-union.schema`

The focused fixture round-trips both valid alternatives and verifies that the invalid sample fails.

## Screenshots (if appropriate):

Not applicable.