### PR TITLE
feat(typescript-zod): validate string constraints

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -1,6 +1,10 @@
 import { arrayIntercalate } from "collection-utils";
 
-import { minMaxItemsForType } from "../../attributes/Constraints.js";
+import {
+    minMaxItemsForType,
+    minMaxLengthForType,
+    patternForType,
+} from "../../attributes/Constraints.js";
 import { ConvenienceRenderer } from "../../ConvenienceRenderer.js";
 import { type Name, type Namer, funPrefixNamer } from "../../Naming.js";
 import type { RenderContext } from "../../Renderer.js";
@@ -99,6 +103,28 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
         return p.isOptional ? [typeMap, ".optional()"] : typeMap;
     }
 
+    protected renderString(type: Type, base: Sourcelike): Sourcelike {
+        const constraints: Sourcelike[] = [base];
+        const [minimumLength, maximumLength] = minMaxLengthForType(type) ?? [];
+        const pattern = patternForType(type);
+
+        if (minimumLength !== undefined) {
+            constraints.push(".min(", minimumLength.toString(10), ")");
+        }
+        if (maximumLength !== undefined) {
+            constraints.push(".max(", maximumLength.toString(10), ")");
+        }
+        if (pattern !== undefined) {
+            constraints.push(
+                ".regex(new RegExp(",
+                JSON.stringify(pattern),
+                "))",
+            );
+        }
+
+        return constraints;
+    }
+
     protected typeMapTypeFor(t: Type, required = true): Sourcelike {
         if (["class", "object", "enum"].includes(t.kind)) {
             return [this.nameForNamedType(t), "Schema"];
@@ -111,7 +137,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
             (_boolType) => "z.boolean()",
             (_integerType) => "z.number()",
             (_doubleType) => "z.number()",
-            (_stringType) => "z.string()",
+            (stringType) => this.renderString(stringType, "z.string()"),
             (arrayType) => {
                 const [minItems, maxItems] =
                     minMaxItemsForType(arrayType) ?? [];

--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -104,28 +104,6 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
         return p.isOptional ? [typeMap, ".optional()"] : typeMap;
     }
 
-    protected renderString(type: Type, base: Sourcelike): Sourcelike {
-        const constraints: Sourcelike[] = [base];
-        const [minimumLength, maximumLength] = minMaxLengthForType(type) ?? [];
-        const pattern = patternForType(type);
-
-        if (minimumLength !== undefined) {
-            constraints.push(".min(", minimumLength.toString(10), ")");
-        }
-        if (maximumLength !== undefined) {
-            constraints.push(".max(", maximumLength.toString(10), ")");
-        }
-        if (pattern !== undefined) {
-            constraints.push(
-                ".regex(new RegExp(",
-                JSON.stringify(pattern),
-                "))",
-            );
-        }
-
-        return constraints;
-    }
-
     protected typeMapTypeFor(t: Type, required = true): Sourcelike {
         if (["class", "object", "enum"].includes(t.kind)) {
             return [this.nameForNamedType(t), "Schema"];
@@ -164,7 +142,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
             (_boolType) => "z.boolean()",
             (integerType) => numberType(integerType, true),
             (doubleType) => numberType(doubleType, false),
-            (stringType) => this.renderString(stringType, "z.string()"),
+            (string) => stringType(string),
             (arrayType) => {
                 const [minItems, maxItems] =
                     minMaxItemsForType(arrayType) ?? [];

--- a/test/inputs/schema/minmaxlength.1.fail.minmaxlength.json
+++ b/test/inputs/schema/minmaxlength.1.fail.minmaxlength.json
@@ -2,6 +2,7 @@
   "minlength": "aa",
   "maxlength": "bbb",
   "minmaxlength": "cccc",
+  "emptyOnly": "",
   "union": "dddddd",
   "inUnion": "cccc",
   "minMaxUnion": "eeeee",

--- a/test/inputs/schema/minmaxlength.2.fail.minmaxlength.json
+++ b/test/inputs/schema/minmaxlength.2.fail.minmaxlength.json
@@ -3,7 +3,7 @@
   "maxlength": "bbb",
   "minmaxlength": "cccc",
   "emptyOnly": "",
-  "union": "dddddd",
+  "union": "dd",
   "inUnion": "cccc",
   "minMaxUnion": "eeeee",
   "intersection": "ffff",

--- a/test/inputs/schema/minmaxlength.3.fail.minmaxlength.json
+++ b/test/inputs/schema/minmaxlength.3.fail.minmaxlength.json
@@ -6,6 +6,6 @@
   "union": "dddddd",
   "inUnion": "cccc",
   "minMaxUnion": "eeeee",
-  "intersection": "ffff",
+  "intersection": "fff",
   "minMaxIntersection": "gggg"
 }

--- a/test/inputs/schema/minmaxlength.4.fail.minmaxlength.json
+++ b/test/inputs/schema/minmaxlength.4.fail.minmaxlength.json
@@ -7,5 +7,5 @@
   "inUnion": "cccc",
   "minMaxUnion": "eeeee",
   "intersection": "ffff",
-  "minMaxIntersection": "gggg"
+  "minMaxIntersection": "gggggg"
 }

--- a/test/inputs/schema/minmaxlength.5.fail.minmaxlength.json
+++ b/test/inputs/schema/minmaxlength.5.fail.minmaxlength.json
@@ -2,7 +2,7 @@
   "minlength": "aaaa",
   "maxlength": "bbb",
   "minmaxlength": "cccc",
-  "emptyOnly": "",
+  "emptyOnly": "x",
   "union": "dddddd",
   "inUnion": "cccc",
   "minMaxUnion": "eeeee",

--- a/test/inputs/schema/minmaxlength.6.fail.pattern.json
+++ b/test/inputs/schema/minmaxlength.6.fail.pattern.json
@@ -1,7 +1,7 @@
 {
   "minlength": "aaaa",
   "maxlength": "bbb",
-  "minmaxlength": "cccc",
+  "minmaxlength": "1234",
   "emptyOnly": "",
   "union": "dddddd",
   "inUnion": "cccc",

--- a/test/inputs/schema/minmaxlength.schema
+++ b/test/inputs/schema/minmaxlength.schema
@@ -12,7 +12,12 @@
     "minmaxlength": {
       "type": "string",
       "minLength": 3,
-      "maxLength": 5
+      "maxLength": 5,
+      "pattern": "^[a-z]+$"
+    },
+    "emptyOnly": {
+      "type": "string",
+      "maxLength": 0
     },
     "union": {
       "oneOf": [
@@ -71,6 +76,7 @@
     "minlength",
     "maxlength",
     "minmaxlength",
+    "emptyOnly",
     "union",
     "inUnion",
     "minMaxUnion",

--- a/test/inputs/schema/optional-constraints.1.json
+++ b/test/inputs/schema/optional-constraints.1.json
@@ -2,6 +2,6 @@
   "reqZeroMin": 0,
   "optInt": 0,
   "optDouble": 0.5,
-  "optString": "abc",
+  "optString": "abcdefghij",
   "optPattern": "abc"
 }

--- a/test/inputs/schema/optional-constraints.3.fail.minmaxlength.json
+++ b/test/inputs/schema/optional-constraints.3.fail.minmaxlength.json
@@ -1,0 +1,4 @@
+{
+  "reqZeroMin": 0,
+  "optString": "abcdefghijk"
+}

--- a/test/inputs/schema/pattern.2.fail.pattern.json
+++ b/test/inputs/schema/pattern.2.fail.pattern.json
@@ -1,6 +1,6 @@
 {
-  "pattern1": "qqq",
+  "pattern1": "aa",
   "pattern2": "ba",
   "escaped": "123.abc",
-  "union": "ccc"
+  "union": "qqq"
 }

--- a/test/inputs/schema/pattern.3.fail.pattern.json
+++ b/test/inputs/schema/pattern.3.fail.pattern.json
@@ -1,6 +1,6 @@
 {
   "pattern1": "aa",
   "pattern2": "ba",
-  "escaped": "123.abc",
+  "escaped": "abc.def",
   "union": "ccc"
 }

--- a/test/inputs/schema/pattern.schema
+++ b/test/inputs/schema/pattern.schema
@@ -9,6 +9,10 @@
       "type": "string",
       "pattern": "b[.]*"
     },
+    "escaped": {
+      "type": "string",
+      "pattern": "^\\d+\\.[a-z]+$"
+    },
     "union": {
       "oneOf": [
         {
@@ -21,5 +25,5 @@
       ]
     }
   },
-  "required": ["pattern1", "pattern2", "union"]
+  "required": ["pattern1", "pattern2", "escaped", "union"]
 }

--- a/test/inputs/schema/pattern.schema
+++ b/test/inputs/schema/pattern.schema
@@ -11,7 +11,7 @@
     },
     "escaped": {
       "type": "string",
-      "pattern": "^\\d+\\.[a-z]+$"
+      "pattern": "^[0-9]+\\.[a-z]+$"
     },
     "union": {
       "oneOf": [

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -2037,7 +2037,15 @@ export const TypeScriptZodLanguage: Language = {
         "e8b04.json",
     ],
     allowMissingNull: false,
-    features: ["enum", "union", "no-defaults", "date-time", "minmaxitems"],
+    features: [
+        "enum",
+        "union",
+        "no-defaults",
+        "date-time",
+        "minmaxitems",
+        "minmaxlength",
+        "pattern",
+    ],
     output: "TopLevel.ts",
     topLevel: "TopLevel",
     skipJSON: [


### PR DESCRIPTION
## Description

Generate Zod string schemas with JSON Schema `minLength`, `maxLength`, and `pattern` constraints. Enable the corresponding TypeScript Zod fixture features and expand constraint coverage.

## Related Issue

N/A

## Motivation and Context

TypeScript Zod output previously discarded string length and pattern constraints, allowing invalid input through generated schemas.

## Previous Behaviour / Output

```ts
z.string()
```

## New Behaviour / Output

```ts
z.string().min(3).max(5).regex(new RegExp("^[a-z]+$"))
```

## How Has This Been Tested?

Ran the TypeScript Zod schema fixture suite for string constraints, including valid inputs and feature-specific expected failures for combined constraints, unions/intersections, optional maximum length, escaped patterns, and `maxLength: 0`:

```bash
QUICKTEST=true FIXTURE=schema-typescript-zod npm run test:fixtures -- \
  test/inputs/schema/minmaxlength.schema \
  test/inputs/schema/optional-constraints.schema \
  test/inputs/schema/pattern.schema
```

## Screenshots (if appropriate):

N/A