### PR TITLE
feat(typescript-zod): validate integer schemas

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -109,7 +109,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
             (_anyType) => "z.any()",
             (_nullType) => "z.null()",
             (_boolType) => "z.boolean()",
-            (_integerType) => "z.number()",
+            (_integerType) => "z.number().int()",
             (_doubleType) => "z.number()",
             (_stringType) => "z.string()",
             (arrayType) => {

--- a/test/inputs/schema/integer-type.2.fail.integer.json
+++ b/test/inputs/schema/integer-type.2.fail.integer.json
@@ -1,0 +1,11 @@
+{
+  "small_positive": 50,
+  "small_negative": -50,
+  "i32_range": 2147483647,
+  "above_i32_max": 2147483648,
+  "below_i32_min": -2147483649,
+  "only_minimum": 3000000000,
+  "only_maximum": -3000000000,
+  "unbounded": 1.5,
+  "large_bounds": -9007199254740991
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -73,6 +73,7 @@ export type LanguageFeature =
     | "no-defaults"
     | "strict-optional"
     | "date-time"
+    | "integer"
     | "integer-string"
     | "bool-string"
     | "uuid"
@@ -2037,7 +2038,14 @@ export const TypeScriptZodLanguage: Language = {
         "e8b04.json",
     ],
     allowMissingNull: false,
-    features: ["enum", "union", "no-defaults", "date-time", "minmaxitems"],
+    features: [
+        "enum",
+        "union",
+        "no-defaults",
+        "date-time",
+        "integer",
+        "minmaxitems",
+    ],
     output: "TopLevel.ts",
     topLevel: "TopLevel",
     skipJSON: [


### PR DESCRIPTION
## Description

Generate integer schemas as `z.number().int()` so TypeScript Zod rejects decimal values for JSON Schema `integer` types.

## Related Issue

N/A

## Motivation and Context

TypeScript Zod previously rendered JSON Schema integers as unrestricted `z.number()` values, allowing decimals that violate the input schema.

## Previous Behaviour / Output

```ts
z.number()
```

## New Behaviour / Output

```ts
z.number().int()
```

## How Has This Been Tested?

Compiled both CommonJS and ESM core outputs, then ran the TypeScript Zod integer schema fixture with a decimal expected-failure case:

```bash
QUICKTEST=true FIXTURE=schema-typescript-zod npm run test:fixtures -- \
  test/inputs/schema/integer-type.schema
```

## Screenshots (if appropriate):

N/A