### PR TITLE
feat(typescript-zod): add prefer-unknown

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -106,7 +106,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
 
         const match = matchType<Sourcelike>(
             t,
-            (_anyType) => "z.any()",
+            (_anyType) => "z.unknown()",
             (_nullType) => "z.null()",
             (_boolType) => "z.boolean()",
             (_integerType) => "z.number()",

--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -33,6 +33,12 @@ import { legalizeName } from "../JavaScript/utils.js";
 
 import type { typeScriptZodOptions } from "./language.js";
 
+type TypeScriptZodRendererOptions = Omit<
+    OptionValues<typeof typeScriptZodOptions>,
+    "preferUnknown"
+> &
+    Partial<Pick<OptionValues<typeof typeScriptZodOptions>, "preferUnknown">>;
+
 export class TypeScriptZodRenderer extends ConvenienceRenderer {
     /** TypeRefs of object types that participate in a reference cycle.
      * These must be emitted as z.lazy() schemas with an explicit type
@@ -42,7 +48,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
     public constructor(
         targetLanguage: TargetLanguage,
         renderContext: RenderContext,
-        protected readonly _options: OptionValues<typeof typeScriptZodOptions>,
+        protected readonly _options: TypeScriptZodRendererOptions,
     ) {
         super(targetLanguage, renderContext);
     }
@@ -106,7 +112,10 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
 
         const match = matchType<Sourcelike>(
             t,
-            (_anyType) => "z.unknown()",
+            (_anyType) =>
+                this._options.preferUnknown !== false
+                    ? "z.unknown()"
+                    : "z.any()",
             (_nullType) => "z.null()",
             (_boolType) => "z.boolean()",
             (_integerType) => "z.number()",

--- a/packages/quicktype-core/src/language/TypeScriptZod/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/language.ts
@@ -16,6 +16,11 @@ import { TypeScriptZodRenderer } from "./TypeScriptZodRenderer.js";
 
 export const typeScriptZodOptions = {
     justSchema: new BooleanOption("just-schema", "Schema only", false),
+    preferUnknown: new BooleanOption(
+        "prefer-unknown",
+        "Use unknown instead of any",
+        true,
+    ),
 };
 
 export const typeScriptZodLanguageConfig = {
@@ -35,8 +40,8 @@ export class TypeScriptZodTargetLanguage extends TargetLanguage<
         super(typeScriptZodLanguageConfig);
     }
 
-    public getOptions(): Record<string, never> {
-        return {};
+    public getOptions(): typeof typeScriptZodOptions {
+        return typeScriptZodOptions;
     }
 
     public get stringTypeMapping(): StringTypeMapping {

--- a/packages/quicktype-core/src/language/TypeScriptZod/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/language.ts
@@ -19,7 +19,7 @@ export const typeScriptZodOptions = {
     preferUnknown: new BooleanOption(
         "prefer-unknown",
         "Use unknown instead of any",
-        true,
+        false,
     ),
 };
 

--- a/test/unit/typescript-zod-unknown.test.ts
+++ b/test/unit/typescript-zod-unknown.test.ts
@@ -1,0 +1,24 @@
+import { InputData, JSONSchemaInput, quicktype } from "quicktype-core";
+import { expect, test } from "vitest";
+
+test("TypeScript Zod emits unknown for unconstrained JSON Schema values", async () => {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({
+        name: "TopLevel",
+        schema: JSON.stringify({
+            type: "object",
+            properties: {
+                value: {},
+            },
+            required: ["value"],
+        }),
+    });
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+
+    const result = await quicktype({ inputData, lang: "typescript-zod" });
+    const output = result.lines.join("\n");
+
+    expect(output).toContain("z.unknown()");
+    expect(output).not.toContain("z.any()");
+});

--- a/test/unit/typescript-zod-unknown.test.ts
+++ b/test/unit/typescript-zod-unknown.test.ts
@@ -29,16 +29,16 @@ async function render(rendererOptions: RendererOptions = {}): Promise<string> {
     return result.lines.join("\n");
 }
 
-test("TypeScript Zod emits unknown for unconstrained JSON Schema values by default", async () => {
+test("TypeScript Zod emits any for unconstrained JSON Schema values by default", async () => {
     const output = await render();
-
-    expect(output).toContain("z.unknown()");
-    expect(output).not.toContain("z.any()");
-});
-
-test("TypeScript Zod emits any when prefer-unknown is disabled", async () => {
-    const output = await render({ "prefer-unknown": false });
 
     expect(output).toContain("z.any()");
     expect(output).not.toContain("z.unknown()");
+});
+
+test("TypeScript Zod emits unknown when prefer-unknown is enabled", async () => {
+    const output = await render({ "prefer-unknown": true });
+
+    expect(output).toContain("z.unknown()");
+    expect(output).not.toContain("z.any()");
 });

--- a/test/unit/typescript-zod-unknown.test.ts
+++ b/test/unit/typescript-zod-unknown.test.ts
@@ -1,7 +1,12 @@
-import { InputData, JSONSchemaInput, quicktype } from "quicktype-core";
+import {
+    InputData,
+    JSONSchemaInput,
+    type RendererOptions,
+    quicktype,
+} from "quicktype-core";
 import { expect, test } from "vitest";
 
-test("TypeScript Zod emits unknown for unconstrained JSON Schema values", async () => {
+async function render(rendererOptions: RendererOptions = {}): Promise<string> {
     const schemaInput = new JSONSchemaInput(undefined);
     await schemaInput.addSource({
         name: "TopLevel",
@@ -16,9 +21,24 @@ test("TypeScript Zod emits unknown for unconstrained JSON Schema values", async 
     const inputData = new InputData();
     inputData.addInput(schemaInput);
 
-    const result = await quicktype({ inputData, lang: "typescript-zod" });
-    const output = result.lines.join("\n");
+    const result = await quicktype({
+        inputData,
+        lang: "typescript-zod",
+        rendererOptions,
+    });
+    return result.lines.join("\n");
+}
+
+test("TypeScript Zod emits unknown for unconstrained JSON Schema values by default", async () => {
+    const output = await render();
 
     expect(output).toContain("z.unknown()");
     expect(output).not.toContain("z.any()");
+});
+
+test("TypeScript Zod emits any when prefer-unknown is disabled", async () => {
+    const output = await render({ "prefer-unknown": false });
+
+    expect(output).toContain("z.any()");
+    expect(output).not.toContain("z.unknown()");
 });


### PR DESCRIPTION
## Description

Add the TypeScript-compatible `prefer-unknown` option to TypeScript Zod. It defaults to `false`, preserving `z.any()` output for unconstrained values; enabling it generates `z.unknown()`.

## Related Issue

N/A

## Motivation and Context

`z.unknown()` preserves safer inferred TypeScript types while accepting the same runtime values as `z.any()`. Providing it as an opt-in matches TypeScript’s configurability without breaking existing generated output.

## Previous Behaviour / Output

```ts
z.any()
```

## New Behaviour / Output

```ts
// default
z.any()

// --prefer-unknown
z.unknown()
```

## How Has This Been Tested?

Compiled both CommonJS and ESM core outputs, then tested the default and enabled option states:

```bash
npm run test:unit -- test/unit/typescript-zod-unknown.test.ts
```

## Screenshots (if appropriate):

N/A