### PR TITLE
fix(ruby): escape keywords in union members

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -50,7 +50,7 @@ jobs:
                     - dart,schema-dart
                     # - swift,schema-swift # pgp issue
                     - javascript-prop-types
-                    - ruby
+                    - ruby,schema-ruby-syntax
                     - php,schema-php
                     - scala3,schema-scala3
                     - scala3-upickle,schema-scala3-upickle

--- a/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
+++ b/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
@@ -75,6 +75,16 @@ export class RubyRenderer extends ConvenienceRenderer {
         };
     }
 
+    protected forbiddenForUnionMembers(
+        _u: UnionType,
+        _unionNamed: Name,
+    ): ForbiddenWordsInfo {
+        return {
+            names: forbiddenForObjectProperties,
+            includeGlobalForbidden: true,
+        };
+    }
+
     protected makeNamedTypeNamer(): Namer {
         return new Namer("types", (n) => simpleNameStyle(n, true), []);
     }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -929,6 +929,31 @@ class JSONSchemaFixture extends LanguageFixture {
     }
 }
 
+// Ruby's full schema fixture has known dry-struct runtime failures for unions.
+// Keep keyword-unions covered in CI by checking that its output parses.
+class RubySchemaSyntaxFixture extends JSONSchemaFixture {
+    constructor() {
+        super(
+            {
+                ...languages.RubyLanguage,
+                setupCommand: undefined,
+                compileCommand: "ruby -c TopLevel.rb",
+                runCommand: undefined,
+            },
+            "schema-ruby-syntax",
+        );
+    }
+
+    getSamples(sources: string[]): { priority: Sample[]; others: Sample[] } {
+        return samplesFromSources(
+            sources,
+            ["test/inputs/schema/keyword-unions.schema"],
+            [],
+            "schema",
+        );
+    }
+}
+
 // `leadingComments` is a quicktype-core API option, so the CLI fixture path
 // cannot exercise it.
 class LeadingCommentsGoFixture extends JSONSchemaFixture {
@@ -1811,6 +1836,7 @@ export const allFixtures: Fixture[] = [
     new JSONSchemaFixture(languages.CPlusPlusLanguage),
     new JSONSchemaFixture(languages.RustLanguage),
     new JSONSchemaFixture(languages.RubyLanguage),
+    new RubySchemaSyntaxFixture(),
     new JSONSchemaFixture(languages.PythonLanguage),
     new JSONSchemaFixture(languages.PHPLanguage),
     new JSONSchemaFixture(languages.ElmLanguage),


### PR DESCRIPTION
Closes #3124.

## Summary

- apply Ruby reserved-property and global forbidden names to union members
- add a syntax-only Ruby schema fixture for `keyword-unions.schema`
- run that fixture alongside the existing Ruby fixture in CI

The syntax-only fixture avoids unrelated dry-struct runtime failures in the full Ruby schema suite while ensuring generated keyword-union output is parsed by Ruby.

## Testing

- `npm run build`
- `npm run lint`
- `npm run test:unit`
- `FIXTURE=schema-ruby-syntax npm run test:fixtures -- test/inputs/schema/keyword-unions.schema`
- `QUICKTEST=true FIXTURE=ruby npm run test:fixtures -- test/inputs/json/samples/pokedex.json`