### PR TITLE
fix(cplusplus): reject non-object class values

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1456,6 +1456,9 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             ],
             false,
             () => {
+                this.emitLine(
+                    'if (!j.is_object()) throw std::runtime_error("Expected object");',
+                );
                 if (c.getProperties().size === 0) {
                     this.emitLine("(void)j;");
                     this.emitLine("(void)x;");

--- a/test/fixtures/cplusplus/main.cpp
+++ b/test/fixtures/cplusplus/main.cpp
@@ -18,10 +18,13 @@ int main(int argc, const char * argv[]) {
     std::string str((std::istreambuf_iterator<char>(t)),
                     std::istreambuf_iterator<char>());
 
-    TopLevel tl = json::parse(str);
-    json j2 = tl;
-
-    std::cout << j2 << std::endl;
+    try {
+        TopLevel tl = json::parse(str);
+        json j2 = tl;
+        std::cout << j2 << std::endl;
+    } catch (const std::exception&) {
+        return 1;
+    }
 
     return 0;
 }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -831,8 +831,6 @@ export const CPlusPlusLanguage: Language = {
         "integer-before-number.schema", // Python-specific union-order regression.
         // uses too much memory
         "keyword-unions.schema",
-        // The generated deserializer accepts non-object values when all class properties are optional.
-        "nested-intersection-union.schema",
     ],
     rendererOptions: {},
     quickTestRendererOptions: [


### PR DESCRIPTION
## Description

Check that JSON values are objects before deserializing generated C++ classes.

## Motivation and Context

Classes containing only optional properties silently accepted arrays and scalars, producing an empty object instead of rejecting invalid schema input.

## Previous Behaviour / Output

An array could deserialize as an all-empty generated class.

## New Behaviour / Output

Generated class deserializers throw on non-object JSON. The fixture driver reports exceptions as a normal nonzero exit, enabling the nested intersection/union fixture.

## How Has This Been Tested?

- `npm run build`
- `npm run lint`
- `FIXTURE=schema-cplusplus npm run test:fixtures -- test/inputs/schema/nested-intersection-union.schema`