### PR TITLE
fix(cjson): allocate scalar array elements

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -4863,18 +4863,29 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                             cJSON.items?.cType,
                                                             " *));",
                                                         );
-                                                    } else {
+                                                    } else if (
+                                                        cJSON.items
+                                                            ?.deleteType ===
+                                                        "cJSON_free"
+                                                    ) {
                                                         this.emitLine(
-                                                            // @ts-expect-error awaiting refactor
-                                                            cJSON.items?.cType,
+                                                            cJSON.items.cType,
                                                             " * item = cJSON_malloc(sizeof(*item));",
                                                         );
                                                         this.emitLine(
                                                             "if (NULL != item) { *item = ",
-                                                            cJSON.items
-                                                                ?.getValue ??
-                                                                "",
+                                                            cJSON.items.getValue,
                                                             "(e); list_add_tail(x->value, item, sizeof(*item)); }",
+                                                        );
+                                                    } else {
+                                                        this.emitLine(
+                                                            "list_add_tail(x->value, ",
+                                                            // @ts-expect-error awaiting refactor
+                                                            cJSON.items
+                                                                ?.getValue,
+                                                            "(e), sizeof(",
+                                                            cJSON.items?.cType,
+                                                            " *));",
                                                         );
                                                     }
                                                 };

--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -4865,13 +4865,16 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                         );
                                                     } else {
                                                         this.emitLine(
-                                                            "list_add_tail(x->value, ",
                                                             // @ts-expect-error awaiting refactor
-                                                            cJSON.items
-                                                                ?.getValue,
-                                                            "(e), sizeof(",
                                                             cJSON.items?.cType,
-                                                            " *));",
+                                                            " * item = cJSON_malloc(sizeof(*item));",
+                                                        );
+                                                        this.emitLine(
+                                                            "if (NULL != item) { *item = ",
+                                                            cJSON.items
+                                                                ?.getValue ??
+                                                                "",
+                                                            "(e); list_add_tail(x->value, item, sizeof(*item)); }",
                                                         );
                                                     }
                                                 };

--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -4874,7 +4874,8 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                         );
                                                         this.emitLine(
                                                             "if (NULL != item) { *item = ",
-                                                            cJSON.items.getValue,
+                                                            cJSON.items
+                                                                .getValue,
                                                             "(e); list_add_tail(x->value, item, sizeof(*item)); }",
                                                         );
                                                     } else {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -645,8 +645,6 @@ export const CJSONLanguage: Language = {
         "combinations2.json",
         /* Array in Array in Union is not supported (for the current implementation, can be added later, need recursivity) */
         "combinations4.json",
-        /* Top-level arrays of scalars store scalar values as pointers incorrectly. */
-        "issue2680-scalar-array.json",
     ],
     skipMiscJSON: false,
     skipSchema: [


### PR DESCRIPTION
## Description

Allocate scalar top-level array values before storing their pointers in the generated C list, while preserving pointer-returning object and union elements.

## Motivation and Context

The list was given scalar values as though they were pointers. The first fix applied scalar allocation to every remaining element type, which caused struct-valued arrays to fail compilation.

## New Behaviour / Output

Scalar and enum values are allocated before storage. Objects and unions retain their existing pointers. The scalar-array fixture is enabled and existing union-schema arrays still compile and round-trip.

## How Has This Been Tested?

- npm run build
- npm run lint
- Focused scalar-array and union-schema generated binaries compiled and round-tripped
- cjson,schema-cjson GitHub Actions job passes