### PR TITLE
fix(typescript-zod): handle constructor properties

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -230,7 +230,16 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
         }
 
         this.ensureBlankLine();
-        this.emitLine("\nexport const ", name, "Schema = ", "z.object({");
+        const hasOptionalConstructor =
+            t.getProperties().get("constructor")?.isOptional === true;
+        this.emitLine(
+            "\nexport const ",
+            name,
+            "Schema = ",
+            hasOptionalConstructor
+                ? 'z.preprocess(value => typeof value === "object" && value !== null && !Array.isArray(value) ? Object.assign(Object.create(null), value) : value, z.object({'
+                : "z.object({",
+        );
         this.indent(() => {
             this.forEachClassProperty(t, "none", (_, jsonName, property) => {
                 this.emitLine(
@@ -241,7 +250,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
                 );
             });
         });
-        this.emitLine("});");
+        this.emitLine(hasOptionalConstructor ? "}));" : "});");
         if (!this._options.justSchema) {
             this.emitLine(
                 "export type ",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -2097,15 +2097,11 @@ export const TypeScriptZodLanguage: Language = {
         ...skipsUntypedUnions,
         "direct-union.schema",
         ...skipsEnumValueValidation,
-        // zod validates the inherited Object.prototype.constructor when an
-        // optional "constructor" property is absent
-        "constructor.schema",
         // z.coerce.date() serializes back as ISO UTC, not the input string
         "date-time.schema",
         ...skipsMapValueValidation,
         "intersection.schema",
         "multi-type-enum.schema",
-        "keyword-unions.schema",
         "optional-any.schema",
         "recursive-union-flattening.schema",
         "required.schema",


### PR DESCRIPTION
## Description

Preprocess objects with an optional `constructor` property onto a null-prototype object before Zod validation.

## Motivation and Context

Zod 3 reads the inherited `Object.prototype.constructor` value when the optional property is absent, then rejects an otherwise valid object.

## Previous Behaviour / Output

Parsing `{}` failed because the inherited constructor function was validated against the generated union.

## New Behaviour / Output

Only own properties participate in validation, while arrays and non-objects retain their existing behavior. This enables the constructor and keyword-unions schema fixtures.

## How Has This Been Tested?

- `npm run build`
- `npm run lint`
- `FIXTURE=schema-typescript-zod npm run test:fixtures -- test/inputs/schema/constructor.schema test/inputs/schema/keyword-unions.schema`