### PR TITLE
fix(csharp): qualify System.Text.Json serializer

### DIFF
--- a/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
@@ -370,7 +370,7 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
                 this.emitExpressionMember(
                     ["public static ", csType, " FromJson(string json)"],
                     [
-                        "JsonSerializer.Deserialize<",
+                        "global::System.Text.Json.JsonSerializer.Deserialize<",
                         csType,
                         ">(json, ",
                         this._options.namespace,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -212,7 +212,6 @@ export const CSharpLanguageSystemTextJson: Language = {
         "top-level-enum.schema", // The code we generate for top-level enums is incompatible with the driver
         // The following skips are pre-existing System.Text.Json renderer issues,
         // found when first enabling the schema fixture for this language:
-        "keyword-unions.schema", // a property named "JsonSerializer" collides with System.Text.Json.JsonSerializer: CS0120
         // minmaxlength.schema, optional-constraints.schema, and
         // optional-const-ref.schema used to be skipped here because the
         // generated converters triggered CS8602 warnings, which "dotnet


### PR DESCRIPTION
## Description

Fully qualify the System.Text.Json `JsonSerializer` reference in generated `FromJson` helpers.

## Motivation and Context

A generated property named `JsonSerializer` shadows the imported type and causes CS0120.

## Previous Behaviour / Output

Keyword-heavy schemas failed to compile when a property collided with `JsonSerializer`.

## New Behaviour / Output

The helper emits `global::System.Text.Json.JsonSerializer.Deserialize`, enabling the keyword-unions schema fixture.

## How Has This Been Tested?

- `npm run build`
- `npm run lint`
- Focused System.Text.Json fixture generated and compiled successfully