### PR TITLE
fix(kotlin): support kotlinx top-level arrays

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinXRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinXRenderer.ts
@@ -94,7 +94,7 @@ export class KotlinXRenderer extends KotlinRenderer {
 
     protected emitTopLevelArray(t: ArrayType, name: Name): void {
         const elementType = this.kotlinType(t.items);
-        this.emitLine(["typealias ", name, " = JsonArray<", elementType, ">"]);
+        this.emitLine(["typealias ", name, " = List<", elementType, ">"]);
     }
 
     protected emitUsageHeader(): void {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1608,15 +1608,8 @@ export const KotlinXLanguage: Language = {
     output: "TopLevel.kt",
     topLevel: "TopLevel",
     skipJSON: [
-        // Top-level arrays render as `typealias TopLevel = JsonArray<T>`,
-        // which doesn't compile — kotlinx's JsonArray takes no type
-        // arguments (documented TODO in KotlinXRenderer.ts).
-        "kotlin-enum-class-case-collision.json",
         "bug863.json",
-        "github-events.json",
         "optional-union.json",
-        "issue2680-object-array.json",
-        "issue2680-scalar-array.json",
         "00c36.json",
         "010b1.json",
         "050b0.json",
@@ -1715,12 +1708,7 @@ export const KotlinXLanguage: Language = {
         // Additionally exceeds the JVM's 255-parameter limit when the
         // serialization plugin generates the synthesized constructors.
         "keyword-unions.schema",
-        // Top-level array: `typealias TopLevel = JsonArray<T>` doesn't
-        // compile (documented TODO in KotlinXRenderer.ts).
         "union.schema",
-        "top-level-array.schema",
-        "top-level-primitive-array.schema",
-        "issue2680-top-level-array.schema",
     ],
     skipMiscJSON: false,
     rendererOptions: { framework: "kotlinx" },


### PR DESCRIPTION
## Description

Render KotlinX top-level arrays as `List<T>` instead of the invalid generic `JsonArray<T>`.

## Motivation and Context

`kotlinx.serialization.json.JsonArray` is not generic, so the previous generated alias did not compile. `List<T>` preserves the inferred element type and has built-in serializer support.

## Previous Behaviour / Output

Generated `typealias TopLevel = JsonArray<Element>`, which fails to compile.

## New Behaviour / Output

Generates `typealias TopLevel = List<Element>` and enables four JSON fixtures plus three schema fixtures.

## How Has This Been Tested?

- `npm run build`
- `npm run lint`
- Focused generated outputs compiled and round-tripped with the KotlinX serialization plugin