### PR TITLE
test(javascript): enable keyword union schema

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1122,7 +1122,6 @@ export const TypeScriptLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        "keyword-unions.schema", // can't handle "constructor" property
         // Pre-existing failures (this fixture is not in CI yet, and these
         // fail with unmodified master too): objects with both declared
         // properties and typed additionalProperties render as an interface
@@ -1166,7 +1165,6 @@ export const JavaScriptLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        "keyword-unions.schema", // can't handle "constructor" property
     ],
     rendererOptions: {},
     quickTestRendererOptions: [


### PR DESCRIPTION
## Description

Enable the keyword-unions schema fixture for JavaScript and TypeScript.

## Motivation and Context

The skips claimed that a `constructor` property was unsupported, but the current shared runtime converter handles own properties correctly.

## Previous Behaviour / Output

The fixture was skipped for both renderers.

## New Behaviour / Output

Both JavaScript and TypeScript run the existing positive keyword-unions samples end to end.

## How Has This Been Tested?

`FIXTURE=schema-javascript,schema-typescript npm run test:fixtures -- test/inputs/schema/keyword-unions.schema`