### PR TITLE
fix(kotlin): escape strings as UTF-16

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/utils.ts
+++ b/packages/quicktype-core/src/language/Kotlin/utils.ts
@@ -14,7 +14,7 @@ import {
     isPrintable,
     legalizeCharacters,
     splitIntoWords,
-    utf32ConcatMap,
+    utf16ConcatMap,
 } from "../../support/Strings.js";
 
 function isPartCharacter(codePoint: number): boolean {
@@ -50,7 +50,7 @@ function unicodeEscape(codePoint: number): string {
 }
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
-const _stringEscape = utf32ConcatMap(
+const _stringEscape = utf16ConcatMap(
     escapeNonPrintableMapper(isPrintable, unicodeEscape),
 );
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1677,11 +1677,6 @@ export const KotlinXLanguage: Language = {
         "a3d8c.json",
         "f74d5.json",
         "fcca3.json",
-        // stringEscape renders astral-plane characters as `\u{5 hex digits}`,
-        // which Kotlin misparses (it only supports 4-digit `\u` escapes), so
-        // the @SerialName annotations don't match the JSON keys.
-        "blns-object.json",
-        "identifiers.json",
     ],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1677,6 +1677,7 @@ export const KotlinXLanguage: Language = {
         "a3d8c.json",
         "f74d5.json",
         "fcca3.json",
+        "blns-object.json", // JSON-to-schema property naming is not stable for case collisions.
     ],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.


### PR DESCRIPTION
## Description

Use UTF-16 code units when escaping Kotlin string literals.

## Motivation and Context

Kotlin only accepts four-digit Unicode escapes. Escaping astral code points directly produced invalid five-digit escapes and broke generated SerialName annotations.

## New Behaviour / Output

Astral characters render as valid UTF-16 surrogate pairs, enabling the identifiers fixture for KotlinX. BLNS remains skipped because its separate JSON-to-schema property-name collision behavior makes generated-code comparison unstable.

## How Has This Been Tested?

- npm run build
- npm run lint
- Focused identifiers output compiled and round-tripped with the KotlinX serialization plugin
- kotlinx,schema-kotlinx GitHub Actions job passes