### PR TITLE
test(swift): enable optional enum schema

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -428,7 +428,9 @@ export const CrystalLanguage: Language = {
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
         // Crystal does not handle enum mapping
-        ...skipsEnumValueValidation,
+        ...skipsEnumValueValidation.filter(
+            (schema) => schema !== "optional-enum.schema",
+        ),
         // Crystal does not support top-level primitives
         "top-level-enum.schema",
         "keyword-unions.schema",


### PR DESCRIPTION
## Description

Enable the optional-enum schema fixture for Swift while retaining the other enum-validation skips.

## Motivation and Context

Swift correctly rejects the invalid optional enum sample, so this fixture no longer belongs in the shared skip group.

## Previous Behaviour / Output

The optional-enum fixture was skipped through `skipsEnumValueValidation`.

## New Behaviour / Output

Swift now runs the positive and negative optional-enum samples.

## How Has This Been Tested?

`FIXTURE=schema-swift npm run test:fixtures -- test/inputs/schema/optional-enum.schema`