### PR TITLE
fix(elixir): handle top-level arrays

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -1163,6 +1163,11 @@ end`);
                             if (isTopLevelArray) {
                                 const arrayElement = (topLevel as ArrayType)
                                     .items;
+                                const elementModule = arrayElement.isPrimitive()
+                                    ? ""
+                                    : this.nameForNamedTypeWithNamespace(
+                                          arrayElement,
+                                      );
 
                                 let isUnion = false;
 
@@ -1180,12 +1185,11 @@ end`);
                                     this.emitLine("|> Jason.decode!()");
                                     this.emitLine(
                                         "|> Enum.map(&",
-                                        isUnion
-                                            ? ["decode_element/1)"]
-                                            : [
-                                                  this.nameWithNamespace(name),
-                                                  "Element.from_map/1)",
-                                              ],
+                                        arrayElement.isPrimitive()
+                                            ? [" &1)"]
+                                            : isUnion
+                                              ? ["decode_element/1)"]
+                                              : [elementModule, ".from_map/1)"],
                                     );
                                 });
 
@@ -1194,12 +1198,11 @@ end`);
                                 this.emitBlock("def to_json(list) do", () => {
                                     this.emitLine(
                                         "Enum.map(list, &",
-                                        isUnion
-                                            ? ["encode_element/1)"]
-                                            : [
-                                                  this.nameWithNamespace(name),
-                                                  "Element.to_map/1)",
-                                              ],
+                                        arrayElement.isPrimitive()
+                                            ? [" &1)"]
+                                            : isUnion
+                                              ? ["encode_element/1)"]
+                                              : [elementModule, ".to_map/1)"],
                                     );
                                     this.emitLine("|> Jason.encode!()");
                                 });

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -2280,12 +2280,6 @@ export const ElixirLanguage: Language = {
     skipJSON: [
         // Some field names are too long to be expressed as atoms and some contain invalid characters.
         "blns-object.json",
-        // A top-level array of scalars generates a TopLevel that maps
-        // `TopLevelElement.from_map/1` over the elements, but no
-        // `TopLevelElement` module is emitted for a scalar element type, so
-        // the program raises UndefinedFunctionError at runtime. (A top-level
-        // array of objects works because that module is emitted.)
-        "issue2680-scalar-array.json",
     ],
     skipMiscJSON: false,
     skipSchema: [
@@ -2300,9 +2294,6 @@ export const ElixirLanguage: Language = {
         "required.schema",
         // The default-value fail sample also relies on required-property enforcement.
         "default-value.schema",
-        // The renderer references a nonexistent TopLevelElement module for
-        // top-level arrays.
-        "top-level-array.schema",
         "top-level-primitive-array.schema",
         "boolean-subschema.schema",
         "intersection.schema",


### PR DESCRIPTION
## Description

Use the actual generated element module for top-level object arrays and an identity mapping for primitive arrays.

## Motivation and Context

The wrapper always referenced a synthesized `TopLevelElement` module. That module does not exist when the generated element type has another name or is primitive.

## Previous Behaviour / Output

Top-level arrays called nonexistent `TopLevelElement.from_map/1` and `TopLevelElement.to_map/1`.

## New Behaviour / Output

Object arrays call their real generated module. Primitive arrays pass elements through unchanged. This enables one JSON fixture and one schema fixture.

## How Has This Been Tested?

- `npm run build`
- `npm run lint`
- Inspected focused generated output for object and primitive top-level arrays