### PR TITLE
test(swift): support top-level aliases in fixture driver

### DIFF
--- a/test/fixtures/swift/main.swift
+++ b/test/fixtures/swift/main.swift
@@ -7,12 +7,6 @@ guard let data = FileHandle(forReadingAtPath: filename)?.readDataToEndOfFile() e
     exit(1)
 }
 
-let obj = try TopLevel(data: data)
-
-guard let jsonString = try obj.jsonString() else {
-    print("Error: Could not serialize")
-    exit(1)
-}
-
-print(jsonString)
-
+let obj = try newJSONDecoder().decode(TopLevel.self, from: data)
+let jsonData = try newJSONEncoder().encode(obj)
+FileHandle.standardOutput.write(jsonData)

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -983,8 +983,6 @@ export const SwiftLanguage: Language = {
     output: "quicktype.swift",
     topLevel: "TopLevel",
     skipJSON: [
-        // Swift only supports top-level arrays and objects
-        "no-classes.json",
         // This at least is keeping blns-object from working: https://bugs.swift.org/browse/SR-6314
         "blns-object.json",
         // Doesn't seem to work on Linux, works on MacOS

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -994,8 +994,6 @@ export const SwiftLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        // The code we generate for top-level enums is incompatible with the driver
-        "top-level-enum.schema",
         // This works on macOS, but on Linux one of the failure test cases doesn't fail
         ...skipsUntypedUnions,
         "required.schema",
@@ -1008,7 +1006,6 @@ export const SwiftLanguage: Language = {
         "date-time.schema",
         "class-with-additional.schema",
         "vega-lite.schema",
-        "top-level-primitive.schema",
     ],
     rendererOptions: { "support-linux": "true" },
     quickTestRendererOptions: [


### PR DESCRIPTION
## Description

Decode and encode the generated TopLevel type through JSONDecoder and JSONEncoder instead of relying on convenience extensions that are only emitted for object types.

## New Behaviour

The Swift fixture now handles top-level primitives and enums, enabling no-classes.json, top-level-primitive.schema, and top-level-enum.schema.

## Testing

- Focused Swift no-classes JSON fixture
- Focused schema-Swift top-level primitive and enum fixtures
- Biome formatting check