### PR TITLE
test(haskell): detect failed fixture decodes

### DIFF
--- a/test/fixtures/haskell/Main.hs
+++ b/test/fixtures/haskell/Main.hs
@@ -13,4 +13,4 @@ main = do
     let filePath = head args
     content <- BS.readFile filePath
     let dec = decodeTopLevel content
-    BS.putStr $ encode dec
+    BS.putStr $ encode $ fromJust dec

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1895,18 +1895,8 @@ export const HaskellLanguage: Language = {
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
         ...skipsUntypedUnions,
-        // The test driver encodes the Maybe result, so a failed decode prints
-        // "null" and exits 0 — expected-failure samples cannot be detected.
-        // (A top-level `[Int]` correctly fails to decode `[1, 2, "three"]`,
-        // but the driver still exits 0.)
-        "boolean-subschema.schema",
-        "issue2680-top-level-array.schema",
-        "nested-intersection-union.schema",
-        "prefix-items.schema",
         "direct-union.schema",
         "empty-object.schema",
-        ...skipsEnumValueValidation,
-        ...skipsMapValueValidation,
         "intersection.schema",
         "multi-type-enum.schema",
         "keyword-unions.schema",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1897,6 +1897,7 @@ export const HaskellLanguage: Language = {
         ...skipsUntypedUnions,
         "direct-union.schema",
         "empty-object.schema",
+        ...skipsEnumValueValidation,
         "intersection.schema",
         "multi-type-enum.schema",
         "keyword-unions.schema",


### PR DESCRIPTION
## Description

Force the fixture decoder result before encoding it. Aeson returns Nothing for invalid input; encoding the Maybe directly previously printed null and exited successfully.

## New Behaviour

Invalid object, top-level-array, prefix-item, and map-value samples now make the fixture process fail, enabling six existing schema tests. Enum skips remain because enum.schema has a separate positive-case generated-parser crash.

## Testing

The first CI run confirmed boolean-subschema, issue2680-top-level-array, nested-intersection-union, prefix-items, go-schema-pattern-properties, and unevaluated-properties pass. The enum group was restored after CI exposed its independent failure.