### PR TITLE
fix(cjson): validate top-level array elements

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -4810,6 +4810,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                 cJSON.cjsonType === "cJSON_Array" &&
                                 cJSON.items !== undefined
                             ) {
+                                const items = cJSON.items;
                                 this.emitLine(
                                     "x->value = list_create(false, NULL);",
                                 );
@@ -4891,7 +4892,20 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                     }
                                                 };
 
-                                                if (cJSON.items?.isNullable) {
+                                                if (
+                                                    !items.isNullable &&
+                                                    items.isType !== ""
+                                                ) {
+                                                    this.emitLine(
+                                                        "if (!",
+                                                        items.isType,
+                                                        "(e)) { cJSON_Delete",
+                                                        className,
+                                                        "(x); return NULL; }",
+                                                    );
+                                                }
+
+                                                if (items.isNullable) {
                                                     this.emitBlock(
                                                         [
                                                             "if (!cJSON_IsNull(e))",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -664,7 +664,6 @@ export const CJSONLanguage: Language = {
         ...skipsMapValueValidation,
         /* Top-level array elements with invalid types (e.g. a string where
          * an integer is expected) are not checked either. */
-        ...skipsArrayElementValidation,
         "multi-type-enum.schema",
         "nested-intersection-union.schema",
         "prefix-items.schema",


### PR DESCRIPTION
## Description

Check non-nullable top-level array elements with the generated cJSON type predicate before decoding and clean up the partially built value on failure.

## New Behaviour

A string in a top-level integer array is rejected instead of being converted to zero. This enables issue2680-top-level-array.schema.

## Size

The production change adds exactly 15 lines.

## Testing

- npm run build
- Biome formatting check
- Focused schema-CJSON fixture compiled locally; positive and negative execution was validated without Valgrind because Valgrind is unavailable on macOS