### PR TITLE
test(kotlin-jackson): support top-level aliases in fixture driver

### DIFF
--- a/test/fixtures/kotlin-jackson/main.kt
+++ b/test/fixtures/kotlin-jackson/main.kt
@@ -10,6 +10,6 @@ fun output(json: String) {
 
 fun main(args: Array<String>) {
 	val json = File(args[0]).readText()
-	val top = TopLevel.fromJson(json)!!
-	output(top.toJson())
+	val top = mapper.readValue(json, TopLevel::class.java)
+	output(mapper.writeValueAsString(top))
 }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1522,8 +1522,6 @@ export const KotlinJacksonLanguage: Language = {
         "unions.json",
         "php-mixed-union.json",
         "nst-test-suite.json",
-        // Klaxon does not support top-level primitives
-        "no-classes.json",
         // These should be enabled
         "nbl-stats.json",
         // TODO Investigate these
@@ -1557,13 +1555,7 @@ export const KotlinJacksonLanguage: Language = {
         // Some weird name collision
         "keyword-enum.schema",
         "keyword-unions.schema",
-        // Klaxon does not support top-level primitives/unions
-        "top-level-enum.schema",
-        "top-level-primitive.schema",
         "recursive-union-flattening.schema",
-        // Jackson cannot deserialize the generated ArrayList subclass because
-        // it has no default constructor.
-        "top-level-array.schema",
         "top-level-primitive-array.schema",
         // A top-level array is deserialized into an `ArrayList<Long>` whose
         // element type is erased at runtime, so a mistyped element


### PR DESCRIPTION
## Description

Use the generated Jackson mapper directly in the Kotlin fixture driver instead of calling convenience methods that only exist on generated object types.

## New Behaviour

The Jackson fixture handles top-level primitives, enums, objects, and object arrays. This enables no-classes.json plus three existing schema tests.

## Testing

Focused forced fixtures for no-classes.json, top-level-enum.schema, top-level-primitive.schema, and top-level-array.schema all pass.