### PR TITLE
fix(csharp): allow optional empty-string enums

### DIFF
--- a/packages/quicktype-core/src/language/CSharp/NewtonSoftCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/NewtonSoftCSharpRenderer.ts
@@ -294,7 +294,10 @@ export class NewtonsoftCSharpRenderer extends CSharpRenderer {
             ? denseJsonPropertyName
             : "JsonProperty";
         const escapedName = utf16StringEscape(jsonName);
-        const isNullable = followTargetType(property.type).isNullable;
+        const targetType = followTargetType(property.type);
+        const isNullable = targetType.isNullable;
+        const isEmptyStringEnum =
+            targetType instanceof EnumType && targetType.cases.has("");
         const isOptional = property.isOptional;
         const requiredClass = this._options.dense ? "R" : "Required";
         const nullValueHandlingClass = this._options.dense
@@ -305,7 +308,10 @@ export class NewtonsoftCSharpRenderer extends CSharpRenderer {
                 ? [", NullValueHandling = ", nullValueHandlingClass, ".Ignore"]
                 : [];
         let required: Sourcelike;
-        if (!this._options.checkRequired || (isOptional && isNullable)) {
+        if (
+            !this._options.checkRequired ||
+            (isOptional && (isNullable || isEmptyStringEnum))
+        ) {
             required = [nullValueHandling];
         } else if (isOptional && !isNullable) {
             required = [

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -147,7 +147,6 @@ export const CSharpLanguage: Language = {
     output: "QuickType.cs",
     topLevel: "TopLevel",
     skipJSON: [
-        "empty-enum.json", // https://github.com/JamesNK/Newtonsoft.Json/issues/1687
         "31189.json", // JSON.NET doesn't accept year 0000 as 1BC, though it should
     ],
     skipMiscJSON: false,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -147,7 +147,6 @@ export const CSharpLanguage: Language = {
     output: "QuickType.cs",
     topLevel: "TopLevel",
     skipJSON: [
-        "nbl-stats.json", // See issue #823
         "empty-enum.json", // https://github.com/JamesNK/Newtonsoft.Json/issues/1687
         "31189.json", // JSON.NET doesn't accept year 0000 as 1BC, though it should
     ],


### PR DESCRIPTION
## Description

Avoid Json.NET Required.DisallowNull on optional enums that contain an empty-string case. Json.NET treats the empty string as null during required-property bookkeeping even though the generated enum converter handles it.

## New Behaviour

Optional transformed enums can deserialize their declared empty-string case. This enables nbl-stats.json and empty-enum.json for both normal and records Newtonsoft fixtures.

## Size

The production diff adds 8 lines.

## Testing

Focused csharp and csharp-records fixtures pass for both inputs.