### PR TITLE
test(zod): enable stale schema fixtures

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -2069,24 +2069,9 @@ export const TypeScriptZodLanguage: Language = {
     ],
     skipMiscJSON: false,
     skipSchema: [
-        // The renderer does not support a bare top-level map.
-        "empty-object.schema",
         "integer-before-number.schema", // Python-specific union-order regression.
-        "any.schema",
-        ...skipsUntypedUnions,
-        "direct-union.schema",
-        ...skipsEnumValueValidation,
         // z.coerce.date() serializes back as ISO UTC, not the input string
         "date-time.schema",
-        ...skipsMapValueValidation,
-        "intersection.schema",
-        "multi-type-enum.schema",
-        "optional-any.schema",
-        "recursive-union-flattening.schema",
-        "required.schema",
-        // The default-value fail sample also relies on required-property enforcement.
-        "default-value.schema",
-        "required-non-properties.schema",
     ],
     rendererOptions: {},
     quickTestRendererOptions: [],


### PR DESCRIPTION
## Description

Remove stale TypeScript Zod schema skips. The renderer now passes these object, union, enum, map, intersection, recursion, optional, and required-property fixtures.

Only the documented integer-before-number and date-time normalization skips remain.

## Testing

CPUs=1 FIXTURE=schema-typescript-zod was run against all 21 newly enabled schemas; every positive and expected-failure sample passed.