### PR TITLE
fix(cplusplus): preserve NULs in string literals

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/utils.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/utils.ts
@@ -213,7 +213,17 @@ export class BaseString {
     }
 
     public createStringLiteral(inner: Sourcelike): Sourcelike {
-        return [this._stringLiteralPrefix, '"', inner, '"'];
+        const literal = [this._stringLiteralPrefix, '"', inner, '"'];
+        return [
+            this._stringType,
+            "(",
+            literal,
+            ", sizeof(",
+            literal,
+            ") / sizeof(",
+            literal,
+            "[0]) - 1)",
+        ];
     }
 
     public wrapToString(inner: Sourcelike): Sourcelike {

--- a/packages/quicktype-core/src/language/CPlusPlus/utils.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/utils.ts
@@ -214,15 +214,18 @@ export class BaseString {
 
     public createStringLiteral(inner: Sourcelike): Sourcelike {
         const literal = [this._stringLiteralPrefix, '"', inner, '"'];
+        const hasNul = (source: Sourcelike): boolean =>
+            Array.isArray(source)
+                ? source.some(hasNul)
+                : typeof source === "string" &&
+                  /(^|[^\\])(?:\\\\)*\\u0000/.test(source);
+        if (!hasNul(inner)) return literal;
         return [
+            "([] { constexpr auto &s = ",
+            literal,
+            "; return ",
             this._stringType,
-            "(",
-            literal,
-            ", sizeof(",
-            literal,
-            ") / sizeof(",
-            literal,
-            "[0]) - 1)",
+            "(s, sizeof(s) / sizeof(s[0]) - 1); }())",
         ];
     }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -805,8 +805,6 @@ export const CPlusPlusLanguage: Language = {
     output: "quicktype.hpp",
     topLevel: "TopLevel",
     skipJSON: [
-        // fails on a string containing null
-        "nst-test-suite.json",
         // uses too much memory compiling
         "combinations.json",
         "combinations1.json",


### PR DESCRIPTION
## Description

Preserve embedded NULs in generated C++ string literals. Ordinary literals retain their original output; only escaped literals containing a real NUL use a length-aware construction. The exceptional expression binds the literal once and derives its array length with sizeof.

## New Behaviour

Keys such as foo followed by NUL followed by bar retain their full length, enabling nst-test-suite.json. A key containing the literal characters \\u0000 remains on the ordinary path.

## Size

The production diff adds 14 lines.

## Testing

- npm run build
- Focused nst-test-suite.json fixture passes
- Focused pokedex.json regression fixture passes
- Narrow and wide NUL expressions compile
- Literal \\u0000 generation remains unchanged