### PR TITLE
test(cplusplus): enable nbl stats fixture

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -816,8 +816,6 @@ export const CPlusPlusLanguage: Language = {
     skipJSON: [
         // fails on a string containing null
         "nst-test-suite.json",
-        // compiler error I don't want to figure out right now
-        "nbl-stats.json",
         // uses too much memory compiling
         "combinations.json",
         "combinations1.json",


### PR DESCRIPTION
The nbl-stats.json skip is stale. The current C++ renderer compiles and passes the full round-trip and schema-diff fixture unchanged.

Production code changes: none.