### PR TITLE
test(flow): enable keyword union schema

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1221,7 +1221,6 @@ export const FlowLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        "keyword-unions.schema", // can't handle "constructor" property
     ],
     rendererOptions: { "explicit-unions": "yes" },
     quickTestRendererOptions: [


### PR DESCRIPTION
The Flow keyword-unions.schema skip is stale. With the repository-pinned Flow toolchain, the focused fixture passes positive round-trip and expected-failure validation unchanged.

Production code changes: none.