### PR TITLE
test(kotlin): enable 32431 fixture

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1433,7 +1433,6 @@ export const KotlinLanguage: Language = {
         "nbl-stats.json",
         // TODO Investigate these
         "af2d1.json",
-        "32431.json",
         "bug427.json",
     ],
     skipSchema: [
@@ -1528,7 +1527,6 @@ export const KotlinJacksonLanguage: Language = {
         "nbl-stats.json",
         // TODO Investigate these
         "af2d1.json",
-        "32431.json",
         "bug427.json",
     ],
     skipSchema: [


### PR DESCRIPTION
The 32431.json skips are stale for both Klaxon and Jackson Kotlin fixtures. Both focused fixtures pass compilation, runtime round-trip, and schema-generated output comparison unchanged.

Production code changes: none.