### PR TITLE
fix(java): preserve top-level array element types

### DIFF
--- a/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
@@ -31,6 +31,13 @@ export class JacksonRenderer extends JavaRenderer {
         "SerializerProvider",
     ];
 
+    private mapperType(t: Type): Sourcelike {
+        if (this._options.useList && t instanceof ArrayType) {
+            return ["new TypeReference<", this.javaType(false, t), ">() {}"];
+        }
+        return [this.javaTypeWithoutGenerics(false, t), ".class"];
+    }
+
     protected emitClassAttributes(c: ClassType, _className: Name): void {
         if (c.getProperties().size === 0)
             this.emitLine(
@@ -635,6 +642,7 @@ export class JacksonRenderer extends JavaRenderer {
             "com.fasterxml.jackson.databind.module.SimpleModule",
             "com.fasterxml.jackson.core.JsonParser",
             "com.fasterxml.jackson.core.JsonProcessingException",
+            "com.fasterxml.jackson.core.type.TypeReference",
             "java.util.*",
         ].concat(this._dateTimeProvider.converterImports);
         this.emitPackageAndImports(imports);
@@ -719,11 +727,8 @@ export class JacksonRenderer extends JavaRenderer {
                             "()",
                         ],
                         () => {
-                            const renderedForClass =
-                                this.javaTypeWithoutGenerics(
-                                    false,
-                                    topLevelType,
-                                );
+                            const renderedForMapper =
+                                this.mapperType(topLevelType);
                             this.emitLine(
                                 "ObjectMapper mapper = new ObjectMapper();",
                             );
@@ -738,14 +743,14 @@ export class JacksonRenderer extends JavaRenderer {
                             this.emitLine(
                                 readerName,
                                 " = mapper.readerFor(",
-                                renderedForClass,
-                                ".class);",
+                                renderedForMapper,
+                                ");",
                             );
                             this.emitLine(
                                 writerName,
                                 " = mapper.writerFor(",
-                                renderedForClass,
-                                ".class);",
+                                renderedForMapper,
+                                ");",
                             );
                         },
                     );

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -264,7 +264,6 @@ export const JavaLanguage: Language = {
         "keyword-unions.schema", // generates classes with names that are case-insensitively equal
         // The generated converter deserializes a top-level array with a raw
         // `List`, so a mistyped element round-trips instead of failing.
-        ...skipsArrayElementValidation,
     ],
     rendererOptions: {},
     // The default is array-type=list; this keeps the T[] code path


### PR DESCRIPTION
## Description

Use a Jackson TypeReference when the generated top level is a List. The raw List.class reader erased the element type and accepted strings in integer arrays.

## New Behaviour

Top-level array element types are enforced during deserialization, enabling issue2680-top-level-array.schema.

## Size

The production diff adds 14 lines.

## Testing

- Focused schema-java top-level-array validation passes
- Pokedex Java regression fixture passes