### PR TITLE
fix(cjson): escape JSON strings in C literals

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -21,6 +21,7 @@ import {
     type NamingStyle,
     allUpperWordStyle,
     makeNameStyle,
+    stringEscape,
 } from "../../support/Strings.js";
 import {
     assert,
@@ -522,6 +523,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
                         this.sourcelikeToString(enumName),
                     );
                     this.forEachEnumCase(enumType, "none", (name, jsonName) => {
+                        jsonName = stringEscape(jsonName);
                         this.emitLine(
                             onFirst ? "" : "else ",
                             'if (!strcmp(cJSON_GetStringValue(j), "',
@@ -556,6 +558,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
                         this.sourcelikeToString(enumName),
                     );
                     this.forEachEnumCase(enumType, "none", (name, jsonName) => {
+                        jsonName = stringEscape(jsonName);
                         this.emitLine(
                             "case ",
                             combinedName,
@@ -2366,6 +2369,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                         type,
                                         "none",
                                         (name, jsonName, property) => {
+                                            jsonName = stringEscape(jsonName);
                                             const cJSON =
                                                 this.quicktypeTypeToCJSON(
                                                     property.type,
@@ -3337,6 +3341,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                         type,
                                         "none",
                                         (name, jsonName, property) => {
+                                            jsonName = stringEscape(jsonName);
                                             const cJSON =
                                                 this.quicktypeTypeToCJSON(
                                                     property.type,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -632,11 +632,8 @@ export const CJSONLanguage: Language = {
     output: "TopLevel.h",
     topLevel: "TopLevel",
     skipJSON: [
-        /* Line feed in identifiers is not supported */
-        "identifiers.json",
         /* Quote in identifier is not supported */
         "blns-object.json",
-        "simple-identifiers.json",
         /* cJSON is not able to parse input with special characters */
         "nst-test-suite.json",
         /* Union with no name in nullable Array in Array is not supported */


### PR DESCRIPTION
## Description

Escape enum values and property names before embedding them in generated C string literals. Quotes and control characters previously produced malformed C source.

## New Behaviour

identifiers.json and simple-identifiers.json compile and round-trip in CJSON. BLNS remains skipped because C forbids universal character names for its C1 control characters.

## Size

The production diff adds 5 lines.

## Testing

Both focused CJSON inputs compile and round-trip using direct execution; Valgrind is unavailable locally.