### PR TITLE
test(javascript): enable schema diff coverage

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1151,8 +1151,7 @@ export const JavaScriptLanguage: Language = {
     runCommand(sample: string) {
         return `node main.js "${sample}"`;
     },
-    // FIXME: enable once TypeScript supports unions
-    diffViaSchema: false,
+    diffViaSchema: true,
     skipDiffViaSchema: [],
     allowMissingNull: false,
     features: ["enum", "union", "no-defaults", "strict-optional", "date-time"],


### PR DESCRIPTION
Enable JSON-via-schema generated-output comparison for the JavaScript fixture. Every priority, sample, and miscellaneous JSON input was audited with the real fixture options; direct JSON generation and JSON-to-schema-to-JavaScript output match exactly.

Production code changes: none.