### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -82,7 +82,7 @@ Check out the "Language" and "Other" tabs in the options panel. What you're look
 
 <img width="33%" height="33%" alt="Screenshot showing the options panel" src="https://raw.githubusercontent.com/quicktype/quicktype/master/media/faq/options-panel.png" />
 
-If it isn't, then depending on your coding skills, you might be able to [customize the output](https://blog.quicktype.io/customizing-quicktype/).
+If it isn't, then depending on your coding skills, you might be able to [customize the output](doc/CustomRenderer.md).
 
 ## Am I allowed to use the generated code in my software?
 
@@ -108,7 +108,7 @@ The [JSON Schema homepage](http://json-schema.org) contains many links and resou
 
 ## I'd like to customize the output for my particular application.
 
-We have [a blog post](https://blog.quicktype.io/customizing-quicktype/) on that very topic.
+Check out our guide on [customizing output](doc/CustomRenderer.md).
 
 ## How can I control the property order in JSON Schema?
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ async function main() {
 main();
 ```
 
-The argument to `quicktype` is a complex object with many optional properties. [Explore its definition](https://github.com/quicktype/quicktype/blob/master/packages/quicktype-core/src/Run.ts#L637) to understand what options are allowed.
+The argument to `quicktype` is a complex object with many optional properties. [Explore its definition](https://github.com/quicktype/quicktype/blob/master/packages/quicktype-core/src/Run.ts#L126) to understand what options are allowed.
 
 #### TypeScript: the `lang` option is a `LanguageName`, not a `string`
 

--- a/doc/CustomRenderer.md
+++ b/doc/CustomRenderer.md
@@ -30,7 +30,6 @@ export class MyCustomRenderer extends CSharpRenderer {
         }
         return undefined;
     }
-    // See: http://blog.quicktype.io/customizing-quicktype/ for more context
 }
 ```
 
@@ -139,7 +138,3 @@ export class BrandNewRenderer extends ConvenienceRenderer {
     // Please reference existing Renderer classes and open a GitHub issue if you need help
 }
 ```
-
-## Links
-
-Blog post with an older example: http://blog.quicktype.io/customizing-quicktype/


### PR DESCRIPTION
## Summary

- replace dead customization-blog links with the existing custom-renderer guide
- correct the stale source-line link for the programmatic `Options` type
- remove remaining references to the unavailable blog post

This extracts the link fixes from #3128 into a focused PR. Akshay (`Aster1145`), the author of #3128, is credited as a co-author on the commit.

Related to #3117.

## Validation

- `git diff --check`
- verified the replacement local documentation target exists
- verified the stale URLs no longer appear in the affected files
