### PR TITLE
test(go): enable schema diff fixtures

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -544,10 +544,7 @@ export const GoLanguage: Language = {
         "bug427.json",
         "nbl-stats.json",
         "0e0c2.json",
-        "2df80.json",
-        "337ed.json",
         "34702.json",
-        "7eb30.json",
         "e8b04.json",
     ],
     allowMissingNull: false,
@@ -565,7 +562,6 @@ export const GoLanguage: Language = {
     ],
     skipMiscJSON: false,
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         // can't differenciate empty array and nothing for optional empty array
         // (omitempty).
         "postman-collection.schema",


### PR DESCRIPTION
## Description

Remove three stale Go `skipDiffViaSchema` entries and the stale `integer-before-number.schema` skip. Direct JSON generation and JSON-via-schema generation now match for all three JSON inputs, and the schema fixture passes all three positive/negative samples.

This enables schema-regeneration comparison coverage for `2df80.json`, `337ed.json`, and `7eb30.json`, plus schema validation coverage for `integer-before-number.schema`.

## Production code

No production changes.

## Testing

- `npm run build`
- `CPUs=1 FIXTURE=golang npm run test:fixtures -- test/inputs/json/misc/2df80.json test/inputs/json/misc/337ed.json test/inputs/json/misc/7eb30.json`
- `CPUs=1 FIXTURE=schema-golang npm run test:fixtures -- test/inputs/schema/integer-before-number.schema`