### PR TITLE
test(kotlin): enable more JSON fixtures

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1415,7 +1415,6 @@ export const KotlinLanguage: Language = {
         "nbl-stats.json",
         // TODO Investigate these
         "af2d1.json",
-        "bug427.json",
     ],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
@@ -1441,7 +1440,6 @@ export const KotlinLanguage: Language = {
         // KlaxonException: Couldn't find a suitable constructor for class UnionValue to initialize with {}
         "direct-union.schema",
         // Some weird name collision
-        "keyword-enum.schema",
         "keyword-unions.schema",
         // Klaxon does not support top-level primitives/unions
         "top-level-enum.schema",
@@ -1505,9 +1503,6 @@ export const KotlinJacksonLanguage: Language = {
         "nst-test-suite.json",
         // These should be enabled
         "nbl-stats.json",
-        // TODO Investigate these
-        "af2d1.json",
-        "bug427.json",
     ],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.


### PR DESCRIPTION
## Description

Remove stale Kotlin runtime skips now that the generated code and fixture drivers handle these inputs correctly.

This enables:

- `bug427.json` for Klaxon
- `af2d1.json` and `bug427.json` for Kotlin-Jackson
- `keyword-enum.schema` for Klaxon, including its negative sample

## Production code

No production changes.

## Testing

- `npm run build`
- `CPUs=1 FIXTURE=kotlin,kotlin-jackson npm run test:fixtures -- test/inputs/json/misc/af2d1.json test/inputs/json/priority/bug427.json`
- `CPUs=1 FIXTURE=schema-kotlin npm run test:fixtures -- test/inputs/schema/keyword-enum.schema`