### PR TITLE
fix(prop-types): export top-level maps

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -281,6 +281,9 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
                     this.typeMapTypeFor((type as ArrayType).items),
                     ")",
                 ]);
+            } else if (type.kind === "map") {
+                this.ensureBlankLine();
+                this.emitExport(name, this.typeMapTypeFor(type));
             } else {
                 this.ensureBlankLine();
                 this.emitExport(name, ["_", name]);

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1171,7 +1171,6 @@ export const JavaScriptPropTypesLanguage: Language = {
     output: "toplevel.js",
     topLevel: "TopLevel",
     skipJSON: [
-        "ed095.json",
         "bug790.json", // renderer does not support recursion
         "recursive.json", // renderer does not support recursion
         "spotify-album.json", // renderer does not support recursion


### PR DESCRIPTION
## Description

Export a top-level map using its PropTypes map representation instead of referencing an object placeholder that is never declared. This enables ed095.json.

## Size

3 production lines.

## Testing

- npm run build
- CPUs=1 FIXTURE=javascript-prop-types npm run test:fixtures -- test/inputs/json/misc/ed095.json