### PR TITLE
test(rust): enable more schema fixtures

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -352,7 +352,6 @@ export const RustLanguage: Language = {
         "keywords.json",
         "recursive.json",
         "github-events.json",
-        "nst-test-suite.json",
         "0a91a.json",
         "0cffa.json",
         "127a1.json",
@@ -362,7 +361,6 @@ export const RustLanguage: Language = {
         "76ae1.json",
         "af2d1.json",
         "c3303.json",
-        "e8b04.json",
         "f6a65.json",
     ],
     allowMissingNull: false,
@@ -370,7 +368,7 @@ export const RustLanguage: Language = {
     output: "module_under_test.rs",
     topLevel: "TopLevel",
     skipJSON: [],
-    skipSchema: ["integer-before-number.schema"], // Python-specific union-order regression.
+    skipSchema: [],
     skipMiscJSON: false,
     rendererOptions: {},
     quickTestRendererOptions: [


### PR DESCRIPTION
## Description

Remove stale Rust fixture skips for:

- schema-diffing nst-test-suite.json and e8b04.json
- integer-before-number.schema, whose positive and negative schema samples now pass

## Production code

No production changes.

## Testing

- npm run build
- npx biome check test/languages.ts
- CPUs=1 FIXTURE=rust npm run test:fixtures -- test/inputs/schema/integer-before-number.schema test/inputs/json/priority/nst-test-suite.json test/inputs/json/misc/e8b04.json