### PR TITLE
test(swift): enable more schema diffs

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -945,12 +945,9 @@ export const SwiftLanguage: Language = {
         "keywords.json",
         "0a358.json", // date-time issues
         "0a91a.json",
-        "26c9c.json", // uri/string confusion
-        "32d5c.json", // date-time issues
         "337ed.json",
         "34702.json",
         "54d32.json", // date-time issues
-        "5eae5.json", // date-time issues
         "77392.json", // date-time issues
         "7f568.json",
         "734ad.json",
@@ -964,8 +961,6 @@ export const SwiftLanguage: Language = {
         "e53b5.json",
         "e8b04.json",
         "fcca3.json",
-        "f82d9.json",
-        "bug863.json", // Unable to resolve reserved keyword use, "description"
     ],
     allowMissingNull: true,
     features: ["enum", "union", "no-defaults", "date-time"],


### PR DESCRIPTION
## Description

Remove stale Swift skipDiffViaSchema entries for:

- f82d9.json
- 26c9c.json
- 32d5c.json
- 5eae5.json
- bug863.json

## Production code

No production changes.

## Testing

- npm run build
- npx biome check test/languages.ts
- CPUs=1 FIXTURE=swift npm run test:fixtures -- test/inputs/json/misc/f82d9.json test/inputs/json/misc/26c9c.json test/inputs/json/misc/32d5c.json test/inputs/json/misc/5eae5.json test/inputs/json/priority/bug863.json