### PR TITLE
test(effect-schema): enable f22f5 fixture

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -2065,7 +2065,6 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         "c8c7e.json",
         "e53b5.json",
         "f3139.json",
-        "f22f5.json",
         "bug855-short.json",
         "bug427.json",
         "nst-test-suite.json",


### PR DESCRIPTION
## Description

Remove the stale f22f5.json runtime skip for TypeScript Effect Schema.

## Production code

No production changes.

## Testing

- npm run build
- CPUs=1 FIXTURE=typescript-effect-schema npm run test:fixtures -- test/inputs/json/misc/f22f5.json