### PR TITLE
fix(cjson): validate property types

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -2375,6 +2375,8 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                     property.type,
                                                     property.isOptional,
                                                 );
+                                            const object = `j${level > 0 ? level.toString() : ""}`;
+                                            const value = `cJSON_GetObjectItemCaseSensitive(${object}, "${jsonName}")`;
                                             this.emitBlock(
                                                 !cJSON.isNullable
                                                     ? [
@@ -2402,6 +2404,11 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                           '"))))',
                                                       ],
                                                 () => {
+                                                    if (cJSON.isType !== "") {
+                                                        this.emitLine(
+                                                            `if (!${cJSON.isType}(${value})) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                        );
+                                                    }
                                                     if (
                                                         cJSON.cjsonType ===
                                                             "cJSON_Array" &&

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -651,7 +651,6 @@ export const CJSONLanguage: Language = {
         /* Enum with invalid values are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         ...skipsEnumValueValidation,
         /* Union, Map and Arrays with invalid types are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
-        "boolean-subschema.schema",
         "class-with-additional.schema",
         ...skipsMapValueValidation,
         /* Top-level array elements with invalid types (e.g. a string where


### PR DESCRIPTION
## Description

Validate a present CJSON class property before converting it. A mismatched primitive previously flowed through the cJSON accessor and was accepted as a default value.

This enables boolean-subschema.schema and its negative sample.

## Size

7 production lines.

## Testing

- npm run build
- CPUs=1 FIXTURE=schema-cjson npm run test:fixtures -- test/inputs/schema/boolean-subschema.schema

Local runtime testing used a direct-binary valgrind shim because valgrind is unavailable on macOS; CI retains the real valgrind invocation.