### PR TITLE
fix(cjson): validate enum properties

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -2404,6 +2404,18 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                 () => {
                                                     if (
                                                         cJSON.cjsonType ===
+                                                        "cJSON_Enum"
+                                                    ) {
+                                                        const object = `j${level > 0 ? level.toString() : ""}`;
+                                                        const value = `cJSON_GetObjectItemCaseSensitive(${object}, "${jsonName}")`;
+                                                        // Enum getters return zero for unknown strings, so
+                                                        // every direct enum property needs this guard.
+                                                        this.emitLine(
+                                                            `if (!cJSON_IsString(${value}) || 0 == ${this.sourcelikeToString(cJSON.getValue)}(${value})) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                        );
+                                                    }
+                                                    if (
+                                                        cJSON.cjsonType ===
                                                             "cJSON_Array" &&
                                                         cJSON.items !==
                                                             undefined

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -648,8 +648,6 @@ export const CJSONLanguage: Language = {
         "top-level-enum.schema",
         /* Union with Number and Integer are not supported; min/max constraints on numbers rely on the same distinction */
         ...skipsIntFloatUnions,
-        /* Enum with invalid values are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
-        ...skipsEnumValueValidation,
         /* Union, Map and Arrays with invalid types are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         "boolean-subschema.schema",
         "class-with-additional.schema",


### PR DESCRIPTION
## Summary
- validate direct CJSON enum properties before accepting parsed values
- emit the guard only for direct enum properties
- keep enum-only supporting expressions inside that conditional path
- enable all seven enum-validation schema fixtures

Unknown enum strings otherwise become the zero sentinel and are silently accepted, so each emitted enum guard changes behavior for the property it protects.

## Validation
- npm run build
- Biome passed
- focused schema-cjson run passed all seven schemas and their expected-failure inputs

Production code changes: 10 added lines.