### PR TITLE
Test TypeScript Effect Schema against JSON Schema fixtures

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -35,7 +35,7 @@ jobs:
 
             matrix:
                 fixture:
-                    - typescript,typescript-zod,schema-typescript-zod,typescript-effect-schema
+                    - typescript,typescript-zod,schema-typescript-zod,typescript-effect-schema,schema-typescript-effect-schema
                     - javascript,schema-javascript
                     - golang,schema-golang
                     - cjson,schema-cjson

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1843,6 +1843,7 @@ export const allFixtures: Fixture[] = [
     new JSONSchemaFixture(languages.SwiftLanguage),
     new JSONSchemaFixture(languages.TypeScriptLanguage),
     new JSONSchemaFixture(languages.TypeScriptZodLanguage),
+    new JSONSchemaFixture(languages.TypeScriptEffectSchemaLanguage),
     new JSONSchemaFixture(languages.FlowLanguage),
     new JSONSchemaFixture(languages.JavaScriptLanguage),
     new JSONSchemaFixture(languages.KotlinLanguage),

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -2076,19 +2076,18 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         // The renderer does not support a bare top-level map.
         "empty-object.schema",
         "integer-before-number.schema", // Python-specific union-order regression.
-        "any.schema",
-        ...skipsUntypedUnions,
-        "direct-union.schema",
-        ...skipsEnumValueValidation,
-        ...skipsMapValueValidation,
-        "intersection.schema",
-        "multi-type-enum.schema",
         "keyword-unions.schema",
-        "optional-any.schema",
-        "required.schema",
-        // The default-value fail sample also relies on required-property enforcement.
-        "default-value.schema",
-        "required-non-properties.schema",
+        // Recursive schemas reference declarations before initialization.
+        "list.schema",
+        "union-list.schema",
+        "simple-ref.schema",
+        "rust-cycle-breaker-union.schema",
+        "ref-remote.schema",
+        "recursive-union-flattening.schema",
+        "postman-collection.schema",
+        // The driver cannot find schemas for top-level arrays.
+        "top-level-array.schema",
+        "top-level-primitive-array.schema",
         "issue2680-top-level-array.schema",
     ],
     rendererOptions: {},


### PR DESCRIPTION
## Summary

- register the existing TypeScript Effect Schema language with the JSON Schema fixture suite
- remove 19 stale schema skips that now pass, including enum, required-property, map-value, and untyped-union validation cases
- retain the four reproduced existing skips and add nine reproduced recursion/top-level-array exclusions required by the newly active fixture
- add `schema-typescript-effect-schema` to the existing TypeScript fixture-matrix entry so the new coverage runs in PR CI

## Validation

- `npx biome check test/fixtures.ts test/languages.ts`
- parsed `.github/workflows/test-pr.yaml` successfully with Ruby Psych
- `git diff --check`
- `ALL_FIXTURES=1 FIXTURE=schema-typescript-effect-schema CPUs=4 npx tsx test/test.ts` (85 tests)
- each prior skip was also enabled and run independently to distinguish stale exclusions from reproduced failures

Production code changed: 0 lines.