### PR TITLE
test(cjson): enable Vega-Lite schema

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -642,8 +642,6 @@ export const CJSONLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        /* Member names are different when generating with schema */
-        "vega-lite.schema",
         /* Enum as TopLevel is not supported */
         "top-level-enum.schema",
         /* Union with Number and Integer are not supported; min/max constraints on numbers rely on the same distinction */


### PR DESCRIPTION
## Summary\n- remove the stale CJSON skip for vega-lite.schema\n- restore generation and compilation coverage for this large schema\n\n## Validation\n- npm run build\n- npx biome check test/languages.ts\n- focused schema-cjson fixture passed\n\nProduction code changes: 0 lines.