### PR TITLE
fix(cjson): validate map property values

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -2689,6 +2689,13 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                     ) {
                                                         const child_level =
                                                             level + 1;
+                                                        const items =
+                                                            cJSON.items;
+                                                        const element = `e${child_level}`;
+                                                        const nullable =
+                                                            items.isNullable
+                                                                ? `!cJSON_IsNull(${element}) && `
+                                                                : "";
                                                         this.emitLine(
                                                             cJSON.cType,
                                                             " * x",
@@ -2729,6 +2736,14 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                                         ")",
                                                                     ],
                                                                     () => {
+                                                                        if (
+                                                                            items.isType !==
+                                                                            ""
+                                                                        ) {
+                                                                            this.emitLine(
+                                                                                `if (${nullable}!${items.isType}(${element})) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                                            );
+                                                                        }
                                                                         const add =
                                                                             (
                                                                                 type: Type,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -653,7 +653,9 @@ export const CJSONLanguage: Language = {
         /* Union, Map and Arrays with invalid types are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         "boolean-subschema.schema",
         "class-with-additional.schema",
-        ...skipsMapValueValidation,
+        ...skipsMapValueValidation.filter(
+            (schema) => schema !== "go-schema-pattern-properties.schema",
+        ),
         /* Top-level array elements with invalid types (e.g. a string where
          * an integer is expected) are not checked either. */
         "multi-type-enum.schema",


### PR DESCRIPTION
## Summary\n- reject wrong-typed values while parsing typed CJSON map properties\n- preserve nullable map values\n- enable go-schema-pattern-properties.schema for CJSON\n\n## Validation\n- npm run build\n- Biome passed\n- focused schema-cjson fixture passed both positive and expected-failure samples\n\nProduction code changes: 15 added lines.