### PR TITLE
test(flow): enable integer-before-number schema

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1163,9 +1163,7 @@ export const FlowLanguage: Language = {
     topLevel: "TopLevel",
     skipJSON: [],
     skipMiscJSON: false,
-    skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
-    ],
+    skipSchema: [],
     rendererOptions: { "explicit-unions": "yes" },
     quickTestRendererOptions: [
         { "runtime-typecheck": "false" },


### PR DESCRIPTION
Removes Flow’s last schema fixture exclusion. The integer-before-number union-order regression now compiles, round-trips both positive samples, and rejects the negative sample.\n\nValidation:\n- npx biome check test/languages.ts\n- FIXTURE=schema-flow focused fixture (3 files)