### PR TITLE
test(kotlinx): enable runtime coverage for date inputs

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1493,6 +1493,8 @@ export const KotlinXLanguage: Language = {
     skipDiffViaSchema: [
         "bug427.json",
         "keywords.json",
+        "77392.json",
+        "b4865.json",
         // TODO Investigate these
         "34702.json",
         "76ae1.json",
@@ -1513,9 +1515,7 @@ export const KotlinXLanguage: Language = {
         "optional-union.json",
         "00c36.json",
         "2df80.json",
-        "77392.json",
         "7fbfb.json",
-        "b4865.json",
         "c8c7e.json",
         "cda6c.json",
         "e53b5.json",


### PR DESCRIPTION
Moves 77392.json and b4865.json from skipJSON to skipDiffViaSchema. KotlinX now compiles and round-trips both inputs; only their known JSON-via-schema output difference remains exempted.\n\nValidation:\n- npx biome check test/languages.ts\n- focused KotlinX fixture for both inputs