### PR TITLE
test(kotlin-jackson): enable BLNS runtime fixture

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1429,6 +1429,7 @@ export const KotlinJacksonLanguage: Language = {
     skipDiffViaSchema: [
         "bug427.json",
         "keywords.json",
+        "blns-object.json",
         // TODO Investigate these
         "34702.json",
         "76ae1.json",
@@ -1440,7 +1441,6 @@ export const KotlinJacksonLanguage: Language = {
     skipJSON: [
         // Some odd property names prevent Klaxon from mapping to constructors
         // https://github.com/cbeust/klaxon/issues/146
-        "blns-object.json",
         "identifiers.json",
         "simple-identifiers.json",
         // Klaxon cannot parse List<List<Enum | Union>>


### PR DESCRIPTION
Moves blns-object.json from skipJSON to skipDiffViaSchema. Kotlin/Jackson now compiles and round-trips the Big List of Naughty Strings input; only its known schema-regeneration difference remains exempted.\n\nValidation:\n- npx biome check test/languages.ts\n- focused Kotlin/Jackson fixture