### PR TITLE
test(swift): enable optional enum schema

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -969,7 +969,9 @@ export const SwiftLanguage: Language = {
         "multi-type-enum.schema",
         "intersection.schema",
         ...skipsMapValueValidation,
-        ...skipsEnumValueValidation,
+        ...skipsEnumValueValidation.filter(
+            (schema) => schema !== "optional-enum.schema",
+        ),
         "date-time.schema",
         "class-with-additional.schema",
         "vega-lite.schema",


### PR DESCRIPTION
Excludes optional-enum.schema from Swift’s shared enum-validation skip list. Its two positive samples compile and round-trip successfully, so the fixture no longer needs to be disabled.\n\nValidation:\n- npx biome check test/languages.ts\n- focused schema-swift fixture (2 files)