### PR TITLE
test(haskell): compare more JSON schema output

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1709,12 +1709,10 @@ export const HaskellLanguage: Language = {
     },
     diffViaSchema: true,
     skipDiffViaSchema: [
-        "bug863.json",
         "reddit.json",
         "github-events.json",
         "nbl-stats.json",
         "0a91a.json",
-        "0e0c2.json",
         "29f47.json",
         "2df80.json",
         "27332.json",


### PR DESCRIPTION
Removes two active stale Haskell skipDiffViaSchema exclusions: bug863.json and 0e0c2.json. Exact generation audits confirm direct JSON inference and JSON-via-schema now emit identical QuickType.hs files.\n\nValidation:\n- npx biome check test/languages.ts\n- exact generated-output comparison for both inputs