### PR TITLE
test(elixir): compare 34702 schema output

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -2011,7 +2011,6 @@ export const ElixirLanguage: Language = {
         "76ae1.json",
         "6de06.json",
         "4d6fb.json",
-        "34702.json",
         "2df80.json",
         "29f47.json",
         "27332.json",


### PR DESCRIPTION
Removes the stale Elixir skipDiffViaSchema exclusion for 34702.json. Direct JSON inference and JSON-via-schema now emit identical QuickType.ex output.\n\nValidation:\n- npx biome check test/languages.ts\n- exact generated-output comparison for 34702.json