### PR TITLE
test(haskell): enable integer-before-number schema

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1770,7 +1770,6 @@ export const HaskellLanguage: Language = {
     ],
     skipMiscJSON: false,
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         ...skipsUntypedUnions,
         "direct-union.schema",
         "empty-object.schema",


### PR DESCRIPTION
Removes the stale Haskell exclusion for integer-before-number.schema. The generated FromJSON instance accepts numeric values only, and the fixture driver now exits nonzero when decoding the string failure sample.\n\nValidation:\n- npx biome check test/languages.ts\n- inspected generated FromJSON alternatives for the schema\n- GitHub Actions exercises the Haskell toolchain