### PR TITLE
fix(ruby): use native JSON encoding for primitive arrays

### DIFF
--- a/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
+++ b/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
@@ -871,7 +871,9 @@ export class RubyRenderer extends ConvenienceRenderer {
 
                         // The json gem defines to_json on maps and primitives, so we only need to supply
                         // it for arrays.
-                        const needsToJsonDefined = topLevel.kind === "array";
+                        const needsToJsonDefined =
+                            topLevel instanceof ArrayType &&
+                            !topLevel.items.isPrimitive();
 
                         const classDeclaration = (): void => {
                             this.emitBlock(["class ", name], () => {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -512,15 +512,11 @@ export const RubyLanguage: Language = {
         "php-mixed-union.json",
         "nbl-stats.json",
         "kitchen-sink.json",
-        // Top-level scalar arrays redefine Array#to_json recursively.
-        "issue2680-scalar-array.json",
     ],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
         // We don't generate a convenience method for top-level enums
         "top-level-enum.schema",
-        // Top-level scalar arrays redefine Array#to_json recursively.
-        "issue2680-top-level-array.schema",
     ],
     skipMiscJSON: false,
     rendererOptions: {},


### PR DESCRIPTION
Primitive arrays do not need quicktype’s singleton to_json conversion hook. The hook recursively called JSON.generate on the same array and also rejected the state argument supplied by the JSON gem.\n\nRestricting it to arrays with non-primitive elements enables both the scalar-array JSON fixture and the top-level-array schema fixture.\n\nProduction change: 3 added lines.\n\nValidation:\n- npm run build\n- focused Ruby JSON fixture\n- focused schema-ruby fixture, including its invalid element sample