### PR TITLE
fix(effect-schema): emit unnamed top-level schemas

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -293,6 +293,18 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
                 }),
             );
         });
+
+        this.forEachTopLevel("none", (type, name) => {
+            if (["class", "object", "enum"].includes(type.kind)) return;
+
+            this.ensureBlankLine();
+            const schema = this.typeMapTypeFor(type);
+            this.emitLine(["export const ", name, " = ", schema, ";"]);
+            if (!this._options.justSchema) {
+                const typeOf = " = S.Schema.Type<typeof ";
+                this.emitLine(["export type ", name, typeOf, name, ">;"]);
+            }
+        });
     }
 
     protected emitSourceStructure(): void {

--- a/test/fixtures/typescript-effect-schema/main.ts
+++ b/test/fixtures/typescript-effect-schema/main.ts
@@ -22,15 +22,7 @@ if (!schema) {
     throw new Error("No schema found");
 }
 
-let backToJson: string;
-if (Array.isArray(value)) {
-    const parsedValue = value.map((v) => {
-        return Schema.decodeUnknownSync(schema)(v);
-    });
-    backToJson = JSON.stringify(parsedValue, null, 2);
-} else {
-    const parsedValue = Schema.decodeUnknownSync(schema)(value);
-    backToJson = JSON.stringify(parsedValue, null, 2);
-}
+const parsedValue = Schema.decodeUnknownSync(schema)(value);
+const backToJson = JSON.stringify(parsedValue, null, 2);
 
 console.log(backToJson);

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1896,34 +1896,16 @@ export const TypeScriptEffectSchemaLanguage: Language = {
     output: "TopLevel.ts",
     topLevel: "TopLevel",
     skipJSON: [
-        "2df80.json",
-        "29f47.json",
-
         // Does not handle recursive
         "direct-recursive.json",
         "list.json",
         "bug790.json",
 
-        // Does not handle top level arrays
-        "bug863.json",
-        "issue2680-scalar-array.json",
-
-        "no-classes.json",
-        "00c36.json",
-        "7fbfb.json",
-        "cda6c.json",
-        "c8c7e.json",
-        "e53b5.json",
-        "bug855-short.json",
         "bug427.json",
         "nst-test-suite.json",
-        "ed095.json",
     ],
     skipMiscJSON: false,
     skipSchema: [
-        // The renderer does not support a bare top-level map.
-        "empty-object.schema",
-        "integer-before-number.schema", // Python-specific union-order regression.
         "keyword-unions.schema",
         // Recursive schemas reference declarations before initialization.
         "list.schema",
@@ -1933,10 +1915,6 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         "ref-remote.schema",
         "recursive-union-flattening.schema",
         "postman-collection.schema",
-        // The driver cannot find schemas for top-level arrays.
-        "top-level-array.schema",
-        "top-level-primitive-array.schema",
-        "issue2680-top-level-array.schema",
     ],
     rendererOptions: {},
     quickTestRendererOptions: [],


### PR DESCRIPTION
Emit Effect schemas for unnamed top-level arrays, maps, primitives, and unions, and have the fixture driver decode the complete top-level value instead of treating every array as an array of independently decoded top levels.\n\nThis enables 12 JSON fixtures and 5 schema fixtures, including top-level scalar arrays with invalid-element validation.\n\nProduction change: 12 added lines.\n\nValidation:\n- npm run build\n- Biome checks\n- focused TypeScript Effect Schema JSON fixture: 12/12\n- focused TypeScript Effect Schema schema fixture: 5/5