### PR TITLE
test(php): enable more sample JSON fixtures

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1815,6 +1815,11 @@ export const PHPLanguage: Language = {
         "number-map.json",
         "omit-empty.json",
         "url.json",
+        "nbl-stats.json",
+        "reddit.json",
+        "spotify-album.json",
+        "us-avg-temperatures.json",
+        "us-senators.json",
         // The motivating repro for non-nullable union support: a
         // heterogeneous array under a PHP-reserved-word property name.
         "php-mixed-union.json",


### PR DESCRIPTION
Adds five currently passing priority/sample inputs to PHP’s explicit JSON fixture allowlist: nbl-stats, Reddit, Spotify albums, average temperatures, and US senators.\n\nProduction changes: none.\n\nValidation:\n- npx biome check test/languages.ts\n- focused PHP fixture: 5/5