### PR TITLE
fix(kotlin): deserialize top-level primitive arrays with Jackson

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -169,7 +169,7 @@ import com.fasterxml.jackson.module.kotlin.*`);
                 name,
                 "(elements: Collection<",
                 elementType,
-                ">) : ArrayList<",
+                "> = emptyList()) : ArrayList<",
                 elementType,
                 ">(elements)",
             ],

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1459,7 +1459,6 @@ export const KotlinJacksonLanguage: Language = {
         // KlaxonException: Couldn't find a suitable constructor for class UnionValue to initialize with {}
         "direct-union.schema",
         "keyword-unions.schema",
-        "top-level-primitive-array.schema",
     ],
     skipMiscJSON: false,
     rendererOptions: { framework: "jackson" },


### PR DESCRIPTION
Jackson needs a no-argument constructor when it instantiates the generated top-level `ArrayList` subclass. Give the existing collection constructor an empty-list default so both Jackson construction and the convenience API continue to work.

This enables `top-level-primitive-array.schema` for the Kotlin/Jackson fixture.

Production change: 1 added line.

Validation:
- `npm run build`
- `CPUs=1 FIXTURE=schema-kotlin-jackson npm run test:fixtures -- test/inputs/schema/top-level-primitive-array.schema`