### PR TITLE
fix(cjson): reject missing required properties

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -2377,6 +2377,11 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                 );
                                             const object = `j${level > 0 ? level.toString() : ""}`;
                                             const value = `cJSON_GetObjectItemCaseSensitive(${object}, "${jsonName}")`;
+                                            if (!property.isOptional) {
+                                                this.emitLine(
+                                                    `if (!cJSON_HasObjectItem(${object}, "${jsonName}")) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                );
+                                            }
                                             this.emitBlock(
                                                 !cJSON.isNullable
                                                     ? [

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -657,10 +657,6 @@ export const CJSONLanguage: Language = {
         /* Required properties absent are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         "ie-suffix-singularization.schema",
         "intersection.schema",
-        "required.schema",
-        // The default-value fail sample also relies on required-property
-        // enforcement, which cJSON does not do.
-        "default-value.schema",
         /* Pure Any type not supported (for the current implementation, can be added later, should manage a callback to provide the final application a way to handle it at parsing and creation of cJSON) */
         "any.schema",
         "direct-union.schema",


### PR DESCRIPTION
Reject an object as soon as a generated required property is absent, cleaning up the partially allocated class before returning `NULL`.

This enables the CJSON `required.schema` and `default-value.schema` validation fixtures, including their expected-failure inputs.

Production change: 5 added lines.

Validation:
- `npm run build`
- `PATH=/tmp/quicktype-cjson-wrapper:$PATH CPUs=1 FIXTURE=schema-cjson npm run test:fixtures -- test/inputs/schema/required.schema test/inputs/schema/default-value.schema`

The local wrapper only substitutes direct execution for unavailable Valgrind; generated cleanup remains covered by CI with Valgrind.