### PR TITLE
fix(cjson): reject non-object elements in object arrays

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -2573,6 +2573,16 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                                                         ?.cjsonType ===
                                                                                         "cJSON_Union"
                                                                                 ) {
+                                                                                    if (
+                                                                                        cJSON
+                                                                                            .items
+                                                                                            ?.cjsonType ===
+                                                                                        "cJSON_Object"
+                                                                                    ) {
+                                                                                        this.emitLine(
+                                                                                            `if (!cJSON_IsObject(e${child_level})) { x${level > 0 ? level.toString() : ""}->${this.sourcelikeToString(name)} = x${child_level}; cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                                                        );
+                                                                                    }
                                                                                     this.emitLine(
                                                                                         "list_add_tail(x",
                                                                                         child_level.toString(),

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -641,7 +641,6 @@ export const CJSONLanguage: Language = {
         /* Top-level array elements with invalid types (e.g. a string where
          * an integer is expected) are not checked either. */
         "multi-type-enum.schema",
-        "nested-intersection-union.schema",
         "prefix-items.schema",
         /* Constraints (min/max and regex) are not supported (for the current implementation, can be added later, should abord parsing and return NULL) */
         "minmaxlength.schema",


### PR DESCRIPTION
Generated object-array parsers now reject non-object JSON elements before invoking the class parser. The failure path attaches the partial list before deleting the parent, so already parsed elements are cleaned up.

The check is emitted only for arrays whose elements are generated object types. Ordinary class parsers and non-object arrays remain byte-for-byte unchanged.

This enables `nested-intersection-union.schema` for CJSON and rejects its invalid nested array element.

Production change: 10 added lines.

Validation:
- `npm run build`
- `PATH=/tmp/quicktype-cjson-wrapper:$PATH CPUs=1 FIXTURE=schema-cjson npm run test:fixtures -- test/inputs/schema/nested-intersection-union.schema`

The local wrapper only substitutes direct execution for unavailable Valgrind; CI retains the Valgrind run.
