### PR TITLE
test(elixir): enable top-level primitive arrays

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1996,7 +1996,6 @@ export const ElixirLanguage: Language = {
         "required.schema",
         // The default-value fail sample also relies on required-property enforcement.
         "default-value.schema",
-        "top-level-primitive-array.schema",
         "boolean-subschema.schema",
         "intersection.schema",
         "optional-any.schema",


### PR DESCRIPTION
The Elixir renderer now handles primitive top-level arrays through the generated identity mapping path, but this schema remained disabled after that support landed. Remove the stale skip.

Production change: none.

Validation:
- `npm run build`
- `CPUs=1 FIXTURE=schema-elixir npm run test:fixtures -- test/inputs/schema/top-level-primitive-array.schema` (Elixir 1.18 container)