### PR TITLE
fix(effect-schema): support recursive object schemas

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -164,7 +164,6 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
     }
 
     private emitObject(name: Name, t: ObjectType): void {
-        this.emittedObjects.add(name);
         this.ensureBlankLine();
         this.emitLine(
             "\nexport class ",
@@ -186,6 +185,7 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
             });
         });
         this.emitLine("}) {}");
+        this.emittedObjects.add(name);
     }
 
     private emitEnum(e: EnumType, enumName: Name): void {
@@ -212,8 +212,11 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
 
     protected walkObjectNames(objectType: ObjectType): Name[] {
         const names: Name[] = [];
+        const visited = new Set<Type>();
 
         const recurse = (type: Type): void => {
+            if (visited.has(type)) return;
+            visited.add(type);
             if (type.kind === "object" || type.kind === "class") {
                 names.push(this.nameForNamedType(type));
                 this.forEachClassProperty(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1895,27 +1895,9 @@ export const TypeScriptEffectSchemaLanguage: Language = {
     features: ["enum", "union", "no-defaults"],
     output: "TopLevel.ts",
     topLevel: "TopLevel",
-    skipJSON: [
-        // Does not handle recursive
-        "direct-recursive.json",
-        "list.json",
-        "bug790.json",
-
-        "bug427.json",
-        "nst-test-suite.json",
-    ],
+    skipJSON: ["bug427.json", "nst-test-suite.json"],
     skipMiscJSON: false,
-    skipSchema: [
-        "keyword-unions.schema",
-        // Recursive schemas reference declarations before initialization.
-        "list.schema",
-        "union-list.schema",
-        "simple-ref.schema",
-        "rust-cycle-breaker-union.schema",
-        "ref-remote.schema",
-        "recursive-union-flattening.schema",
-        "postman-collection.schema",
-    ],
+    skipSchema: ["keyword-unions.schema"],
     rendererOptions: {},
     quickTestRendererOptions: [],
     sourceFiles: ["src/language/TypeScriptEffectSchema/index.ts"],


### PR DESCRIPTION
Stacked on #3187 so the two Effect Schema fixes stay isolated and merge without conflicts. Once #3187 lands, this PR contains only the recursion change.

Keep the object currently being emitted out of the initialized-schema set until its declaration is complete, so self references are emitted through `S.suspend`. Also make dependency walking cycle-safe.

This enables 10 fixtures:
- JSON: `direct-recursive.json`, `list.json`, `bug790.json`
- Schema: `list.schema`, `union-list.schema`, `simple-ref.schema`, `rust-cycle-breaker-union.schema`, `ref-remote.schema`, `recursive-union-flattening.schema`, `postman-collection.schema`

Production change in this PR: 4 added lines and one moved line.

Validation:
- `npm run build`
- focused Effect Schema JSON fixture for all 3 inputs
- focused Effect Schema schema fixture for all 7 schemas, including their positive and negative samples