### PR TITLE
fix(elixir): validate primitive array elements

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -372,11 +372,12 @@ export class ElixirRenderer extends ConvenienceRenderer {
         parentName: Sourcelike,
         suffix = "",
         optional = false,
+        force = false,
     ): void {
         this.ensureBlankLine();
 
         let typesToMatch = this.sortAndFilterPatternMatchTypes(types);
-        if (typesToMatch.length < 2) {
+        if (typesToMatch.length < 2 && !force) {
             return;
         }
 
@@ -1178,6 +1179,16 @@ end`);
                                         name,
                                     );
                                     isUnion = true;
+                                } else if (arrayElement.isPrimitive()) {
+                                    this.emitPatternMatches(
+                                        [arrayElement],
+                                        "element",
+                                        name,
+                                        "",
+                                        false,
+                                        true,
+                                    );
+                                    isUnion = true;
                                 }
 
                                 this.emitBlock("def from_json(json) do", () => {
@@ -1185,11 +1196,9 @@ end`);
                                     this.emitLine("|> Jason.decode!()");
                                     this.emitLine(
                                         "|> Enum.map(&",
-                                        arrayElement.isPrimitive()
-                                            ? [" &1)"]
-                                            : isUnion
-                                              ? ["decode_element/1)"]
-                                              : [elementModule, ".from_map/1)"],
+                                        isUnion
+                                            ? ["decode_element/1)"]
+                                            : [elementModule, ".from_map/1)"],
                                     );
                                 });
 
@@ -1198,11 +1207,9 @@ end`);
                                 this.emitBlock("def to_json(list) do", () => {
                                     this.emitLine(
                                         "Enum.map(list, &",
-                                        arrayElement.isPrimitive()
-                                            ? [" &1)"]
-                                            : isUnion
-                                              ? ["encode_element/1)"]
-                                              : [elementModule, ".to_map/1)"],
+                                        isUnion
+                                            ? ["encode_element/1)"]
+                                            : [elementModule, ".to_map/1)"],
                                     );
                                     this.emitLine("|> Jason.encode!()");
                                 });

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -2016,7 +2016,6 @@ export const ElixirLanguage: Language = {
 
         // A top-level array is deserialized without enforcing its element
         // type, so a mistyped element round-trips instead of failing.
-        ...skipsArrayElementValidation,
     ],
     rendererOptions: {},
     quickTestRendererOptions: [],


### PR DESCRIPTION
Reuse the renderer’s existing pattern-match codecs for primitive top-level array elements. A mismatched value now reaches the generated catch-all clause and exits nonzero instead of round-tripping unchanged.

This enables `issue2680-top-level-array.schema` for Elixir, including its invalid string-in-integer-array sample.

Production change: 18 added lines.

Validation:
- `npm run build`
- `CPUs=1 FIXTURE=schema-elixir npm run test:fixtures -- test/inputs/schema/issue2680-top-level-array.schema` (Elixir 1.18 container, both positive and negative files)