### PR TITLE
test(php): enable five miscellaneous JSON inputs

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1855,6 +1855,11 @@ export const PHPLanguage: Language = {
         "43eaf.json",
         "458db.json",
         "4961a.json",
+        "4a0d7.json",
+        "4a455.json",
+        "4c547.json",
+        "4d6fb.json",
+        "4e336.json",
     ],
     skipMiscJSON: false,
     skipSchema: [


### PR DESCRIPTION
Add five independently validated miscellaneous JSON inputs to the PHP fixture allowlist. All generate valid PHP and round-trip under PHP 8.2.

Production change: none.

Validation: focused `FIXTURE=php` run for all five inputs.