### PR TITLE
Fix Ruby union validation with current dry-struct

### DIFF
--- a/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
+++ b/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
@@ -622,7 +622,11 @@ export class RubyRenderer extends ConvenienceRenderer {
                             .map((memberName) => [", ", memberName, ": nil"]);
                         if (this.propertyTypeMarshalsImplicitlyFromDynamic(t)) {
                             this.emitBlock(
-                                ["if schema[:", name, "].right.valid? d"],
+                                [
+                                    "if schema.key(:",
+                                    name,
+                                    ").type.right.valid? d",
+                                ],
                                 () => {
                                     this.emitLine(
                                         "return new(",
@@ -642,9 +646,9 @@ export class RubyRenderer extends ConvenienceRenderer {
                                 );
                                 this.emitBlock(
                                     [
-                                        "if schema[:",
+                                        "if schema.key(:",
                                         name,
-                                        "].right.valid? value",
+                                        ").type.right.valid? value",
                                     ],
                                     () => {
                                         this.emitLine(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -498,23 +498,8 @@ export const RubyLanguage: Language = {
     skipJSON: [
         // Chokes on { "1": "one" } because _[0-9]+ is reserved in ruby
         "blns-object.json",
-        // Ruby union code does not work with new Dry
-        // can't convert Symbol into Hash (Dry::Types::CoercionError)
-        "bug863.json",
-        "combinations1.json",
-        "combinations2.json",
-        "combinations3.json",
-        "combinations4.json",
-        "nst-test-suite.json",
-        "optional-union.json",
-        "union-constructor-clash.json",
-        "unions.json",
-        "php-mixed-union.json",
-        "nbl-stats.json",
-        "kitchen-sink.json",
     ],
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         // We don't generate a convenience method for top-level enums
         "top-level-enum.schema",
     ],


### PR DESCRIPTION
## Summary

Current `dry-struct` treats `schema[:member]` as a schema application, so generated non-null union deserializers pass a Symbol to the schema's Hash constructor and raise `Dry::Types::CoercionError`.

Use the current key API (`schema.key(:member).type`) before checking the union member's right-hand type. This restores union decoding and enables 12 JSON round-trip fixtures plus the three-sample `integer-before-number.schema` fixture.

Production code: 7 added lines (two generated expressions), within the 20-line limit.

## Validation

- `npm run build`
- `npx biome check packages/quicktype-core/src/language/Ruby/RubyRenderer.ts test/languages.ts`
- `PATH=/tmp/quicktype-ruby-generic:$PATH CPUs=1 QUICKTEST=true FIXTURE=ruby npm run test:fixtures --` with all 12 newly enabled JSON inputs (12/12 passed under Ruby 3.2)
- `PATH=/tmp/quicktype-ruby-generic:$PATH CPUs=1 FIXTURE=schema-ruby npm run test:fixtures -- test/inputs/schema/integer-before-number.schema` (3 files passed)
