### PR TITLE
test(pike): handle fixture JSON as UTF-8

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -61,9 +61,6 @@ jobs:
                     # Partially working
                     # - schema-typescript # TODO Unify with typescript once fixed
 
-                    # Language is too niche / obscure to test easily on ubuntu-22.04
-                    # - pike,schema-pike
-
                     # Not yet started
                     # @schani can you help me understand this fixture?
                     # It looks like it tests 13+ languages?
@@ -83,6 +80,8 @@ jobs:
                       runs-on: ubuntu-latest-16-cores
                     - fixture: kotlinx,schema-kotlinx
                       runs-on: ubuntu-latest-16-cores
+                    - fixture: pike,schema-pike
+                      runs-on: ubuntu-24.04
 
                     # - fixture: objective-c # segfault on compiled test cmd
                     #   runs-on: macos-latest
@@ -100,6 +99,12 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: "8.2"
+
+            - name: Install Pike
+              if: ${{ contains(matrix.fixture, 'pike') }}
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y pike8.0-core
 
             - name: Setup Dart
               if: ${{ contains(matrix.fixture, 'dart') }}

--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -164,6 +164,11 @@ export class PikeRenderer extends ConvenienceRenderer {
             });
             this.emitTable(table);
         });
+        this.ensureBlankLine();
+        this.emitBlock(
+            [enumName, " ", enumName, "_from_JSON(mixed json)"],
+            () => this.emitLine("return json;"),
+        );
     }
 
     protected emitUnion(u: UnionType, unionName: Name): void {

--- a/test/fixtures/pike/main.pike
+++ b/test/fixtures/pike/main.pike
@@ -3,11 +3,11 @@ import .TopLevel;
 int main (int argc, array(string) argv) {
   Stdio.File f = Stdio.File(argv[1], "r");
 
-  mixed json = Standards.JSON.decode(f.read());
+  mixed json = Standards.JSON.decode(utf8_to_string(f.read()));
   TopLevel tl = TopLevel_from_JSON(json);
   string to_json = Standards.JSON.encode(tl, Standards.JSON.HUMAN_READABLE);
 
-  write(to_json);
+  write(string_to_utf8(to_json));
 
   return 0;
 }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1631,7 +1631,7 @@ export const PikeLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["union"],
+    features: [],
     output: "TopLevel.pmod",
     topLevel: "TopLevel",
     skipJSON: [
@@ -1647,8 +1647,12 @@ export const PikeLanguage: Language = {
         ...skipsIntFloatUnions,
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.
         ...skipsMapValueValidation,
+        "all-of-additional-properties-false.schema",
         "class-with-additional.schema",
+        "const-non-string.schema",
         "multi-type-enum.schema",
+        "optional-any.schema",
+        ...skipsArrayElementValidation,
         ...skipsUntypedUnions,
     ],
     rendererOptions: {},

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1643,8 +1643,6 @@ export const PikeLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        "top-level-enum.schema", // output generated properly, but not a class
-        "keyword-unions.schema", // seems like a problem with deserializing
         // no implicit cast int <-> float in Pike
         ...skipsIntFloatUnions,
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1639,23 +1639,6 @@ export const PikeLanguage: Language = {
         "identifiers.json", // quicktype internal error
         "7eb30.json", // illegal characters in expressions
         "c6cfd.json", // illegal characters in values
-        // all below: Pike's Stdio.File.write() does not support wide strings.
-        "nst-test-suite.json",
-        "0b91a.json",
-        "29f47.json",
-        "337ed.json",
-        "33d2e.json",
-        "458db.json",
-        "6c155.json",
-        "6de06.json",
-        "734ad.json",
-        "8592b.json",
-        "9ac3b.json",
-        "cb0cc.json",
-        "d23d5.json",
-        "dc44f.json",
-        "dec3a.json",
-        "f22f5.json",
     ],
     skipMiscJSON: false,
     skipSchema: [


### PR DESCRIPTION
## Summary

Pike strings distinguish byte strings from wide strings. The fixture currently decodes UTF-8 input as raw bytes and writes Unicode JSON directly to `Stdio.File.write`, which rejects wide strings.

Decode the input bytes with `utf8_to_string` and encode the generated JSON with `string_to_utf8` before writing. This enables 16 existing Unicode-heavy JSON round-trip fixtures.

Production code: 0 lines.

## Validation

- `npm run build`
- `npx biome check test/languages.ts`
- `PATH=/tmp/quicktype-pike-wrapper-round6:$PATH CPUs=1 QUICKTEST=true FIXTURE=pike npm run test:fixtures -- <16 newly enabled inputs>` (16/16 passed under Pike 8.0.1738)
