### PR TITLE
Fix Objective-C scalar and string literal JSON

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -84,11 +84,8 @@ jobs:
                     - fixture: kotlinx,schema-kotlinx
                       runs-on: ubuntu-latest-16-cores
 
-                    # - fixture: objective-c # segfault on compiled test cmd
-                    #   runs-on: macos-latest
-                    # comment-injection-objective-c also hits that runtime
-                    # segfault (the generated .m compiles but ./test crashes
-                    # with SIGSEGV), so it stays out of CI too.
+                    - fixture: objective-c,comment-injection-objective-c
+                      runs-on: macos-latest
 
         name: ${{ matrix.fixture }}
         steps:

--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -50,6 +50,9 @@ import {
 
 type MemoryAttribute = "assign" | "strong" | "copy";
 
+const objectiveCStringEscape = (s: string): string =>
+    stringEscape(s).replace(/\\u0000/g, "\\000");
+
 const DEBUG = false;
 
 export class ObjectiveCRenderer extends ConvenienceRenderer {
@@ -534,7 +537,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
     }
 
     private emitNonClassTopLevelTypedef(t: Type, name: Name): void {
-        const nonPointerTypeName = this.objcType(t)[0];
+        const nonPointerTypeName = this.objcType(t, true)[0];
         this.emitLine("typedef ", nonPointerTypeName, " ", name, ";");
     }
 
@@ -657,7 +660,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                         ";",
                     );
                     this.emitLine(
-                        "NSData *data = [NSJSONSerialization dataWithJSONObject:json options:kNilOptions error:error];",
+                        "NSData *data = [NSJSONSerialization dataWithJSONObject:json options:NSJSONWritingFragmentsAllowed error:error];",
                     );
                     this.emitLine("return *error ? nil : data;");
                 },
@@ -730,7 +733,8 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
         this.forEachClassProperty(t, "none", (name, jsonName) => {
             irregular =
                 irregular ||
-                stringEscape(jsonName) !== this.sourcelikeToString(name);
+                objectiveCStringEscape(jsonName) !==
+                    this.sourcelikeToString(name);
         });
         return irregular;
     }
@@ -764,7 +768,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                     this.indent(() => {
                         this.forEachClassProperty(t, "none", (name, jsonName) =>
                             this.emitLine(
-                                `@"${stringEscape(jsonName)}": @"`,
+                                `@"${objectiveCStringEscape(jsonName)}": @"`,
                                 name,
                                 '",',
                             ),
@@ -927,7 +931,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                                         property.type,
                                     )
                                 ) {
-                                    const key = stringEscape(jsonKey);
+                                    const key = objectiveCStringEscape(jsonKey);
                                     const name = ["_", propertyName];
                                     this.emitLine(
                                         '@"',
@@ -1040,7 +1044,11 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 );
                 this.indent(() => {
                     this.forEachEnumCase(enumType, "none", (_, jsonValue) => {
-                        const value = ['@"', stringEscape(jsonValue), '"'];
+                        const value = [
+                            '@"',
+                            objectiveCStringEscape(jsonValue),
+                            '"',
+                        ];
                         this.emitLine(
                             value,
                             ": [[",
@@ -1065,7 +1073,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 " { return ",
                 instances,
                 '[@"',
-                stringEscape(jsonValue),
+                objectiveCStringEscape(jsonValue),
                 '"]; }',
             );
         });

--- a/test/fixtures/objective-c/main.m
+++ b/test/fixtures/objective-c/main.m
@@ -13,7 +13,7 @@ int main(int argc, const char * argv[]) {
             exit(1);
         }
         
-        NSError *error;
+        NSError *error = nil;
         NSString *inputJSON = [NSString stringWithContentsOfFile:filePath
                                                         encoding:NSUTF8StringEncoding
                                                            error:&error];
@@ -38,4 +38,3 @@ int main(int argc, const char * argv[]) {
     }
     return 0;
 }
-

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1007,15 +1007,10 @@ export const ObjectiveCLanguage: Language = {
         // Almost all strings work except any containing \u001b
         // See https://goo.gl/L8HfUP
         "blns-object.json",
-        // NSJSONSerialization can read but not write top-level primitives
-        "no-classes.json",
         // TODO
         "combinations.json",
-        "combinations1.json",
         // Needs to distinguish between optional and null properties
         "optional-union.json",
-        // Compile error
-        "nst-test-suite.json",
         // Could not convert JSON to model: Error Domain=JSONSerialization Code=-1 "(null)" UserInfo={exception=-[NSNull countByEnumeratingWithState:objects:count:]: unrecognized selector sent to instance 0x7fff807b6ea0}
         "combinations2.json",
         "combinations3.json",


### PR DESCRIPTION
Fixes three independent Objective-C fixture gaps:

- box non-class top-level scalars and allow JSON fragments (`no-classes.json`)
- initialize the fixture NSError pointer (`combinations1.json`)
- emit NUL safely in Objective-C string literals (`nst-test-suite.json`)

The harness initialization also removes the historical runtime segfault, so this restores the `objective-c` and `comment-injection-objective-c` macOS CI fixtures.

Production change: 15 added / 7 deleted lines.

Validation:
- focused 4/4 Objective-C inputs passed
- full QUICKTEST Objective-C suite passed 51/51
- comment-injection Objective-C passed 4/4
- `npm run build` and Biome passed
- workflow YAML parses successfully