### PR TITLE
fix(cjson): propagate nested object parse failures

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -3074,6 +3074,9 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                             jsonName,
                                                             '"));',
                                                         );
+                                                        this.emitLine(
+                                                            `if (NULL == x${level > 0 ? level.toString() : ""}->${this.sourcelikeToString(name)}) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                        );
                                                     } else if (
                                                         property.isOptional ||
                                                         cJSON.isNullable

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -652,7 +652,6 @@ export const CJSONLanguage: Language = {
         "pattern.schema",
         /* Required properties absent are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         "ie-suffix-singularization.schema",
-        "intersection.schema",
         /* Pure Any type not supported (for the current implementation, can be added later, should manage a callback to provide the final application a way to handle it at parsing and creation of cJSON) */
         "any.schema",
         "direct-union.schema",


### PR DESCRIPTION
## Summary

When a generated parser rejects a nested object property, its parent currently stores the returned `NULL` and continues, silently omitting the invalid property during serialization.

Propagate that failed parse by cleaning up the parent and returning `NULL`. This enables `intersection.schema`, including its two invalid nested-object samples.

Production code: 3 added lines (one emitted C statement).

## Validation

- `npm run build`
- `npx biome check packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts test/languages.ts`
- `PATH=/tmp/quicktype-cjson-wrapper:$PATH CPUs=1 FIXTURE=schema-cjson npm run test:fixtures -- test/inputs/schema/intersection.schema` (3 files passed)
