### PR TITLE
Fix Java legacy datetime fractional seconds

### DIFF
--- a/packages/quicktype-core/src/language/Java/DateTimeProvider.ts
+++ b/packages/quicktype-core/src/language/Java/DateTimeProvider.ts
@@ -217,7 +217,7 @@ export class JavaLegacyDateTimeProvider extends JavaDateTimeProvider {
     public timeType = "Date";
 
     public dateTimeJacksonAnnotations: string[] = [
-        '@JsonFormat(pattern = "yyyy-MM-dd\'T\'HH:mm:ssX", timezone = "UTC")',
+        '@JsonFormat(pattern = "yyyy-MM-dd\'T\'HH:mm:ss.SSSX", timezone = "UTC")',
     ];
 
     public dateJacksonAnnotations: string[] = [
@@ -259,6 +259,9 @@ export class JavaLegacyDateTimeProvider extends JavaDateTimeProvider {
         this._renderer.emitBlock(
             "public static Date parseAllDateTimeString(String str)",
             () => {
+                this._renderer.emitLine(
+                    'str = str.replaceFirst("(\\\\.\\\\d{3})\\\\d+", "$1");',
+                );
                 this._renderer.emitBlock(
                     "for (String format : DATE_TIME_FORMATS)",
                     () => {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -275,8 +275,6 @@ export const JavaLanguageWithLegacyDateTime: Language = {
     ],
     skipJSON: [
         ...(JavaLanguage.skipJSON !== undefined ? JavaLanguage.skipJSON : []),
-        "0a358.json", // Expects less strict serialization (optional milliseconds).
-        "337ed.json", // Expects less strict serialization (optional milliseconds).
     ],
     skipMiscJSON: true, // Handles edge cases differently and does not allow optional milliseconds.
     rendererOptions: { "datetime-provider": "legacy" },


### PR DESCRIPTION
## Summary

Java's legacy `SimpleDateFormat` treats every fractional digit as part of the millisecond value, so an input such as `.459583` is parsed as 459583 milliseconds and changes the timestamp. Truncate excess precision to three digits before parsing and include milliseconds in Jackson's output format.

This enables `0a358.json` and `337ed.json` for the legacy datetime fixture while preserving millisecond precision on round-trip.

Production code: 4 added lines, 1 replaced line after formatting.

## Validation

- `npm run build`
- `npx biome check packages/quicktype-core/src/language/Java/DateTimeProvider.ts test/languages.ts`
- `MAVEN_ARGS='-Dmaven.compiler.source=8 -Dmaven.compiler.target=8' CPUs=1 FIXTURE=java-datetime-legacy npm run test:fixtures -- test/inputs/json/misc/0a358.json test/inputs/json/misc/337ed.json test/inputs/json/samples/github-events.json` (3/3 passed; compiler properties only accommodate local JDK 17)
