### PR TITLE
test(swift): report fixture decoding failures

### DIFF
--- a/test/fixtures/swift/main.swift
+++ b/test/fixtures/swift/main.swift
@@ -7,6 +7,11 @@ guard let data = FileHandle(forReadingAtPath: filename)?.readDataToEndOfFile() e
     exit(1)
 }
 
-let obj = try newJSONDecoder().decode(TopLevel.self, from: data)
-let jsonData = try newJSONEncoder().encode(obj)
-FileHandle.standardOutput.write(jsonData)
+do {
+    let obj = try newJSONDecoder().decode(TopLevel.self, from: data)
+    let jsonData = try newJSONEncoder().encode(obj)
+    FileHandle.standardOutput.write(jsonData)
+} catch {
+    fputs("\(error)\n", stderr)
+    exit(1)
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -938,20 +938,6 @@ export const SwiftLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        // This works on macOS, but on Linux one of the failure test cases doesn't fail
-        ...skipsUntypedUnions,
-        "required.schema",
-        // The default-value fail sample also relies on required-property enforcement.
-        "default-value.schema",
-        "multi-type-enum.schema",
-        "intersection.schema",
-        ...skipsMapValueValidation,
-        ...skipsEnumValueValidation.filter(
-            (schema) => schema !== "optional-enum.schema",
-        ),
-        "date-time.schema",
-        "class-with-additional.schema",
-        "vega-lite.schema",
     ],
     rendererOptions: { "support-linux": "true" },
     quickTestRendererOptions: [


### PR DESCRIPTION
## Summary

Uncaught errors in the Swift fixture's top-level code are not reliably surfaced as a nonzero status to the fixture runner. Catch decode/encode errors explicitly, print the diagnostic, and call `exit(1)` so negative schema samples are actually observed.

This enables 17 existing schema fixtures; only the genuinely failing `integer-before-number.schema` remains skipped.

Production code: 0 lines.

## Validation

- `npm run build`
- `npx biome check test/languages.ts`
- `CPUs=2 FIXTURE=schema-swift npm run test:fixtures -- <17 newly enabled schemas>` (17/17 passed, including all positive and negative samples)
