### PR TITLE
Fix Kotlin Jackson numeric union matching

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -26,7 +26,7 @@ export class KotlinJacksonRenderer extends KotlinRenderer {
             (_nullType) => "null",
             (_boolType) => "is BooleanNode",
             (_integerType) => "is IntNode, is LongNode",
-            (_doubleType) => "is DoubleNode",
+            (_doubleType) => "is IntNode, is LongNode, is DoubleNode",
             (_stringType) => "is TextNode",
             (_arrayType) => "is ArrayNode",
             // These could be stricter, but for now we don't allow maps

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1420,9 +1420,6 @@ export const KotlinJacksonLanguage: Language = {
         // https://github.com/cbeust/klaxon/issues/146
         "identifiers.json",
         "simple-identifiers.json",
-        "combinations2.json",
-        "combinations3.json",
-        "combinations4.json",
         "nst-test-suite.json",
         // These should be enabled
         "nbl-stats.json",


### PR DESCRIPTION
## Summary

Jackson represents integral JSON numbers as `IntNode` or `LongNode` even when quicktype inferred a `Double` union member. Accept those node types in the generated double guard, matching Jackson's normal numeric coercion behavior.

This enables `combinations2.json`, `combinations3.json`, and `combinations4.json` for Kotlin/Jackson.

This PR is stacked on #3208 because both edit the adjacent Kotlin/Jackson skip block; its own diff is one production replacement plus three test deletions.

## Validation

- `npm run build`
- `npx biome check packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts test/languages.ts`
- focused Kotlin/Jackson combinations 2–4 (3/3 passed)
- focused `integer-float-union.schema`, `union-int-double.schema`, and `minmax.schema` (3/3 passed)
