### PR TITLE
Fix Go optional collection presence

### DIFF
--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -152,6 +152,10 @@ export class GoRenderer extends ConvenienceRenderer {
 
     private propertyGoType(cp: ClassProperty): Sourcelike {
         const t = cp.type;
+        if (cp.isOptional && (t.kind === "array" || t.kind === "map")) {
+            return ["*", this.goType(t, true)];
+        }
+
         if (t instanceof UnionType && nullableFromUnion(t) === null) {
             return ["*", this.goType(t, true)];
         }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -547,16 +547,9 @@ export const GoLanguage: Language = {
         "simple-identifiers.json",
         "blns-object.json",
         "nst-test-suite.json",
-        // can't differenciate empty array and nothing for optional empty array
-        // (omitempty).
-        "github-events.json",
     ],
     skipMiscJSON: false,
-    skipSchema: [
-        // can't differenciate empty array and nothing for optional empty array
-        // (omitempty).
-        "postman-collection.schema",
-    ],
+    skipSchema: [],
     rendererOptions: {},
     quickTestRendererOptions: [
         // Runs against the expected-output file


### PR DESCRIPTION
## Summary

A non-pointer Go slice or map tagged `omitempty` cannot distinguish an absent optional property from a present empty collection. Render optional collection properties as pointers, preserving that distinction through unmarshalling and re-serialization.

This enables `github-events.json` and `postman-collection.schema`.

Production code: 4 added lines.

## Validation

- `npm run build`
- `npx biome check packages/quicktype-core/src/language/Golang/GolangRenderer.ts test/languages.ts`
- focused `golang` github-events fixture (passed)
- focused `schema-golang` postman-collection fixture, positive and negative samples (passed)
- full Go QUICKTEST, 52/52 passed in the parallel survey worktree
