### PR TITLE
fix(elixir): validate required properties and map values

### DIFF
--- a/.github/workflows/output-diffs.yaml
+++ b/.github/workflows/output-diffs.yaml
@@ -93,12 +93,16 @@ jobs:
                   cache-dependency-path: head-source/package-lock.json
 
             - name: Build base after a cache miss
+              id: base-build
               if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true'
+              continue-on-error: true
               working-directory: base-source
               run: npm ci && npm run build
 
             - name: Generate base snapshot after a cache miss
-              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true'
+              id: base-snapshot
+              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true' && steps.base-build.outcome == 'success'
+              continue-on-error: true
               working-directory: base-source
               env:
                   ALL_FIXTURES: "1"
@@ -108,19 +112,19 @@ jobs:
               run: npm run test:output-snapshot
 
             - name: Save PR-scoped base snapshot after a cache miss
-              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true'
+              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true' && steps.base-snapshot.outcome == 'success'
               uses: actions/cache/save@v4
               with:
                   path: .output-diffs/base
                   key: ${{ env.OUTPUT_SNAPSHOT_CACHE_PREFIX }}-${{ runner.os }}-${{ github.event.pull_request.base.sha }}
 
             - name: Build tested PR merge
-              if: steps.compatibility.outputs.supported == 'true'
+              if: steps.compatibility.outputs.supported == 'true' && (steps.base-cache.outputs.cache-hit == 'true' || steps.base-snapshot.outcome == 'success')
               working-directory: head-source
               run: npm ci && npm run build
 
             - name: Generate tested PR merge snapshot
-              if: steps.compatibility.outputs.supported == 'true'
+              if: steps.compatibility.outputs.supported == 'true' && (steps.base-cache.outputs.cache-hit == 'true' || steps.base-snapshot.outcome == 'success')
               working-directory: head-source
               env:
                   ALL_FIXTURES: "1"
@@ -130,19 +134,20 @@ jobs:
               run: npm run test:output-snapshot
 
             - name: Compare snapshots
-              if: steps.compatibility.outputs.supported == 'true'
+              if: steps.compatibility.outputs.supported == 'true' && (steps.base-cache.outputs.cache-hit == 'true' || steps.base-snapshot.outcome == 'success')
               run: |
                   mkdir -p .output-diffs/result
                   head-source/node_modules/.bin/tsx head-source/script/output-diff.ts compare \
                       .output-diffs/base .output-diffs/head \
                       .output-diffs/result/result.json .output-diffs/result/output.diff
 
-            - name: Write bootstrap result
-              if: steps.compatibility.outputs.supported != 'true'
+            - name: Write unavailable comparison result
+              if: steps.compatibility.outputs.supported != 'true' || (steps.base-cache.outputs.cache-hit != 'true' && steps.base-snapshot.outcome != 'success')
               run: |
                   mkdir -p .output-diffs/result
                   printf '%s\n' '{"version":1,"hasDifferences":false,"files":[],"summary":{"added":0,"changedLines":0,"deleted":0,"deletions":0,"files":0,"insertions":0,"modified":0}}' > .output-diffs/result/result.json
                   : > .output-diffs/result/output.diff
+                  echo "The base commit could not generate an output snapshot, so this comparison is unavailable." >> "$GITHUB_STEP_SUMMARY"
 
             - name: Write comparison metadata
               env:
@@ -151,7 +156,7 @@ jobs:
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   PR_SHA: ${{ github.sha }}
                   PR_URL: ${{ github.event.pull_request.html_url }}
-                  SUPPORTED: ${{ steps.compatibility.outputs.supported }}
+                  SUPPORTED: ${{ steps.compatibility.outputs.supported == 'true' && (steps.base-cache.outputs.cache-hit == 'true' || steps.base-snapshot.outcome == 'success') }}
               run: |
                   node - <<'NODE'
                   const fs = require("node:fs");

--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -13,7 +13,6 @@ import {
     ClassType,
     EnumType,
     MapType,
-    PrimitiveType,
     type Type,
     UnionType,
 } from "../../Type/index.js";
@@ -454,11 +453,11 @@ export class ElixirRenderer extends ConvenienceRenderer {
         return matchType<Sourcelike>(
             t,
             (_anyType) => [],
-            (_nullType) => [],
-            (_boolType) => [],
-            (_integerType) => [],
-            (_doubleType) => [],
-            (_stringType) => [],
+            (_nullType) => [`${mode}_`, name, prefix],
+            (_boolType) => [`${mode}_`, name, prefix],
+            (_integerType) => [`${mode}_`, name, prefix],
+            (_doubleType) => [`${mode}_`, name, prefix],
+            (_stringType) => [`${mode}_`, name, prefix],
             (_arrayType) => [],
             (classType) => [
                 this.nameForNamedTypeWithNamespace(classType),
@@ -545,11 +544,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
                 ")",
             ],
             (mapType) => {
-                const mapValueTypes = [...mapType.values.getChildren()];
-                const mapValueTypesNotPrimitive = mapValueTypes.filter(
-                    (type) => !(type instanceof PrimitiveType),
-                );
-                if (mapValueTypesNotPrimitive.length === 0) {
+                if (mapType.values.kind === "any") {
                     return [primitive];
                 }
 
@@ -560,7 +555,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
                         '"]\n|> Map.new(fn {key, value} -> {key, ',
                         this.nameOfTransformFunction(
                             mapType.values,
-                            jsonName,
+                            name,
                             false,
                         ),
                         "_value(value)} end)",
@@ -568,7 +563,8 @@ export class ElixirRenderer extends ConvenienceRenderer {
                 }
                 if (
                     mapType.values instanceof EnumType ||
-                    mapType.values instanceof ClassType
+                    mapType.values instanceof ClassType ||
+                    (mapType.values.isPrimitive() && !optional)
                 ) {
                     return [
                         'm["',
@@ -576,8 +572,9 @@ export class ElixirRenderer extends ConvenienceRenderer {
                         '"]\n|> Map.new(fn {key, value} -> {key, ',
                         this.nameOfTransformFunction(
                             mapType.values,
-                            jsonName,
+                            name,
                             false,
+                            "_value",
                         ),
                         "(value)} end)",
                     ];
@@ -701,11 +698,10 @@ export class ElixirRenderer extends ConvenienceRenderer {
                 ")",
             ],
             (mapType) => {
-                const mapValueTypes = [...mapType.values.getChildren()];
-                const mapValueTypesNotPrimitive = mapValueTypes.filter(
-                    (type) => !(type instanceof PrimitiveType),
-                );
-                if (mapValueTypesNotPrimitive.length === 0) {
+                if (
+                    mapType.values.kind === "any" ||
+                    mapType.values.isPrimitive()
+                ) {
                     return [expression];
                 }
 
@@ -940,7 +936,15 @@ export class ElixirRenderer extends ConvenienceRenderer {
                         }
                     } else if (p.type.kind === "map") {
                         const mapType = p.type as MapType;
-                        if (mapType.values instanceof UnionType) {
+                        const value = mapType.values;
+                        if (value.isPrimitive() && value.kind !== "any") {
+                            this.emitPatternMatches(
+                                [value],
+                                name,
+                                parentName,
+                                "_value",
+                            );
+                        } else if (mapType.values instanceof UnionType) {
                             const unionType = mapType.values;
                             const typesInUnion = [...unionType.getChildren()];
 

--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -372,12 +372,12 @@ export class ElixirRenderer extends ConvenienceRenderer {
         parentName: Sourcelike,
         suffix = "",
         optional = false,
-        force = false,
+        _force = false,
     ): void {
         this.ensureBlankLine();
 
         let typesToMatch = this.sortAndFilterPatternMatchTypes(types);
-        if (typesToMatch.length < 2 && !force) {
+        if (typesToMatch.length === 0) {
             return;
         }
 
@@ -484,25 +484,26 @@ export class ElixirRenderer extends ConvenienceRenderer {
         optional = false,
     ): Sourcelike {
         const primitive = ['m["', jsonName, '"]'];
+        const checked = ["decode_", name, "(", primitive, ")"];
 
         return matchType<Sourcelike>(
             t,
             (_anyType) => primitive,
-            (_nullType) => primitive,
-            (_boolType) => primitive,
-            (_integerType) => primitive,
-            (_doubleType) => primitive,
-            (_stringType) => primitive,
+            (_nullType) => (optional ? primitive : checked),
+            (_boolType) => (optional ? primitive : checked),
+            (_integerType) => (optional ? primitive : checked),
+            (_doubleType) => (optional ? primitive : checked),
+            (_stringType) => (optional ? primitive : checked),
             (arrayType) => {
                 const arrayElement = arrayType.items;
                 if (arrayElement instanceof ArrayType) {
-                    return primitive;
+                    return optional ? primitive : checked;
                 }
                 if (arrayElement.isPrimitive()) {
-                    return primitive;
+                    return optional ? primitive : checked;
                 }
                 if (arrayElement instanceof MapType) {
-                    return primitive;
+                    return optional ? primitive : checked;
                 }
 
                 if (optional) {
@@ -864,6 +865,14 @@ export class ElixirRenderer extends ConvenienceRenderer {
                 }
 
                 this.forEachClassProperty(c, "none", (name, _jsonName, p) => {
+                    const parentName = this.nameForNamedTypeWithNamespace(c);
+                    if (
+                        (p.type.isPrimitive() || p.type.kind === "array") &&
+                        p.type.kind !== "any" &&
+                        !p.isOptional
+                    ) {
+                        this.emitPatternMatches([p.type], name, parentName);
+                    }
                     if (p.type.kind === "union") {
                         const unionTypes = [...p.type.getChildren()];
                         const unionPrimitiveTypes = unionTypes.filter((type) =>

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1844,7 +1844,9 @@ export const ElixirLanguage: Language = {
 
         // The test incorrectly succeeds due to the emitter being permissive for unions that contain only primitives. A future enhancement
         // for the Elixir emitter could be a user-controlled 'strict' mode that pattern matches even on unions of only primitive types.
-        ...skipsMapValueValidation,
+        ...skipsMapValueValidation.filter(
+            (schema) => schema !== "go-schema-pattern-properties.schema",
+        ),
 
         // The generated top-level type is not emitted as a TopLevel module the fixture can call.
         "recursive-union-flattening.schema",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1526,7 +1526,7 @@ export const PikeLanguage: Language = {
         "const-non-string.schema",
         "multi-type-enum.schema",
         "optional-any.schema",
-        ...skipsArrayElementValidation,
+        "issue2680-top-level-array.schema",
         ...skipsUntypedUnions,
     ],
     rendererOptions: {},

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1842,15 +1842,6 @@ export const ElixirLanguage: Language = {
         // TopLevel before Bar, but this doesn't address the actual problem if for example a pattern match to Bar was in TopLevel.
         "mutually-recursive.schema",
 
-        // Struct keys cannot be enforced at runtime in Elixir and their values will just be set to null.
-        "ie-suffix-singularization.schema",
-        "required.schema",
-        // The default-value fail sample also relies on required-property enforcement.
-        "default-value.schema",
-        "boolean-subschema.schema",
-        "intersection.schema",
-        "optional-any.schema",
-
         // The test incorrectly succeeds due to the emitter being permissive for unions that contain only primitives. A future enhancement
         // for the Elixir emitter could be a user-controlled 'strict' mode that pattern matches even on unions of only primitive types.
         ...skipsMapValueValidation,


### PR DESCRIPTION
## Summary

Generated Elixir class decoders read required primitive and raw-array properties directly from their input map, so wrong-typed values bypassed the existing pattern-match validation helpers. Map properties had the same gap for primitive values.

Emit single-type matchers for required primitive/array properties, route required values through them, and decode primitive map values through dedicated value matchers. This enables seven existing schemas: `ie-suffix-singularization`, `required`, `default-value`, `intersection`, `optional-any`, `boolean-subschema`, and `go-schema-pattern-properties`.

The branch also includes the CI-unblocking Pike/test-workflow commit from #3235; that commit disappears from this diff when #3235 lands.

## Validation

- `npm run build`
- Biome and `git diff --check`
- focused `schema-elixir` run for all seven enabled schemas: 7/7 passed, including positive and negative samples, under Elixir 1.18