### PR TITLE
Fix Zod coercion order in unions

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -141,11 +141,15 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
             (unionType) => {
                 const children = Array.from(unionType.getChildren())
                     // Coercing schemas can accept null, so handle it first.
-                    .sort(
-                        (a, b) =>
-                            Number(b.kind === "null") -
-                            Number(a.kind === "null"),
-                    )
+                    .sort((a, b) => {
+                        const rank = (x: Type): number =>
+                            x.kind === "null"
+                                ? 0
+                                : x.kind === "date-time"
+                                  ? 2
+                                  : 1;
+                        return rank(a) - rank(b);
+                    })
                     .map((type: Type) => this.typeMapTypeFor(type, false));
                 return ["z.union([", ...arrayIntercalate(", ", children), "])"];
             },

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1867,10 +1867,7 @@ export const TypeScriptZodLanguage: Language = {
     topLevel: "TopLevel",
     skipJSON: [],
     skipMiscJSON: false,
-    skipSchema: [
-        // z.coerce.date() serializes back as ISO UTC, not the input string
-        "date-time.schema",
-    ],
+    skipSchema: [],
     rendererOptions: {},
     quickTestRendererOptions: [],
     sourceFiles: ["src/language/TypeScriptZod/index.ts"],


### PR DESCRIPTION
## Summary

`z.coerce.date()` accepts numbers and broad strings. When a date-time alternative appears before exact primitive alternatives in a union, it can greedily convert those values into dates.

Rank null first, ordinary alternatives next, and date-time last when emitting Zod unions. This enables TypeScript Zod's final skipped schema, `date-time.schema`.

Production code: 9 added lines, 5 deleted lines after formatting.

## Validation

- `npm run build`
- `npx biome check packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts test/languages.ts`
- `CPUs=4 QUICKTEST=true FIXTURE=typescript-zod,schema-typescript-zod npm run test:fixtures` (136/136 passed)
