### PR TITLE
test(crystal): reactivate fixtures and enable enum coverage

### DIFF
--- a/.github/workflows/output-diffs.yaml
+++ b/.github/workflows/output-diffs.yaml
@@ -93,12 +93,16 @@ jobs:
                   cache-dependency-path: head-source/package-lock.json
 
             - name: Build base after a cache miss
+              id: base-build
               if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true'
+              continue-on-error: true
               working-directory: base-source
               run: npm ci && npm run build
 
             - name: Generate base snapshot after a cache miss
-              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true'
+              id: base-snapshot
+              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true' && steps.base-build.outcome == 'success'
+              continue-on-error: true
               working-directory: base-source
               env:
                   ALL_FIXTURES: "1"
@@ -108,19 +112,19 @@ jobs:
               run: npm run test:output-snapshot
 
             - name: Save PR-scoped base snapshot after a cache miss
-              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true'
+              if: steps.compatibility.outputs.supported == 'true' && steps.base-cache.outputs.cache-hit != 'true' && steps.base-snapshot.outcome == 'success'
               uses: actions/cache/save@v4
               with:
                   path: .output-diffs/base
                   key: ${{ env.OUTPUT_SNAPSHOT_CACHE_PREFIX }}-${{ runner.os }}-${{ github.event.pull_request.base.sha }}
 
             - name: Build tested PR merge
-              if: steps.compatibility.outputs.supported == 'true'
+              if: steps.compatibility.outputs.supported == 'true' && (steps.base-cache.outputs.cache-hit == 'true' || steps.base-snapshot.outcome == 'success')
               working-directory: head-source
               run: npm ci && npm run build
 
             - name: Generate tested PR merge snapshot
-              if: steps.compatibility.outputs.supported == 'true'
+              if: steps.compatibility.outputs.supported == 'true' && (steps.base-cache.outputs.cache-hit == 'true' || steps.base-snapshot.outcome == 'success')
               working-directory: head-source
               env:
                   ALL_FIXTURES: "1"
@@ -130,19 +134,20 @@ jobs:
               run: npm run test:output-snapshot
 
             - name: Compare snapshots
-              if: steps.compatibility.outputs.supported == 'true'
+              if: steps.compatibility.outputs.supported == 'true' && (steps.base-cache.outputs.cache-hit == 'true' || steps.base-snapshot.outcome == 'success')
               run: |
                   mkdir -p .output-diffs/result
                   head-source/node_modules/.bin/tsx head-source/script/output-diff.ts compare \
                       .output-diffs/base .output-diffs/head \
                       .output-diffs/result/result.json .output-diffs/result/output.diff
 
-            - name: Write bootstrap result
-              if: steps.compatibility.outputs.supported != 'true'
+            - name: Write unavailable comparison result
+              if: steps.compatibility.outputs.supported != 'true' || (steps.base-cache.outputs.cache-hit != 'true' && steps.base-snapshot.outcome != 'success')
               run: |
                   mkdir -p .output-diffs/result
                   printf '%s\n' '{"version":1,"hasDifferences":false,"files":[],"summary":{"added":0,"changedLines":0,"deleted":0,"deletions":0,"files":0,"insertions":0,"modified":0}}' > .output-diffs/result/result.json
                   : > .output-diffs/result/output.diff
+                  echo "The base commit could not generate an output snapshot, so this comparison is unavailable." >> "$GITHUB_STEP_SUMMARY"
 
             - name: Write comparison metadata
               env:
@@ -151,7 +156,7 @@ jobs:
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   PR_SHA: ${{ github.sha }}
                   PR_URL: ${{ github.event.pull_request.html_url }}
-                  SUPPORTED: ${{ steps.compatibility.outputs.supported }}
+                  SUPPORTED: ${{ steps.compatibility.outputs.supported == 'true' && (steps.base-cache.outputs.cache-hit == 'true' || steps.base-snapshot.outcome == 'success') }}
               run: |
                   node - <<'NODE'
                   const fs = require("node:fs");

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -52,6 +52,7 @@ jobs:
                     - javascript-prop-types
                     - ruby,schema-ruby-syntax
                     - php,schema-php
+                    - crystal,schema-crystal
                     - scala3,schema-scala3
                     - scala3-upickle,schema-scala3-upickle
                     - elixir,schema-elixir,graphql-elixir
@@ -65,9 +66,6 @@ jobs:
                     # @schani can you help me understand this fixture?
                     # It looks like it tests 13+ languages?
                     # - graphql
-
-                    # Never tested?
-                    # - crystal
 
                 runs-on: [ubuntu-22.04]
 
@@ -102,6 +100,10 @@ jobs:
               run: |
                   sudo apt-get update
                   sudo apt-get install -y pike8.0-core
+
+            - name: Setup Crystal
+              if: ${{ contains(matrix.fixture, 'crystal') }}
+              uses: crystal-lang/install-crystal@v1
 
             - name: Setup Dart
               if: ${{ contains(matrix.fixture, 'dart') }}

--- a/packages/quicktype-core/src/language/Crystal/CrystalRenderer.ts
+++ b/packages/quicktype-core/src/language/Crystal/CrystalRenderer.ts
@@ -213,7 +213,9 @@ export class CrystalRenderer extends ConvenienceRenderer {
         this.forEachTopLevel(
             "leading",
             (t, name) => this.emitTopLevelAlias(t, name),
-            (t) => this.namedTypeToNameForTopLevel(t) === undefined,
+            (t) =>
+                t.kind === "enum" ||
+                this.namedTypeToNameForTopLevel(t) === undefined,
         );
 
         this.forEachObject(

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1760,7 +1760,7 @@ class CommandSuccessfulLanguageFixture extends LanguageFixture {
 }
 
 export const allFixtures: Fixture[] = [
-    // new JSONFixture(languages.CrystalLanguage),
+    new JSONFixture(languages.CrystalLanguage),
     new JSONFixture(languages.CSharpLanguage),
     new JSONFixture(languages.CSharpLanguageRecords, "csharp-records"),
     new JSONFixture(
@@ -1810,7 +1810,7 @@ export const allFixtures: Fixture[] = [
     new JSONFixture(languages.ElixirLanguage),
     new JSONSchemaJSONFixture(languages.CSharpLanguage),
     new JSONTypeScriptFixture(languages.CSharpLanguage),
-    // new JSONSchemaFixture(languages.CrystalLanguage),
+    new JSONSchemaFixture(languages.CrystalLanguage),
     new JSONSchemaFixture(languages.JSONSchemaLanguage),
     new JSONSchemaFixture(languages.CSharpLanguage),
     new JSONSchemaFixture(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -389,14 +389,11 @@ export const CrystalLanguage: Language = {
         "nst-test-suite.json",
     ],
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         "integer-type.schema", // Crystal integers are Int32.
         // Crystal does not handle enum mapping
         ...skipsEnumValueValidation.filter(
             (schema) => schema !== "optional-enum.schema",
         ),
-        // Crystal does not support top-level primitives
-        "top-level-enum.schema",
         "keyword-unions.schema",
     ],
     skipMiscJSON: false,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -379,7 +379,7 @@ export const CrystalLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["enum", "union", "no-defaults"],
+    features: ["union", "no-defaults"],
     output: "TopLevel.cr",
     topLevel: "TopLevel",
     skipJSON: [
@@ -390,10 +390,6 @@ export const CrystalLanguage: Language = {
     ],
     skipSchema: [
         "integer-type.schema", // Crystal integers are Int32.
-        // Crystal does not handle enum mapping
-        ...skipsEnumValueValidation.filter(
-            (schema) => schema !== "optional-enum.schema",
-        ),
         "keyword-unions.schema",
     ],
     skipMiscJSON: false,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1526,7 +1526,7 @@ export const PikeLanguage: Language = {
         "const-non-string.schema",
         "multi-type-enum.schema",
         "optional-any.schema",
-        ...skipsArrayElementValidation,
+        "issue2680-top-level-array.schema",
         ...skipsUntypedUnions,
     ],
     rendererOptions: {},

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -386,17 +386,11 @@ export const CrystalLanguage: Language = {
         "blns-object.json",
         "identifiers.json",
         "simple-identifiers.json",
-        "bug427.json",
         "nst-test-suite.json",
-        "34702.json",
-        "34702.json",
-        "4961a.json",
-        "32431.json",
-        "68c30.json",
-        "e8b04.json",
     ],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
+        "integer-type.schema", // Crystal integers are Int32.
         // Crystal does not handle enum mapping
         ...skipsEnumValueValidation.filter(
             (schema) => schema !== "optional-enum.schema",


### PR DESCRIPTION
## Summary

Reactivates Crystal JSON and JSON Schema fixtures, adds Crystal to the PR matrix with the official toolchain setup action, removes six stale JSON exclusions, emits the missing top-level enum alias, and correctly declares enum-value validation unsupported so positive enum fixtures can run without scheduling unsupported negative cases.

The reactivated Linux job exposed one existing unsupported case: `integer-type.schema` exceeds Crystal’s generated `Int32` range. That schema remains explicitly skipped; changing all generated integers to `Int64` would create unnecessary output churn.

The branch also includes the CI-unblocking Pike/test-workflow commit from #3235; that commit disappears from this diff when #3235 lands.

Production code: 3 added lines after formatting.

## Validation

- `npm run build`
- Biome, YAML parsing, and `git diff --check`
- complete `QUICKTEST=true FIXTURE=crystal,schema-crystal` run: 136/136 passed under Crystal 1.21.0