### PR TITLE
fix(crystal): emit top-level enum aliases

### DIFF
--- a/packages/quicktype-core/src/language/Crystal/CrystalRenderer.ts
+++ b/packages/quicktype-core/src/language/Crystal/CrystalRenderer.ts
@@ -213,7 +213,9 @@ export class CrystalRenderer extends ConvenienceRenderer {
         this.forEachTopLevel(
             "leading",
             (t, name) => this.emitTopLevelAlias(t, name),
-            (t) => this.namedTypeToNameForTopLevel(t) === undefined,
+            (t) =>
+                t.kind === "enum" ||
+                this.namedTypeToNameForTopLevel(t) === undefined,
         );
 
         this.forEachObject(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -408,14 +408,11 @@ export const CrystalLanguage: Language = {
         "nst-test-suite.json",
     ],
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         "integer-type.schema", // Crystal integers are Int32.
         // Crystal does not handle enum mapping
         ...skipsEnumValueValidation.filter(
             (schema) => schema !== "optional-enum.schema",
         ),
-        // Crystal does not support top-level primitives
-        "top-level-enum.schema",
         "keyword-unions.schema",
     ],
     skipMiscJSON: false,


### PR DESCRIPTION
Emits the missing top-level alias when the inferred type is an enum, enabling `top-level-enum.schema`. Also removes the independently stale `integer-before-number.schema` skip.

Production change: 3 added lines.

Validation:
- `npm run build`
- Biome clean
- top-level enum fixture passed in Crystal 1.21.0
- integer-before-number passed all three files

The keyword-union skip remains: Linux CI showed that case is still broken. Stacked on #3215 so CI exercises the reactivated Crystal fixtures.