### PR TITLE
test(python): enable keyword union schema

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -323,9 +323,7 @@ export const PythonLanguage: Language = {
         "31189.json", // year 0 is out of range
     ],
     skipMiscJSON: false,
-    skipSchema: [
-        "keyword-unions.schema", // Requires more than 255 arguments
-    ],
+    skipSchema: [],
     rendererOptions: {},
     quickTestRendererOptions: [
         // The default is "3.10"; keep the older feature sets covered.


### PR DESCRIPTION
The old 255-argument limitation no longer applies to the generated Python union converter. Remove Python's final schema skip.

Production change: 0 lines.

Validation: focused `schema-python` fixture passed both the positive and expected-failure inputs with current Python/mypy.