### PR TITLE
fix(pike): decode top-level enums

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -61,9 +61,6 @@ jobs:
                     # Partially working
                     # - schema-typescript # TODO Unify with typescript once fixed
 
-                    # Language is too niche / obscure to test easily on ubuntu-22.04
-                    # - pike,schema-pike
-
                     # Not yet started
                     # @schani can you help me understand this fixture?
                     # It looks like it tests 13+ languages?
@@ -83,6 +80,8 @@ jobs:
                       runs-on: ubuntu-latest-16-cores
                     - fixture: kotlinx,schema-kotlinx
                       runs-on: ubuntu-latest-16-cores
+                    - fixture: pike,schema-pike
+                      runs-on: ubuntu-24.04
 
                     # - fixture: objective-c # segfault on compiled test cmd
                     #   runs-on: macos-latest
@@ -100,6 +99,12 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: "8.2"
+
+            - name: Install Pike
+              if: ${{ contains(matrix.fixture, 'pike') }}
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y pike8.0-core
 
             - name: Setup Dart
               if: ${{ contains(matrix.fixture, 'dart') }}

--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -164,6 +164,11 @@ export class PikeRenderer extends ConvenienceRenderer {
             });
             this.emitTable(table);
         });
+        this.ensureBlankLine();
+        this.emitBlock(
+            [enumName, " ", enumName, "_from_JSON(mixed json)"],
+            () => this.emitLine("return json;"),
+        );
     }
 
     protected emitUnion(u: UnionType, unionName: Name): void {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1631,7 +1631,7 @@ export const PikeLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["union"],
+    features: [],
     output: "TopLevel.pmod",
     topLevel: "TopLevel",
     skipJSON: [
@@ -1647,8 +1647,12 @@ export const PikeLanguage: Language = {
         ...skipsIntFloatUnions,
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.
         ...skipsMapValueValidation,
+        "all-of-additional-properties-false.schema",
         "class-with-additional.schema",
+        "const-non-string.schema",
         "multi-type-enum.schema",
+        "optional-any.schema",
+        ...skipsArrayElementValidation,
         ...skipsUntypedUnions,
     ],
     rendererOptions: {},

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1643,8 +1643,6 @@ export const PikeLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        "top-level-enum.schema", // output generated properly, but not a class
-        "keyword-unions.schema", // seems like a problem with deserializing
         // no implicit cast int <-> float in Pike
         ...skipsIntFloatUnions,
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.


### PR DESCRIPTION
Adds the small enum conversion helper expected by the Pike fixture driver, enabling `top-level-enum.schema`. Also removes the independently stale `keyword-unions.schema` skip.

Production change: 5 added lines.

Validation:
- focused top-level enum and keyword-union fixtures passed
- existing `enum.schema` passed all four files
- `npm run build` and Biome passed

Stacked on #3202.