### PR TITLE
test(pike): reactivate runtime fixtures

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -61,9 +61,6 @@ jobs:
                     # Partially working
                     # - schema-typescript # TODO Unify with typescript once fixed
 
-                    # Language is too niche / obscure to test easily on ubuntu-22.04
-                    # - pike,schema-pike
-
                     # Not yet started
                     # @schani can you help me understand this fixture?
                     # It looks like it tests 13+ languages?
@@ -83,6 +80,8 @@ jobs:
                       runs-on: ubuntu-latest-16-cores
                     - fixture: kotlinx,schema-kotlinx
                       runs-on: ubuntu-latest-16-cores
+                    - fixture: pike,schema-pike
+                      runs-on: ubuntu-24.04
 
                     # - fixture: objective-c # segfault on compiled test cmd
                     #   runs-on: macos-latest
@@ -100,6 +99,12 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: "8.2"
+
+            - name: Install Pike
+              if: ${{ contains(matrix.fixture, 'pike') }}
+              run: |
+                  sudo apt-get update
+                  sudo apt-get install -y pike8.0-core
 
             - name: Setup Dart
               if: ${{ contains(matrix.fixture, 'dart') }}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1631,7 +1631,7 @@ export const PikeLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["union"],
+    features: [],
     output: "TopLevel.pmod",
     topLevel: "TopLevel",
     skipJSON: [
@@ -1647,8 +1647,12 @@ export const PikeLanguage: Language = {
         ...skipsIntFloatUnions,
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.
         ...skipsMapValueValidation,
+        "all-of-additional-properties-false.schema",
         "class-with-additional.schema",
+        "const-non-string.schema",
         "multi-type-enum.schema",
+        "optional-any.schema",
+        ...skipsArrayElementValidation,
         ...skipsUntypedUnions,
     ],
     rendererOptions: {},


### PR DESCRIPTION
Restores the Pike JSON and schema fixture group in PR CI using Ubuntu 24.04, where `pike8.0-core` is available.

The reactivated suite exposed Pike’s permissive runtime behavior. The fixture now accurately declares no strict union-validation feature, retains positive union coverage, and skips only unsupported bare-validation cases (required primitive, scalar-array element, and two numeric-const schemas).

Production change: 0 lines.

Validation: build and Biome pass; both surfaced union failures pass with positive samples enabled; two near-complete 136-case sweeps identified the remaining unsupported cases, and the residual focused group passed. A final Docker-backed sweep hit a local container/worktree startup race, not a fixture failure.

Stacked on #3218 (and transitively #3202).