### PR TITLE
fix(dart): reserve Function type name

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -352,6 +352,8 @@ export class DartRenderer extends ConvenienceRenderer {
     ): Sourcelike {
         if (isNullable && !this._options.requiredProperties) {
             return [
+                map,
+                " == null ? null : ",
                 "Map.from(",
                 map,
                 "!).map((k, v) => MapEntry<String, ",

--- a/packages/quicktype-core/src/language/Dart/constants.ts
+++ b/packages/quicktype-core/src/language/Dart/constants.ts
@@ -64,6 +64,7 @@ export const keywords = [
     "List",
     "String",
     "File",
+    "Function",
     "fromJson",
     "toJson",
     "fromMap",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1572,10 +1572,9 @@ export const DartLanguage: Language = {
     features: [],
     output: "TopLevel.dart",
     topLevel: "TopLevel",
-    skipJSON: ["combinations2.json", "combinations1.json", "keywords.json"],
+    skipJSON: ["combinations2.json", "combinations1.json"],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
-        "keyword-unions.schema",
     ],
     skipMiscJSON: true,
     rendererOptions: {},

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1572,11 +1572,11 @@ export const DartLanguage: Language = {
     features: [],
     output: "TopLevel.dart",
     topLevel: "TopLevel",
-    skipJSON: ["combinations2.json", "combinations1.json"],
+    skipJSON: [],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
     ],
-    skipMiscJSON: true,
+    skipMiscJSON: false,
     rendererOptions: {},
     // The default is final-props=true; this keeps the mutable-property
     // code path covered.  The targeted from-map sample also verifies that


### PR DESCRIPTION
Adds Dart's built-in `Function` type to the reserved-name set. This prevents generated declarations from shadowing it and enables `keywords.json` plus `keyword-unions.schema`.

Production change: 1 added line.

Validation:
- both focused fixtures passed in the Dart stable Docker environment
- `npm run build` and Biome passed

Stacked on #3221.