### PR TITLE
fix(dart): preserve nullable maps

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -352,6 +352,8 @@ export class DartRenderer extends ConvenienceRenderer {
     ): Sourcelike {
         if (isNullable && !this._options.requiredProperties) {
             return [
+                map,
+                " == null ? null : ",
                 "Map.from(",
                 map,
                 "!).map((k, v) => MapEntry<String, ",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1572,11 +1572,11 @@ export const DartLanguage: Language = {
     features: [],
     output: "TopLevel.dart",
     topLevel: "TopLevel",
-    skipJSON: ["combinations2.json", "combinations1.json"],
+    skipJSON: [],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
     ],
-    skipMiscJSON: true,
+    skipMiscJSON: false,
     rendererOptions: {},
     // The default is final-props=true; this keeps the mutable-property
     // code path covered.  The targeted from-map sample also verifies that


### PR DESCRIPTION
Avoids calling `Map.from` when an optional map is absent, preserving null instead. This enables `combinations1.json` and `combinations2.json`, leaves Dart with no skipped JSON inputs, and re-enables the complete miscellaneous JSON set.

Production change: 2 added lines.

Validation:
- complete Dart JSON fixture passed 222/222
- complete Dart schema fixture passed 85/85 across the stack
- `npm run build` and Biome passed

Stacked on #3222.