### PR TITLE
fix(elm): strictly decode optional fields

### DIFF
--- a/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
+++ b/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
@@ -465,6 +465,17 @@ export class ElmRenderer extends ConvenienceRenderer {
                         this.decoderNameForProperty(p),
                     );
                     const { reqOrOpt, fallback } = requiredOrOptional(p);
+                    if (reqOrOpt.endsWith("optional")) {
+                        this.emitLine([
+                            '|> Jpipe.custom (optionalField "',
+                            elmStringEscape(jsonName),
+                            '" ',
+                            propDecoder,
+                            fallback,
+                            ")",
+                        ]);
+                        return;
+                    }
                     this.emitLine(
                         "|> ",
                         reqOrOpt,
@@ -723,6 +734,12 @@ import Dict exposing (Dict)`);
 
         this.ensureBlankLine();
         this.emitLine("-- decoders and encoders");
+        this.emitMultiline(`optionalField key decoder fallback =
+    Jdec.dict Jdec.value
+        |> Jdec.andThen (\\m ->
+            case Dict.get key m of
+                Nothing -> Jdec.succeed fallback
+                Just x -> Jdec.decodeValue decoder x |> Result.map Jdec.succeed |> Result.withDefault (Jdec.fail ("Invalid " ++ key)))`);
         this.forEachTopLevel(
             "leading-and-interposing",
             (t: Type, topLevelName: Name) =>

--- a/packages/quicktype-core/src/language/Elm/constants.ts
+++ b/packages/quicktype-core/src/language/Elm/constants.ts
@@ -28,6 +28,7 @@ export const forbiddenNames = [
     "Dict",
     "Maybe",
     "makeNullableEncoder",
+    "optionalField",
     // Parameter names used in generated functions.  Elm 0.19 does not
     // allow a parameter to shadow a top-level definition.
     "x",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -878,14 +878,6 @@ export const ElmLanguage: Language = {
         "simple-ref.schema", // recursion
         "recursive-union-flattening.schema", // recursion
         "rust-cycle-breaker-union.schema", // recursion
-        // elm/json's field decoder uses the JS `in` operator, which finds
-        // inherited Object.prototype members, so an absent "constructor"
-        // property decodes to the object's constructor function.
-        "constructor.schema",
-        "keyword-unions.schema",
-        // The generated decoder accepts invalid union members because all
-        // class properties decode via `Jpipe.optional`.
-        "nested-intersection-union.schema",
     ],
     rendererOptions: {},
     // `list` is the default now; keep the `Array` code path covered.


### PR DESCRIPTION
Decodes optional fields through the object's own-key dictionary before applying their decoder. This avoids JavaScript prototype hits such as `constructor` and stops invalid present values from silently falling back.

Enables `constructor.schema`, `keyword-unions.schema`, and `nested-intersection-union.schema`.

Production change: 18 added lines.

Validation:
- all three focused fixtures passed, including expected failures
- union/name-shadowing regression fixtures passed
- `npm run build` and Biome passed