### PR TITLE
test(crystal): enable enum schema positives

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -398,7 +398,7 @@ export const CrystalLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["enum", "union", "no-defaults"],
+    features: ["union", "no-defaults"],
     output: "TopLevel.cr",
     topLevel: "TopLevel",
     skipJSON: [
@@ -409,10 +409,6 @@ export const CrystalLanguage: Language = {
     ],
     skipSchema: [
         "integer-type.schema", // Crystal integers are Int32.
-        // Crystal does not handle enum mapping
-        ...skipsEnumValueValidation.filter(
-            (schema) => schema !== "optional-enum.schema",
-        ),
         "keyword-unions.schema",
     ],
     skipMiscJSON: false,


### PR DESCRIPTION
Crystal represents enums as strings but does not validate their values. Declare that capability accurately by removing the unsupported `enum` feature, then run the positive samples instead of skipping six whole schema families.

Enables 12 positive files across enum, enum-large, const-non-string, haskell-enum-forbidden, nullable-optional-one-of, and all-of-additional-properties-false.

Production change: 0 lines.

Validation: all six focused schema groups passed with Crystal 1.21.0.

Stacked on #3216.