### PR TITLE
fix(kotlin): support top-level primitives with Klaxon

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -284,6 +284,24 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
         );
     }
 
+    protected emitTopLevelPrimitive(t: PrimitiveType, name: Name): void {
+        const typeName = this.sourcelikeToString(name);
+        const valueType = this.sourcelikeToString(this.kotlinType(t));
+        const parse =
+            t.kind === "integer"
+                ? "json.toLong()"
+                : t.kind === "double"
+                  ? "json.toDouble()"
+                  : `klaxon.parseArray<${valueType}>("[\${json}]")!![0]`;
+        this.emitMultiline(`data class ${typeName}(val value: ${valueType}) {
+    public fun toJson() = klaxon.toJsonString(value)
+
+    companion object {
+        public fun fromJson(json: String) = ${typeName}(${parse})
+    }
+}`);
+    }
+
     protected emitTopLevelMap(t: MapType, name: Name): void {
         const elementType = this.kotlinType(t.values);
         this.emitBlock(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1347,8 +1347,6 @@ export const KotlinLanguage: Language = {
         "unions.json",
         "php-mixed-union.json",
         "nst-test-suite.json",
-        // Klaxon does not support top-level primitives
-        "no-classes.json",
         // These should be enabled
         "nbl-stats.json",
         // TODO Investigate these
@@ -1379,9 +1377,8 @@ export const KotlinLanguage: Language = {
         "direct-union.schema",
         // Some weird name collision
         "keyword-unions.schema",
-        // Klaxon does not support top-level primitives/unions
+        // Klaxon does not support top-level enums/unions
         "top-level-enum.schema",
-        "top-level-primitive.schema",
         "recursive-union-flattening.schema",
         // A top-level array is deserialized without enforcing its element
         // type, so a mistyped element round-trips instead of failing.


### PR DESCRIPTION
Emits a small value wrapper with Klaxon-compatible `fromJson`/`toJson` helpers for primitive top levels. Enables `no-classes.json` and `top-level-primitive.schema`.

Production change: 18 added lines.

Validation:
- both focused Kotlin/Klaxon fixtures passed
- `npm run build` and Biome passed