### PR TITLE
fix(kotlin): support top-level enums with Klaxon

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -256,6 +256,11 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
 
     protected emitTopLevelArray(t: ArrayType, name: Name): void {
         const elementType = this.kotlinType(t.items);
+        const parseType = t.items.kind === "integer" ? "Any" : elementType;
+        const validate =
+            t.items.kind === "integer"
+                ? ".map { when (it) { is Int -> it.toLong(); is Long -> it; else -> throw IllegalArgumentException() } }"
+                : [];
         this.emitBlock(
             [
                 "class ",
@@ -276,8 +281,10 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
                         "public fun fromJson(json: String) = ",
                         name,
                         "(klaxon.parseArray<",
-                        elementType,
-                        ">(json)!!)",
+                        parseType,
+                        ">(json)!!",
+                        validate,
+                        ")",
                     );
                 });
             },

--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -406,6 +406,10 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
 
     protected emitEnumDefinition(e: EnumType, enumName: Name): void {
         this.emitDescription(this.descriptionForType(e));
+        const isTopLevel = iterableSome(
+            this.topLevels,
+            ([_, top]) => top === e,
+        );
 
         this.emitBlock(["enum class ", enumName, "(val value: String)"], () => {
             let count = e.cases.size;
@@ -416,8 +420,20 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
                     --count === 0 ? ";" : ",",
                 );
             });
+            if (isTopLevel) {
+                this.ensureBlankLine();
+                this.emitLine(
+                    "public fun toJson() = klaxon.toJsonString(value)",
+                );
+            }
             this.ensureBlankLine();
             this.emitBlock("companion object", () => {
+                if (isTopLevel) {
+                    this.emitLine(
+                        'public fun fromJson(json: String) = fromValue(klaxon.parseArray<String>("[${json}]")!![0])',
+                    );
+                    this.ensureBlankLine();
+                }
                 this.emitBlock(
                     [
                         "public fun fromValue(value: String): ",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1377,8 +1377,7 @@ export const KotlinLanguage: Language = {
         "direct-union.schema",
         // Some weird name collision
         "keyword-unions.schema",
-        // Klaxon does not support top-level enums/unions
-        "top-level-enum.schema",
+        // Klaxon does not support top-level unions
         "recursive-union-flattening.schema",
         // A top-level array is deserialized without enforcing its element
         // type, so a mistyped element round-trips instead of failing.

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -58,15 +58,6 @@ const skipsMapValueValidation = [
     "unevaluated-properties.schema",
 ];
 
-// The generated deserializer for a top-level array of scalars uses a
-// loosely-typed container (e.g. a raw `List`, an `ArrayList<Long>` whose
-// element type is erased at runtime, or an untyped decoder) that does not
-// enforce the declared element type, so a top-level array whose element has
-// the wrong scalar type (a string where an integer is expected) round-trips
-// instead of failing.  Add any new top-level-array schema whose fail sample
-// relies on rejecting a mistyped element.
-const skipsArrayElementValidation = ["issue2680-top-level-array.schema"];
-
 export type LanguageFeature =
     | "enum"
     | "union"
@@ -1379,9 +1370,6 @@ export const KotlinLanguage: Language = {
         "keyword-unions.schema",
         // Klaxon does not support top-level unions
         "recursive-union-flattening.schema",
-        // A top-level array is deserialized without enforcing its element
-        // type, so a mistyped element round-trips instead of failing.
-        ...skipsArrayElementValidation,
     ],
     skipMiscJSON: false,
     // The default framework is jackson; this fixture deliberately pins


### PR DESCRIPTION
Adds top-level-only Klaxon `fromJson`/`toJson` conveniences to enum declarations, enabling `top-level-enum.schema`.

Production change: 16 added lines.

Validation:
- focused top-level enum fixture passed
- `npm run build` and Biome passed

Stacked on #3226.