### PR TITLE
fix(elixir): distinguish missing nullable fields

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -599,7 +599,9 @@ export class ElixirRenderer extends ConvenienceRenderer {
                     type.isPrimitive(),
                 );
                 if (unionTypes.length === unionPrimitiveTypes.length) {
-                    return ['m["', jsonName, '"]'];
+                    return optional
+                        ? ['m["', jsonName, '"]']
+                        : ['Map.fetch!(m, "', jsonName, '")'];
                 }
 
                 const nullable = nullableFromUnion(unionType);

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1958,7 +1958,6 @@ export const ElixirLanguage: Language = {
 
         // Struct keys cannot be enforced at runtime in Elixir and their values will just be set to null.
         "ie-suffix-singularization.schema",
-        "strict-optional.schema",
         "required.schema",
         // The default-value fail sample also relies on required-property enforcement.
         "default-value.schema",


### PR DESCRIPTION
Uses `Map.fetch!` for required primitive-only union properties, distinguishing an absent field from an explicitly null value. Optional properties retain their existing lookup behavior.

Enables `strict-optional.schema`.

Production change: 3 added / 1 deleted lines.

Validation:
- focused schema fixture passed its positive and expected-failure behavior
- `npm run build` and Biome passed