### PR TITLE
fix(elixir): validate top-level maps

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -1214,8 +1214,22 @@ end`);
                                     this.emitLine("|> Jason.encode!()");
                                 });
                             } else {
+                                if (topLevel instanceof MapType) {
+                                    this.emitLine(
+                                        this.patternMatchClauseDecode(
+                                            topLevel,
+                                            "value",
+                                        ),
+                                    );
+                                    this.ensureBlankLine();
+                                }
+
                                 this.emitBlock("def from_json(json) do", () => {
-                                    this.emitLine("Jason.decode!(json)");
+                                    this.emitLine("json");
+                                    this.emitLine("|> Jason.decode!()");
+                                    if (topLevel instanceof MapType) {
+                                        this.emitLine("|> decode_value()");
+                                    }
                                 });
 
                                 this.ensureBlankLine();

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1970,12 +1970,6 @@ export const ElixirLanguage: Language = {
         // for the Elixir emitter could be a user-controlled 'strict' mode that pattern matches even on unions of only primitive types.
         ...skipsMapValueValidation,
 
-        // A bare top-level map is emitted as a Jason.decode!/encode! pass-through
-        // with no shape validation, so the .fail.json case (a non-object) is not
-        // rejected and round-trips instead of exiting nonzero. Same permissiveness
-        // class as go-schema-pattern-properties above.
-        "empty-object.schema",
-
         // The generated top-level type is not emitted as a TopLevel module the fixture can call.
         "recursive-union-flattening.schema",
 


### PR DESCRIPTION
Routes bare top-level maps through a generated shape guard after Jason decoding, so non-object JSON no longer passes through unchanged.

Enables `empty-object.schema`.

Production change: 15 added / 1 deleted lines.

Validation:
- focused schema fixture passed both positive and expected-failure files
- `npm run build` and Biome passed