### PR TITLE
fix(javascript-prop-types): order nested dependencies

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -232,37 +232,31 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
         const order: number[] = [];
         const mapKey: Name[] = [];
         const mapValue: Sourcelike[][] = [];
+        const find = (value: unknown, found: Name[] = []): Name[] => {
+            if (mapKey.includes(value as Name)) found.push(value as Name);
+            else if (Array.isArray(value))
+                for (const v of value) find(v, found);
+            else if (value !== null && typeof value === "object")
+                for (const v of Object.values(value)) find(v, found);
+            return found;
+        };
         this.forEachObject("none", (type: ObjectType, name: Name) => {
             mapKey.push(name);
             mapValue.push(this.gatherSource(() => this.emitObject(name, type)));
         });
 
-        // order these
-        mapKey.forEach((_, index) => {
-            // assume first
-            let ordinal = 0;
-
-            // pull out all names
-            const source = mapValue[index];
-            const names = source.filter((value) => value as Name);
-
-            // must be behind all these names
-            names.forEach((name) => {
-                const depName = name;
-
-                // find this name's ordinal, if it has already been added
-                order.forEach((orderItem) => {
-                    const depIndex = orderItem;
-                    if (mapKey[depIndex] === depName) {
-                        // this is the index of the dependency, so make sure we come after it
-                        ordinal = Math.max(ordinal, depIndex + 1);
-                    }
-                });
-            });
-
-            // insert index
-            order.splice(ordinal, 0, index);
-        });
+        const pending = mapKey.map((_, index) => index);
+        while (pending.length > 0) {
+            const ready = pending.findIndex((index) =>
+                find(mapValue[index]).every((name) => {
+                    if (name === mapKey[index]) return true;
+                    const dependency = mapKey.indexOf(name);
+                    return dependency < 0 || order.includes(dependency);
+                }),
+            );
+            const at = ready < 0 ? pending.length - 1 : ready;
+            order.push(...pending.splice(at, 1));
+        }
 
         // now emit ordered source
         order.forEach((i) => {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1016,7 +1016,6 @@ export const JavaScriptPropTypesLanguage: Language = {
         "bug790.json", // renderer does not support recursion
         "recursive.json", // renderer does not support recursion
         "spotify-album.json", // renderer does not support recursion
-        "76ae1.json", // renderer does not support recursion
     ],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.


### PR DESCRIPTION
## Summary

The PropTypes renderer tried to order object validators by dependency, but only inspected top-level gathered-source fragments and used source indices as insertion positions. Nested references could therefore capture `undefined` validators even in an acyclic model.

Collect nested `Name` references and topologically emit acyclic validators. If a recursive component cannot be ordered, preserve the renderer’s previous reverse-order fallback. This enables the existing `76ae1.json` fixture without changing its runtime API.

Production code: exactly 20 added lines after formatting.

## Validation

- `npm run build`
- Biome and `git diff --check`
- focused `76ae1.json` fixture passed
- focused recursive `bug427.json` regression passed
- complete `FIXTURE=javascript-prop-types` suite passed: 221/221