### PR TITLE
test(effect-schema): enable resolved schema diffs

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1744,10 +1744,6 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         "7681c.json",
         "127a1.json",
         "26b49.json",
-
-        "bug863.json",
-        "29f47.json",
-        "2df80.json",
     ],
     allowMissingNull: false,
     features: ["enum", "union", "no-defaults"],


### PR DESCRIPTION
## Summary

Remove three stale Effect Schema `skipDiffViaSchema` entries: `bug863.json`, `29f47.json`, and `2df80.json`. Runtime and generated-schema round trips now agree for all three after the recent union-order fixes.

Production code: 0 lines.

## Validation

- focused three-input fixture run passed
- complete `QUICKTEST=true FIXTURE=typescript-effect-schema` suite passed: 51/51