### PR TITLE
Enable schema diffs for C# year-zero dates

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -123,7 +123,7 @@ export const CSharpLanguage: Language = {
         return `dotnet run -p:CheckEolTargetFramework=false -- "${sample}"`;
     },
     diffViaSchema: true,
-    skipDiffViaSchema: ["31189.json", "34702.json"],
+    skipDiffViaSchema: ["34702.json"],
     allowMissingNull: false,
     features: [
         "enum",
@@ -175,7 +175,7 @@ export const CSharpLanguageSystemTextJson: Language = {
         return `dotnet run -p:CheckEolTargetFramework=false -- "${sample}"`;
     },
     diffViaSchema: true,
-    skipDiffViaSchema: ["31189.json", "34702.json"],
+    skipDiffViaSchema: ["34702.json"],
     allowMissingNull: false,
     features: [
         "enum",


### PR DESCRIPTION
The year-zero date inference fix now keeps `31189.json` consistent whether C# code is generated directly from JSON or through inferred JSON Schema. Remove the stale schema-diff exclusions for both C# backends; the records fixture inherits the Newtonsoft setting, so this strengthens three fixture variants.

Validation:
- `DOTNET_ROLL_FORWARD=Major CPUs=3 FIXTURE=csharp,csharp-records,csharp-SystemTextJson npm run test:fixtures -- test/inputs/json/misc/31189.json`
- `npx biome check test/languages.ts`
- `git diff --check`