### PR TITLE
Enable Ruby schema diff for nbl-stats

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -416,7 +416,6 @@ export const RubyLanguage: Language = {
         "bug863.json",
         "kitchen-sink.json",
         "github-events.json",
-        "nbl-stats.json",
         "reddit.json",
         "00c36.json",
         "050b0.json",


### PR DESCRIPTION
The recent Ruby union lookup fix also made `nbl-stats.json` generate identical code directly from JSON and through inferred JSON Schema. Remove the stale diff exclusion so the existing runtime fixture now checks both generation paths.

Validation:
- `PATH=/tmp/quicktype-r7-ruby:$PATH CPUs=1 QUICKTEST=true FIXTURE=ruby npm run test:fixtures -- test/inputs/json/priority/nbl-stats.json` (Ruby 3.2 Docker wrapper)
- `npx biome check test/languages.ts`
- `git diff --check`