### PR TITLE
Propagate CJSON array item parse failures

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -2573,6 +2573,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                                                         ?.cjsonType ===
                                                                                         "cJSON_Union"
                                                                                 ) {
+                                                                                    const item = `item${child_level}`;
                                                                                     if (
                                                                                         cJSON
                                                                                             .items
@@ -2584,15 +2585,28 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                                                         );
                                                                                     }
                                                                                     this.emitLine(
-                                                                                        "list_add_tail(x",
-                                                                                        child_level.toString(),
-                                                                                        ", ",
+                                                                                        cJSON
+                                                                                            .items
+                                                                                            ?.cType,
+                                                                                        " * ",
+                                                                                        item,
+                                                                                        " = ",
                                                                                         cJSON
                                                                                             .items
                                                                                             ?.getValue,
                                                                                         "(e",
                                                                                         child_level.toString(),
-                                                                                        "), sizeof(",
+                                                                                        ");",
+                                                                                    );
+                                                                                    this.emitLine(
+                                                                                        `if (NULL == ${item}) { x${level > 0 ? level.toString() : ""}->${this.sourcelikeToString(name)} = x${child_level}; cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                                                    );
+                                                                                    this.emitLine(
+                                                                                        "list_add_tail(x",
+                                                                                        child_level.toString(),
+                                                                                        ", ",
+                                                                                        item,
+                                                                                        ", sizeof(",
                                                                                         cJSON
                                                                                             .items
                                                                                             ?.cType,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -593,7 +593,6 @@ export const CJSONLanguage: Language = {
         "optional-constraints.schema",
         "pattern.schema",
         /* Required properties absent are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
-        "ie-suffix-singularization.schema",
         /* Pure Any type not supported (for the current implementation, can be added later, should manage a callback to provide the final application a way to handle it at parsing and creation of cJSON) */
         "any.schema",
         "direct-union.schema",


### PR DESCRIPTION
CJSON object parsers already return `NULL` for missing required properties, but array decoding passed that failed result directly to `list_add_tail`. Parse each object/union element into a temporary, clean up the enclosing object on failure, and only append successful elements.

This enables the positive and expected-failure samples for `ie-suffix-singularization.schema`. Production diff: 18 added lines.

Validation:
- `npm run build`
- `PATH=<direct valgrind wrapper> CPUs=1 FIXTURE=schema-cjson npm run test:fixtures -- test/inputs/schema/ie-suffix-singularization.schema`
- `PATH=<direct valgrind wrapper> CPUs=4 QUICKTEST=true FIXTURE=cjson npm run test:fixtures` (55/55)
- `npx biome check packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts test/languages.ts`
- `git diff --check`