### PR TITLE
Enable PHP empty object schema fixture

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1191,8 +1191,6 @@ I havea no idea how to encode these tests correctly.
         "nst-test-suite.json",
     ],
     skipSchema: [
-        // The renderer does not support a bare top-level map.
-        "empty-object.schema",
         "integer-before-number.schema", // Python-specific union-order regression.
     ],
     skipMiscJSON: false,


### PR DESCRIPTION
The PHP fixture driver now has an explicit path for bare top-level maps, so the old `empty-object.schema` exclusion is stale. Enable both its positive object sample and negative array sample.

Validation:
- `PATH=<PHP 8.2 Docker wrapper> CPUs=1 FIXTURE=schema-php npm run test:fixtures -- test/inputs/schema/empty-object.schema`
- `npx biome check test/languages.ts`
- `git diff --check`