### PR TITLE
Use Int64 for Crystal integers

### DIFF
--- a/packages/quicktype-core/src/language/Crystal/CrystalRenderer.ts
+++ b/packages/quicktype-core/src/language/Crystal/CrystalRenderer.ts
@@ -89,7 +89,7 @@ export class CrystalRenderer extends ConvenienceRenderer {
             (_nullType) =>
                 maybeAnnotated(withIssues, nullTypeIssueAnnotation, "Nil"),
             (_boolType) => "Bool",
-            (_integerType) => "Int32",
+            (_integerType) => "Int64",
             (_doubleType) => "Float64",
             (_stringType) => "String",
             (arrayType) => [

--- a/packages/quicktype-core/src/language/Crystal/language.ts
+++ b/packages/quicktype-core/src/language/Crystal/language.ts
@@ -1,5 +1,5 @@
 import type { RenderContext } from "../../Renderer.js";
-import { INT32_RANGE, type IntegerRange } from "../../support/IntegerRange.js";
+import { INT64_RANGE, type IntegerRange } from "../../support/IntegerRange.js";
 import { TargetLanguage } from "../../TargetLanguage.js";
 
 import { CrystalRenderer } from "./CrystalRenderer.js";
@@ -17,9 +17,9 @@ export class CrystalTargetLanguage extends TargetLanguage<
         super(crystalLanguageConfig);
     }
 
-    // The Crystal renderer emits `Int32` for inferred integers.
+    // The Crystal renderer emits `Int64` for inferred integers.
     public getSupportedIntegerRange(): IntegerRange | null {
-        return INT32_RANGE;
+        return INT64_RANGE;
     }
 
     protected makeRenderer(renderContext: RenderContext): CrystalRenderer {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1191,8 +1191,6 @@ I havea no idea how to encode these tests correctly.
         "nst-test-suite.json",
     ],
     skipSchema: [
-        // The renderer does not support a bare top-level map.
-        "empty-object.schema",
         "integer-before-number.schema", // Python-specific union-order regression.
     ],
     skipMiscJSON: false,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -388,10 +388,7 @@ export const CrystalLanguage: Language = {
         "simple-identifiers.json",
         "nst-test-suite.json",
     ],
-    skipSchema: [
-        "integer-type.schema", // Crystal integers are Int32.
-        "keyword-unions.schema",
-    ],
+    skipSchema: ["keyword-unions.schema"],
     skipMiscJSON: false,
     rendererOptions: {},
     quickTestRendererOptions: [],

--- a/test/unit/integer-range-inference.test.ts
+++ b/test/unit/integer-range-inference.test.ts
@@ -16,7 +16,6 @@ import { describe, expect, test } from "vitest";
 
 import {
     INT16_RANGE,
-    INT32_RANGE,
     INT64_RANGE,
     InputData,
     type IntegerRange,
@@ -130,8 +129,8 @@ function rangeForLanguage(lang: LanguageName): IntegerRange | null {
 }
 
 describe("language-declared integer ranges", () => {
-    test("Crystal renders integers as Int32, so its range is int32", () => {
-        expect(rangeForLanguage("crystal")).toEqual(INT32_RANGE);
+    test("Crystal renders integers as Int64, so its range is int64", () => {
+        expect(rangeForLanguage("crystal")).toEqual(INT64_RANGE);
     });
 
     test("Elm's Int is a JavaScript number at runtime", () => {
@@ -169,14 +168,14 @@ describe("streaming inference of numbers at the integer-range boundary", () => {
         expect(lines).toMatch(/Smaller\s+\*?float64/);
     });
 
-    test("Crystal: whole numbers beyond Int32 become Float64", async () => {
+    test("Crystal: whole numbers inside Int64 remain integers", async () => {
         const lines = await streamedLinesForJSON(
             "crystal",
             '{"fits": 2147483647, "overflows": 2147483648}',
             rangeForLanguage("crystal"),
         );
-        expect(lines).toMatch(/fits.*Int32/);
-        expect(lines).toMatch(/overflows.*Float64/);
+        expect(lines).toMatch(/fits.*Int64/);
+        expect(lines).toMatch(/overflows.*Int64/);
     });
 
     test("Python: arbitrary-precision integers never overflow to float", async () => {


### PR DESCRIPTION
Crystal currently rendered every JSON integer as `Int32`, which rejected valid inputs above 2,147,483,647 or below -2,147,483,648. Use `Int64` and advertise the matching `INT64_RANGE` during inference, so generated types and inference agree. This enables `integer-type.schema` and updates the focused range regression test.

Production diff: 4 added / 4 deleted lines.

Validation:
- `npm run build`
- `npx vitest run test/unit/integer-range-inference.test.ts` (16/16)
- `PATH=<Crystal 1.21 Docker wrapper> CPUs=1 FIXTURE=schema-crystal npm run test:fixtures -- test/inputs/schema/integer-type.schema`
- `PATH=<Crystal 1.21 Docker wrapper> CPUs=4 QUICKTEST=true FIXTURE=crystal,schema-crystal npm run test:fixtures` (136/136 before the inference-range alignment)
- Biome and `git diff --check`