### PR TITLE
Reserve Crystal to_json method name

### DIFF
--- a/packages/quicktype-core/src/language/Crystal/constants.ts
+++ b/packages/quicktype-core/src/language/Crystal/constants.ts
@@ -127,6 +127,7 @@ export const keywords = [
     "true",
     "type",
     "typeof",
+    "to_json",
     "uninitialized",
     "union",
     "unless",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -388,7 +388,7 @@ export const CrystalLanguage: Language = {
         "simple-identifiers.json",
         "nst-test-suite.json",
     ],
-    skipSchema: ["keyword-unions.schema"],
+    skipSchema: [],
     skipMiscJSON: false,
     rendererOptions: {},
     quickTestRendererOptions: [],


### PR DESCRIPTION
A JSON property named `to_json` currently generates an accessor that shadows `JSON::Serializable#to_json`, so the fixture driver prints the property value instead of serialized JSON. Reserve that method name so the property is renamed while retaining its JSON key.

This enables both `keyword-unions.schema` samples. Production diff: one added line.

Validation:
- `npm run build`
- `PATH=<Crystal 1.21 Docker wrapper> CPUs=1 FIXTURE=schema-crystal npm run test:fixtures -- test/inputs/schema/keyword-unions.schema`
- `PATH=<Crystal 1.21 Docker wrapper> CPUs=1 QUICKTEST=true FIXTURE=crystal npm run test:fixtures -- test/inputs/json/priority/keywords.json`
- `npx biome check packages/quicktype-core/src/language/Crystal/constants.ts test/languages.ts`
- `git diff --check`