### PR TITLE
Enable Swift runtime coverage for blns-object

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -823,6 +823,7 @@ export const SwiftLanguage: Language = {
     diffViaSchema: true,
     skipDiffViaSchema: [
         "bug427.json",
+        "blns-object.json",
         "github-events.json",
         "keywords.json",
         "null-safe.json",
@@ -850,8 +851,6 @@ export const SwiftLanguage: Language = {
     output: "quicktype.swift",
     topLevel: "TopLevel",
     skipJSON: [
-        // This at least is keeping blns-object from working: https://bugs.swift.org/browse/SR-6314
-        "blns-object.json",
         // Doesn't seem to work on Linux, works on MacOS
         "nst-test-suite.json",
     ],


### PR DESCRIPTION
Swift now compiles and round-trips `blns-object.json`; only its direct-JSON versus schema-generated property naming still differs. Move the fixture from `skipJSON` to `skipDiffViaSchema` so the real Swift runtime is covered while retaining the narrowly necessary generation-diff exclusion.

Validation:
- `CPUs=1 QUICKTEST=true FIXTURE=swift npm run test:fixtures -- test/inputs/json/priority/blns-object.json`
- `npx biome check test/languages.ts`
- `git diff --check`