### PR TITLE
Enable Swift integer-before-number schema fixture

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -856,9 +856,7 @@ export const SwiftLanguage: Language = {
         "nst-test-suite.json",
     ],
     skipMiscJSON: false,
-    skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
-    ],
+    skipSchema: [],
     rendererOptions: { "support-linux": "true" },
     quickTestRendererOptions: [
         { "support-linux": "false" },


### PR DESCRIPTION
Swift now handles the integer-before-number union-order regression correctly. Remove its final schema exclusion so all three samples, including the expected failure, run in the normal Swift schema fixture.

Validation:
- `CPUs=1 FIXTURE=schema-swift npm run test:fixtures -- test/inputs/schema/integer-before-number.schema`
- `npx biome check test/languages.ts`
- `git diff --check`