### PR TITLE
Enable Pike integer-before-number schema fixture

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1482,7 +1482,6 @@ export const PikeLanguage: Language = {
     ],
     skipMiscJSON: false,
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         // no implicit cast int <-> float in Pike
         ...skipsIntFloatUnions,
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.


### PR DESCRIPTION
The `integer-before-number.schema` exclusion is stale for Pike. Both samples applicable to Pike compile and round-trip; the union-negative sample remains correctly unscheduled because Pike does not declare the union-validation feature.

Validation:
- `PATH=<Pike 8.0 Docker wrapper> CPUs=1 FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/integer-before-number.schema`
- `npx biome check test/languages.ts`
- `git diff --check`