### PR TITLE
Add Klaxon top-level union JSON overload

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -527,6 +527,10 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
         maybeNull: PrimitiveType | null,
         unionName: Name,
     ): void {
+        const isTopLevel = iterableSome(
+            this.topLevels,
+            ([_, top]) => top === u,
+        );
         this.ensureBlankLine();
         this.emitLine(
             "public fun toJson(): String = klaxon.toJsonString(when (this) {",
@@ -546,6 +550,14 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
         this.emitLine("})");
         this.ensureBlankLine();
         this.emitBlock("companion object", () => {
+            if (isTopLevel) {
+                this.emitLine(
+                    "public fun fromJson(json: String): ",
+                    unionName,
+                    " = fromJson(JsonValue(Parser().parse(StringBuilder(json)), null, null, klaxon))",
+                );
+                this.ensureBlankLine();
+            }
             this.emitLine(
                 "public fun fromJson(jv: JsonValue): ",
                 unionName,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1252,7 +1252,6 @@ export const KotlinLanguage: Language = {
         "af2d1.json",
     ],
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         // Very weird - the types are correct, but it can (de)serialize the string,
         // which is not represented in the types (implicit-class-array-union);
         // class-map-union: KlaxonException: Couldn't find a suitable constructor for class UnionValue to initialize with {}
@@ -1276,8 +1275,6 @@ export const KotlinLanguage: Language = {
         "direct-union.schema",
         // Some weird name collision
         "keyword-unions.schema",
-        // Klaxon does not support top-level unions
-        "recursive-union-flattening.schema",
     ],
     skipMiscJSON: false,
     // The default framework is jackson; this fixture deliberately pins


### PR DESCRIPTION
Klaxon-generated top-level unions only expose `fromJson(JsonValue)`, unlike every other generated top-level form and unlike the documented/fixture API. Add a string overload only for unions that are actual top levels; it parses the root value into Klaxon's `JsonValue` and delegates to the existing validated union decoder.

This enables `integer-before-number.schema` (three samples) and `recursive-union-flattening.schema`. `direct-union.schema` remains skipped because it has a separate nested constructor limitation. Production diff: 12 added lines.

Validation:
- `npm run build`
- focused two-schema fixture (4 files total)
- `CPUs=4 QUICKTEST=true FIXTURE=schema-kotlin npm run test:fixtures` (85/85)
- Biome and `git diff --check`