### PR TITLE
Enable three Kotlin/Jackson schema fixtures

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1318,10 +1318,6 @@ export const KotlinJacksonLanguage: Language = {
     ],
     skipSchema: [
         "implicit-class-array-union.schema",
-        // IllegalArgumentException
-        "accessors.schema",
-        "description.schema",
-        "union-list.schema",
         // KlaxonException: Couldn't find a suitable constructor for class UnionValue to initialize with {}
         "direct-union.schema",
         "keyword-unions.schema",


### PR DESCRIPTION
The Kotlin/Jackson exclusions for `accessors.schema`, `description.schema`, and `union-list.schema` are stale. All three now compile and round-trip; `union-list` exercises three inputs. Remove only those exclusions, retaining the neighboring failures that still reproduce.

Validation:
- `CPUs=3 FIXTURE=schema-kotlin-jackson npm run test:fixtures -- test/inputs/schema/accessors.schema test/inputs/schema/description.schema test/inputs/schema/union-list.schema`
- `npx biome check test/languages.ts`
- `git diff --check`