### PR TITLE
Reactivate Objective-C schema fixtures

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -81,7 +81,7 @@ jobs:
                     - fixture: pike,schema-pike
                       runs-on: ubuntu-24.04
 
-                    - fixture: objective-c,comment-injection-objective-c
+                    - fixture: objective-c,schema-objective-c,comment-injection-objective-c
                       runs-on: macos-latest
 
         name: ${{ matrix.fixture }}

--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -1308,10 +1308,10 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
             this.emitMultiline(`static id map(id collection, id (^f)(id value)) {
 	id result = nil;
 	if ([collection isKindOfClass:NSArray.class]) {
-			result = [NSMutableArray arrayWithCapacity:[collection count]];
+			result = [NSMutableArray arrayWithCapacity:[(NSArray *)collection count]];
 			for (id x in collection) [result addObject:f(x)];
 	} else if ([collection isKindOfClass:NSDictionary.class]) {
-			result = [NSMutableDictionary dictionaryWithCapacity:[collection count]];
+			result = [NSMutableDictionary dictionaryWithCapacity:[(NSDictionary *)collection count]];
 			for (id key in collection) [result setObject:f([collection objectForKey:key]) forKey:key];
 	}
 	return result;

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1841,6 +1841,7 @@ export const allFixtures: Fixture[] = [
     new JSONSchemaFixture(languages.PHPLanguage),
     new JSONSchemaFixture(languages.ElmLanguage),
     new JSONSchemaFixture(languages.SwiftLanguage),
+    new JSONSchemaFixture(languages.ObjectiveCLanguage),
     new JSONSchemaFixture(languages.TypeScriptLanguage),
     new JSONSchemaFixture(languages.TypeScriptZodLanguage),
     new JSONSchemaFixture(languages.TypeScriptEffectSchemaLanguage),

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -898,7 +898,7 @@ export const ObjectiveCLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["enum", "no-defaults"],
+    features: [],
     output: "QTTopLevel.m",
     topLevel: "QTTopLevel",
     skipJSON: [
@@ -915,7 +915,18 @@ export const ObjectiveCLanguage: Language = {
         "combinations4.json",
     ],
     skipMiscJSON: false,
-    skipSchema: ["integer-before-number.schema"], // Python-specific union-order regression.
+    skipSchema: [
+        "boolean-subschema.schema",
+        "direct-union.schema",
+        "empty-object.schema",
+        "go-schema-pattern-properties.schema",
+        "integer-before-number.schema",
+        "issue2680-top-level-array.schema",
+        "optional-any.schema",
+        "recursive-union-flattening.schema",
+        "top-level-enum.schema",
+        "union.schema",
+    ],
     rendererOptions: { functions: "true" },
     quickTestRendererOptions: [],
     sourceFiles: ["src/language/Objective-C/index.ts"],


### PR DESCRIPTION
Objective-C schema coverage was not registered. Enabling it exposed a compiler ambiguity when a generated model also declares `count`: the helper receives `id`, so Clang sees multiple possible `count` selectors under `-Werror`. Cast the already type-checked collection to NSArray/NSDictionary before asking for its count.

This registers and routes `schema-objective-c` in CI, enables all currently supported schemas, and leaves explicit skips for the independently unsupported top-level/validation cases. Enum/no-defaults failure features are removed because the renderer does not enforce them; positive enum coverage still runs.

Production diff: 2 added lines / 2 replaced lines.

Validation:
- `npm run build`
- Biome and `git diff --check`
- `ALL_FIXTURES=1 CPUs=4 FIXTURE=schema-objective-c npm run test:fixtures` (all enabled schemas)