### PR TITLE
Validate Objective-C top-level containers

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -632,6 +632,24 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                     this.emitLine(
                         "id json = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:error];",
                     );
+                    const container =
+                        t instanceof ArrayType ? "NSArray" : "NSDictionary";
+                    if (t instanceof ArrayType || t instanceof MapType) {
+                        this.emitLine(
+                            "if (![json isKindOfClass:",
+                            container,
+                            '.class]) [NSException raise:@"Invalid JSON" format:@"Expected ',
+                            container,
+                            '."];',
+                        );
+                    }
+                    if (t instanceof ArrayType && t.items.isPrimitive()) {
+                        this.emitLine(
+                            "for (id item in json) if (![item isKindOfClass:",
+                            this.jsonType(t.items)[0],
+                            '.class]) [NSException raise:@"Invalid JSON" format:@"Invalid array item."];',
+                        );
+                    }
                     this.emitLine(
                         "return *error ? nil : ",
                         this.fromDynamicExpression(t, "json"),

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -917,9 +917,7 @@ export const ObjectiveCLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         "boolean-subschema.schema",
-        "empty-object.schema",
         "go-schema-pattern-properties.schema",
-        "issue2680-top-level-array.schema",
         "optional-any.schema",
     ],
     rendererOptions: { functions: "true" },


### PR DESCRIPTION
Stacked on #3251.

The Objective-C top-level JSON helper accepted the wrong container kind and primitive arrays with mistyped elements. Validate the decoded Foundation container before converting it, and validate primitive array items against their expected Foundation JSON class.

This enables the positive/negative `empty-object.schema` and `issue2680-top-level-array.schema` fixtures.

Production diff: 18 added lines.

Validation: build, Biome, diff check, and the complete enabled `schema-objective-c` fixture.