### PR TITLE
Emit helpers for Elixir top-level unions

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -1229,6 +1229,13 @@ end`);
                                     this.emitLine("|> Jason.encode!()");
                                 });
                             } else {
+                                if (topLevel instanceof UnionType) {
+                                    this.emitPatternMatches(
+                                        [...topLevel.getChildren()],
+                                        "value",
+                                        name,
+                                    );
+                                }
                                 if (topLevel instanceof MapType) {
                                     this.emitLine(
                                         this.patternMatchClauseDecode(
@@ -1242,7 +1249,10 @@ end`);
                                 this.emitBlock("def from_json(json) do", () => {
                                     this.emitLine("json");
                                     this.emitLine("|> Jason.decode!()");
-                                    if (topLevel instanceof MapType) {
+                                    if (
+                                        topLevel instanceof MapType ||
+                                        topLevel instanceof UnionType
+                                    ) {
                                         this.emitLine("|> decode_value()");
                                     }
                                 });
@@ -1250,13 +1260,20 @@ end`);
                                 this.ensureBlankLine();
 
                                 this.emitBlock("def to_json(data) do", () => {
-                                    this.emitLine("Jason.encode!(data)");
+                                    if (topLevel instanceof UnionType) {
+                                        this.emitLine("data |> encode_value()");
+                                        this.emitLine("|> Jason.encode!()");
+                                    } else {
+                                        this.emitLine("Jason.encode!(data)");
+                                    }
                                 });
                             }
                         },
                     );
                 },
-                (t) => this.namedTypeToNameForTopLevel(t) === undefined,
+                (t) =>
+                    t instanceof UnionType ||
+                    this.namedTypeToNameForTopLevel(t) === undefined,
             );
         }
     }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1780,7 +1780,6 @@ export const ElixirLanguage: Language = {
     ],
     skipMiscJSON: false,
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         // The error occurs because a guard clause that references TopLevel is compiled before TopLevel itself. To fix this, put
         // TopLevel before Bar, but this doesn't address the actual problem if for example a pattern match to Bar was in TopLevel.
         "mutually-recursive.schema",
@@ -1790,9 +1789,6 @@ export const ElixirLanguage: Language = {
         ...skipsMapValueValidation.filter(
             (schema) => schema !== "go-schema-pattern-properties.schema",
         ),
-
-        // The generated top-level type is not emitted as a TopLevel module the fixture can call.
-        "recursive-union-flattening.schema",
 
         // A top-level array is deserialized without enforcing its element
         // type, so a mistyped element round-trips instead of failing.


### PR DESCRIPTION
Elixir emits no module for union declarations, but named top-level unions were also excluded from the generic top-level wrapper pass. The documented `TopLevel.from_json/1` API therefore did not exist.

Emit the wrapper for top-level unions, generate decode/encode pattern matches for their members, and route parsed/serialized values through those checks. This enables `integer-before-number.schema` (including rejection of a string) and `recursive-union-flattening.schema`; the already-enabled `direct-union.schema` remains green.

Production diff: exactly 20 added lines.

Validation:
- `npm run build`
- Biome and `git diff --check`
- focused `schema-elixir` run for integer-before-number, recursive-union-flattening, and direct-union (3/3)