### PR TITLE
Fix PropTypes enum validators

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -114,8 +114,14 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
             (_mapType) => "PropTypes.object",
             (_enumType) => panic("Should already be handled."),
             (unionType) => {
+                const isNullableEnum =
+                    unionType.findMember("enum") !== undefined &&
+                    unionType.findMember("null") !== undefined;
                 const children = Array.from(unionType.getChildren()).map(
-                    (type: Type) => this.typeMapTypeFor(type, false),
+                    (type: Type) =>
+                        isNullableEnum && type.kind === "null"
+                            ? "PropTypes.oneOf([null])"
+                            : this.typeMapTypeFor(type, false),
                 );
                 return [
                     "PropTypes.oneOfType([",
@@ -211,9 +217,9 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
             this.forEachEnumCase(
                 enumType,
                 "none",
-                (name: Name, _jsonName, _position) => {
+                (_name: Name, jsonName, _position) => {
                     options.push("'");
-                    options.push(name);
+                    options.push(utf16StringEscape(jsonName));
                     options.push("'");
                     options.push(", ");
                 },
@@ -223,7 +229,7 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
             this.emitLine([
                 "const _",
                 enumName,
-                " = PropTypes.oneOfType([",
+                " = PropTypes.oneOf([",
                 ...options,
                 "]);",
             ]);

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -990,7 +990,7 @@ export const JavaScriptPropTypesLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: false,
-    features: ["union"],
+    features: ["enum", "union"],
     output: "toplevel.js",
     topLevel: "TopLevel",
     skipJSON: ["bug790.json"], // renderer does not support recursion


### PR DESCRIPTION
Emit PropTypes.oneOf with raw JSON enum values instead of passing renamed identifiers to oneOfType. For unions that contain both an enum and null, use a null-only checker for that null member; unrelated nullable unions keep their existing behavior.

This enables enum validation coverage for all seven schema families, including enum.schema; no existing fixture is skipped.

Production diff: 10 added lines.

Validation:
- npm run build
- Biome on the renderer and language configuration
- full 140-case JavaScript PropTypes quick fixture
- enum.schema runs all five positive and negative samples