### PR TITLE
Fix Kotlin/Jackson leading camel-case JSON names

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -225,7 +225,7 @@ import com.fasterxml.jackson.module.kotlin.*`);
         const isPrefixBool = jsonName.startsWith("is"); // https://github.com/FasterXML/jackson-module-kotlin/issues/80
         const propertyOpts: Sourcelike[] = [];
 
-        if (namesDiffer || isPrefixBool) {
+        if (namesDiffer || isPrefixBool || /^[a-z][A-Z]/.test(jsonName)) {
             propertyOpts.push(`"${escapedName}"`);
         }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1297,8 +1297,6 @@ export const KotlinJacksonLanguage: Language = {
         "identifiers.json",
         "simple-identifiers.json",
         "nst-test-suite.json",
-        // These should be enabled
-        "nbl-stats.json",
     ],
     skipSchema: [
         "implicit-class-array-union.schema",


### PR DESCRIPTION
## Summary
- explicitly annotate JSON names that begin with a lowercase letter followed by an uppercase letter
- prevent Jackson from rewriting keys such as `sAssists` to `sassists`
- enable the previously skipped Kotlin/Jackson `nbl-stats.json` fixture

## Production diff
- 1 added/1 removed production line

## Tests
- `npm run build`
- `npm run lint`
- `CPUs=1 FIXTURE=kotlin-jackson npm run test:fixtures -- test/inputs/json/priority/nbl-stats.json`