### PR TITLE
Enable passing CJSON and Objective-C fixtures

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -553,8 +553,6 @@ export const CJSONLanguage: Language = {
         "combinations3.json",
         /* Map in Array in TopLevel is not supported (for the current implementation, can be added later, need recursivity) */
         "combinations2.json",
-        /* Array in Array in Union is not supported (for the current implementation, can be added later, need recursivity) */
-        "combinations4.json",
     ],
     skipMiscJSON: false,
     skipSchema: [
@@ -896,10 +894,6 @@ export const ObjectiveCLanguage: Language = {
         // Almost all strings work except any containing \u001b
         // See https://goo.gl/L8HfUP
         "blns-object.json",
-        // TODO
-        "combinations.json",
-        // Needs to distinguish between optional and null properties
-        "optional-union.json",
         // Could not convert JSON to model: Error Domain=JSONSerialization Code=-1 "(null)" UserInfo={exception=-[NSNull countByEnumeratingWithState:objects:count:]: unrecognized selector sent to instance 0x7fff807b6ea0}
         "combinations2.json",
         "combinations3.json",


### PR DESCRIPTION
## Summary

- enable `combinations4.json` for CJSON now that the split source fixture compiles and round-trips it
- enable `optional-union.json` for Objective-C now that nullable optional properties round-trip correctly
- remove the dead Objective-C `combinations.json` skip; no input with that name exists

This PR changes test configuration only; production code is untouched.

## Validation

- `npm run build`
- `npm run lint`
- `npm run test:unit` (52 files, 236 tests)
- `CPUs=1 FIXTURE=objective-c npm run test:fixtures -- test/inputs/json/priority/optional-union.json`
- `CPUs=1 FIXTURE=cjson npm run test:fixtures -- test/inputs/json/priority/combinations4.json` (local compile/round-trip; CI exercises the normal Valgrind wrapper)