### PR TITLE
Support recursive PropTypes validators

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -77,6 +77,10 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
         return funPrefixNamer("enum-cases", (s) => this.nameStyle(s, false));
     }
 
+    protected isImplicitCycleBreaker(_t: Type): boolean {
+        return false;
+    }
+
     protected namedTypeToNameForTopLevel(type: Type): Type | undefined {
         return directlyReachableSingleNamedType(type);
     }
@@ -94,6 +98,14 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
 
     private typeMapTypeFor(t: Type, required = true): Sourcelike {
         if (["class", "object", "enum"].includes(t.kind)) {
+            if (this.isCycleBreakerType(t)) {
+                const name = this.nameForNamedType(t);
+                return [
+                    "(...args) => ",
+                    this.sourcelikeToString(["_", name]),
+                    "(...args)",
+                ];
+            }
             return ["_", this.nameForNamedType(t)];
         }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -993,7 +993,7 @@ export const JavaScriptPropTypesLanguage: Language = {
     features: ["enum", "union"],
     output: "toplevel.js",
     topLevel: "TopLevel",
-    skipJSON: ["bug790.json"], // renderer does not support recursion
+    skipJSON: [],
     skipSchema: [
         "integer-before-number.schema", // Python-specific union-order regression.
         "class-with-additional.schema",


### PR DESCRIPTION
Defer references to cycle-breaking validators and hide those lazy references from eager dependency ordering. This allows recursive shapes to initialize without capturing `undefined`.

Enables the previously skipped `bug790.json`; existing recursive inputs remain green.

Production diff: 12 added lines.

Validation:
- `npm run build`
- Biome
- focused `javascript-prop-types` run for bug790, recursive, and spotify-album

Stacked on #3254.