### PR TITLE
Export top-level PropTypes unions

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -293,7 +293,7 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
                     this.typeMapTypeFor((type as ArrayType).items),
                     ")",
                 ]);
-            } else if (type.kind === "map") {
+            } else if (type.kind === "map" || type.kind === "union") {
                 this.ensureBlankLine();
                 this.emitExport(name, this.typeMapTypeFor(type));
             } else {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -995,12 +995,10 @@ export const JavaScriptPropTypesLanguage: Language = {
     topLevel: "TopLevel",
     skipJSON: [],
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         "class-with-additional.schema",
         "go-schema-pattern-properties.schema",
         ...skipsUntypedUnions,
         "multi-type-enum.schema",
-        "recursive-union-flattening.schema",
         "rust-cycle-breaker-union.schema",
         "unevaluated-properties.schema",
     ],


### PR DESCRIPTION
Export a top-level union from its generated checker instead of referencing a nonexistent object declaration.

Enables `integer-before-number.schema` and `recursive-union-flattening.schema`.

Production diff: 1 added/1 removed line.

Validation:
- `npm run build`
- Biome
- focused schema fixture for integer-before-number, recursive-union-flattening, and direct-union

Stacked on #3257.