### PR TITLE
Fix Java empty JSON property round trips

### DIFF
--- a/packages/quicktype-core/src/language/Java/JavaRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaRenderer.ts
@@ -559,6 +559,25 @@ export class JavaRenderer extends ConvenienceRenderer {
                             this._gettersAndSettersForPropertyName.get(name),
                         );
                         const rendered = this.javaType(false, p.type);
+                        if (jsonName.length === 0) {
+                            this.emitLine("@JsonAnyGetter");
+                            this.emitLine(
+                                "public java.util.Map<String, Object> ",
+                                getterName,
+                                '() { return java.util.Collections.<String, Object>singletonMap("", ',
+                                name,
+                                "); }",
+                            );
+                            this.emitLine("@JsonAnySetter");
+                            this.emitLine(
+                                "public void setEmpty(String key, ",
+                                rendered,
+                                " value) { if (key.isEmpty()) this.",
+                                name,
+                                " = value; }",
+                            );
+                            return;
+                        }
                         this.annotationsForAccessor(
                             c,
                             className,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -230,11 +230,7 @@ export const JavaLanguage: Language = {
     features: ["enum", "union", "uuid"],
     output: "src/main/java/io/quicktype/TopLevel.java",
     topLevel: "TopLevel",
-    skipJSON: [
-        "identifiers.json",
-        "simple-identifiers.json",
-        "nst-test-suite.json",
-    ],
+    skipJSON: [],
     skipMiscJSON: false,
     skipSchema: [
         "keyword-unions.schema", // generates classes with names that are case-insensitively equal
@@ -265,6 +261,12 @@ export const JavaLanguageWithLegacyDateTime: Language = {
 export const JavaLanguageWithLombok: Language = {
     ...JavaLanguage,
     base: "test/fixtures/java-lombok",
+    // Lombok-generated accessors cannot use the empty-key any-getter/setter.
+    skipJSON: [
+        "identifiers.json",
+        "simple-identifiers.json",
+        "nst-test-suite.json",
+    ],
     quickTestRendererOptions: [{ "array-type": "array", lombok: "true" }],
 };
 


### PR DESCRIPTION
Jackson treats @JsonProperty("") as an instruction to infer the ordinary bean property name, so JSON objects with an empty-string key silently round-trip it as "empty". Emit a JsonAnyGetter/JsonAnySetter pair for that one property instead.

This enables identifiers.json, simple-identifiers.json, and nst-test-suite.json for the standard Java fixture and its legacy-date-time variant. Lombok keeps the existing skips because its generated accessor path cannot use these custom methods.

Production change: 19 added lines.

Validated with:
- npm run build
- npx biome check packages/quicktype-core/src/language/Java/JavaRenderer.ts test/languages.ts
- CPUs=3 FIXTURE=java npm run test:fixtures -- test/inputs/json/priority/identifiers.json test/inputs/json/priority/simple-identifiers.json test/inputs/json/priority/nst-test-suite.json