### PR TITLE
Handle nullable Objective-C class array elements

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -364,6 +364,15 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
             (unionType) => {
                 const nullable = nullableFromUnion(unionType);
                 if (nullable !== null) {
+                    if (nullable instanceof ClassType) {
+                        return [
+                            "NSNullify([",
+                            typed,
+                            " isKindOfClass:NSNull.class] ? nil : [",
+                            typed,
+                            " JSONDictionary])",
+                        ];
+                    }
                     if (this.implicitlyConvertsFromJSON(nullable)) {
                         return ["NSNullify(", typed, ")"];
                     }
@@ -827,7 +836,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 "+ (instancetype)fromJSONDictionary:(NSDictionary *)dict",
                 () => {
                     this.emitLine(
-                        "return dict ? [[",
+                        "return [dict isKindOfClass:NSDictionary.class] ? [[",
                         className,
                         " alloc] initWithJSONDictionary:dict] : nil;",
                     );
@@ -1343,7 +1352,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
 	id result = nil;
 	if ([collection isKindOfClass:NSArray.class]) {
 			result = [NSMutableArray arrayWithCapacity:[(NSArray *)collection count]];
-			for (id x in collection) [result addObject:f(x)];
+			for (id x in collection) [result addObject:NSNullify(f(x))];
 	} else if ([collection isKindOfClass:NSDictionary.class]) {
 			result = [NSMutableDictionary dictionaryWithCapacity:[(NSDictionary *)collection count]];
 			for (id key in collection) [result setObject:f([collection objectForKey:key]) forKey:key];

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -896,10 +896,6 @@ export const ObjectiveCLanguage: Language = {
         // Almost all strings work except any containing \u001b
         // See https://goo.gl/L8HfUP
         "blns-object.json",
-        // Could not convert JSON to model: Error Domain=JSONSerialization Code=-1 "(null)" UserInfo={exception=-[NSNull countByEnumeratingWithState:objects:count:]: unrecognized selector sent to instance 0x7fff807b6ea0}
-        "combinations2.json",
-        "combinations3.json",
-        "combinations4.json",
     ],
     skipMiscJSON: false,
     skipSchema: [


### PR DESCRIPTION
Nullable class elements currently fail in three stages: NSNull is passed into a dictionary initializer, converting it to nil cannot be inserted into NSMutableArray, and serializing a preserved NSNull sends JSONDictionary to it.

Keep nullable elements as NSNull inside mapped collections, reject non-dictionaries in class initializers, and guard nullable-class serialization. This enables combinations2.json, combinations3.json, and combinations4.json.

Production change: 11 added lines, 2 removed lines.

Validated with:
- npm run build
- npx biome check packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts test/languages.ts
- CPUs=3 FIXTURE=objective-c npm run test:fixtures -- test/inputs/json/priority/combinations2.json test/inputs/json/priority/combinations3.json test/inputs/json/priority/combinations4.json