### PR TITLE
Validate nullable PropTypes unions

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -123,7 +123,11 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
                 ")",
             ],
             (_classType) => panic("Should already be handled."),
-            (_mapType) => "PropTypes.object",
+            (mapType) => [
+                "PropTypes.objectOf(",
+                this.typeMapTypeFor(mapType.values, false),
+                ")",
+            ],
             (_enumType) => panic("Should already be handled."),
             (unionType) => {
                 const isNullableEnum =

--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -112,7 +112,7 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
         const match = matchType<Sourcelike>(
             t,
             (_anyType) => "PropTypes.any",
-            (_nullType) => "PropTypes.any",
+            (_nullType) => "PropTypes.oneOf([null])",
             (_boolType) => "PropTypes.bool",
             (_integerType) => "PropTypes.number",
             (_doubleType) => "PropTypes.number",
@@ -308,10 +308,19 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
         this.emitLine("_", name, " = PropTypes.shape({");
         this.indent(() => {
             this.forEachClassProperty(t, "none", (_, jsonName, property) => {
+                const type = this.typeMapTypeForProperty(property);
+                const validator =
+                    property.isOptional && jsonName in Object.prototype
+                        ? [
+                              "(props, name, ...args) => Object.prototype.hasOwnProperty.call(props, name) ? ",
+                              type,
+                              "(props, name, ...args) : null",
+                          ]
+                        : type;
                 this.emitLine(
                     `"${utf16StringEscape(jsonName)}"`,
                     ": ",
-                    this.typeMapTypeForProperty(property),
+                    validator,
                     ",",
                 );
             });

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -997,9 +997,7 @@ export const JavaScriptPropTypesLanguage: Language = {
     skipSchema: [
         "class-with-additional.schema",
         "go-schema-pattern-properties.schema",
-        ...skipsUntypedUnions,
-        "multi-type-enum.schema",
-        "rust-cycle-breaker-union.schema",
+        "class-map-union.schema",
         "unevaluated-properties.schema",
     ],
     skipMiscJSON: false,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -994,12 +994,7 @@ export const JavaScriptPropTypesLanguage: Language = {
     output: "toplevel.js",
     topLevel: "TopLevel",
     skipJSON: [],
-    skipSchema: [
-        "class-with-additional.schema",
-        "go-schema-pattern-properties.schema",
-        "class-map-union.schema",
-        "unevaluated-properties.schema",
-    ],
+    skipSchema: [],
     skipMiscJSON: false,
     rendererOptions: { "module-system": "es6" },
     quickTestRendererOptions: [{ converters: "top-level" }],


### PR DESCRIPTION
Generalize the enum-scoped null checker from #3254 to all nullable unions. Optional properties whose names exist on Object.prototype get a scoped own-property guard, so missing constructor-style keys are not mistaken for inherited values.

Enables implicit-class-array-union, multi-type-enum, and rust-cycle-breaker-union validation.

Production diff: 11 added lines.

Validation:
- npm run build
- Biome
- focused schema run including keyword-unions regression
- recursive and bug790 JSON regressions
- full 140-case JavaScript PropTypes quick fixture after rebasing

Stacked on #3258.