### PR TITLE
Validate typed maps in PropTypes

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -123,7 +123,11 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
                 ")",
             ],
             (_classType) => panic("Should already be handled."),
-            (_mapType) => "PropTypes.object",
+            (mapType) => [
+                "PropTypes.objectOf(",
+                this.typeMapTypeFor(mapType.values, false),
+                ")",
+            ],
             (_enumType) => panic("Should already be handled."),
             (unionType) => {
                 const isNullableEnum =

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -994,12 +994,7 @@ export const JavaScriptPropTypesLanguage: Language = {
     output: "toplevel.js",
     topLevel: "TopLevel",
     skipJSON: [],
-    skipSchema: [
-        "class-with-additional.schema",
-        "go-schema-pattern-properties.schema",
-        "class-map-union.schema",
-        "unevaluated-properties.schema",
-    ],
+    skipSchema: [],
     skipMiscJSON: false,
     rendererOptions: { "module-system": "es6" },
     quickTestRendererOptions: [{ converters: "top-level" }],


### PR DESCRIPTION
Emit `PropTypes.objectOf(valueChecker)` for typed maps instead of the untyped `PropTypes.object`.

This closes the remaining PropTypes schema skips and enables class-with-additional, class-map-union, go-schema-pattern-properties, and unevaluated-properties validation.

Production diff: 5 added lines.

Validation:
- `npm run build`
- Biome
- focused four-schema fixture run

Stacked on #3261.