### PR TITLE
Validate Objective-C boolean properties

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -840,6 +840,21 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                     this.emitBlock("if (self = [super init])", () => {
                         if (DEBUG) this.emitLine("__json = dict;");
 
+                        this.forEachClassProperty(
+                            t,
+                            "none",
+                            (_name, jsonName, property) => {
+                                if (
+                                    !property.isOptional &&
+                                    property.type.kind === "bool"
+                                ) {
+                                    this.emitLine(
+                                        `if (![dict[@"${objectiveCStringEscape(jsonName)}"] isKindOfClass:NSNumber.class]) return nil;`,
+                                    );
+                                }
+                            },
+                        );
+
                         this.emitLine(
                             "[self setValuesForKeysWithDictionary:dict];",
                         );

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -909,7 +909,6 @@ export const ObjectiveCLanguage: Language = {
     skipSchema: [
         "boolean-subschema.schema",
         "go-schema-pattern-properties.schema",
-        "optional-any.schema",
     ],
     rendererOptions: { functions: "true" },
     quickTestRendererOptions: [],


### PR DESCRIPTION
Reject non-number JSON values before KVC assigns required Objective-C boolean properties. Without the guard, a string is silently coerced to `NO`, so the generated model accepts invalid schema input.

Enables `optional-any.schema`, including its invalid boolean sample.

Production diff: 15 added lines.

Validation:
- `npm run build`
- Biome
- focused `schema-objective-c` optional-any fixture (3 files)
- full Objective-C JSON/schema quick suite (136/136) in the survey worktree