### PR TITLE
fix(objective-c): validate required array properties

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -855,10 +855,13 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                             (_name, jsonName, property) => {
                                 if (
                                     !property.isOptional &&
-                                    property.type.kind === "bool"
+                                    (property.type.kind === "bool" ||
+                                        property.type instanceof ArrayType)
                                 ) {
                                     this.emitLine(
-                                        `if (![dict[@"${objectiveCStringEscape(jsonName)}"] isKindOfClass:NSNumber.class]) return nil;`,
+                                        `if (![dict[@"${objectiveCStringEscape(jsonName)}"] isKindOfClass:`,
+                                        this.jsonType(property.type)[0],
+                                        ".class]) return nil;",
                                     );
                                 }
                             },

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -898,10 +898,7 @@ export const ObjectiveCLanguage: Language = {
         "blns-object.json",
     ],
     skipMiscJSON: false,
-    skipSchema: [
-        "boolean-subschema.schema",
-        "go-schema-pattern-properties.schema",
-    ],
+    skipSchema: ["go-schema-pattern-properties.schema"],
     rendererOptions: { functions: "true" },
     quickTestRendererOptions: [],
     sourceFiles: ["src/language/Objective-C/index.ts"],


### PR DESCRIPTION
## Summary

- reject non-array JSON values for required Objective-C array properties
- enable boolean-subschema.schema for Objective-C
- keep the existing required-boolean validation intact

Production code: 5 added lines.

## Tests

- npm run build
- npx biome check packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts test/languages.ts
- focused boolean-subschema fixture
- full 140-case Objective-C fixture group

