### PR TITLE
fix(objective-c): reject invalid enum values

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -517,6 +517,13 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                         jsonName,
                         nullable,
                     );
+                    if (nullable instanceof EnumType) {
+                        this.emitLine(
+                            "if (",
+                            name,
+                            ` == nil && dict[@"${objectiveCStringEscape(jsonName)}"] && ![dict[@"${objectiveCStringEscape(jsonName)}"] isKindOfClass:NSNull.class]) return nil;`,
+                        );
+                    }
                 } else {
                     // TODO This is a union, but for now we just leave it dynamic
                     this.emitLine(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -889,7 +889,7 @@ export const ObjectiveCLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: [],
+    features: ["enum"],
     output: "QTTopLevel.m",
     topLevel: "QTTopLevel",
     skipJSON: [


### PR DESCRIPTION
## Summary

- reject unknown Objective-C enum strings when enum conversion returns nil
- preserve missing optional enums and explicit nulls
- enable enum negative fixture coverage for Objective-C

Production code: 7 added lines.

## Tests

- npm run build
- npx biome check packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts test/languages.ts
- focused enum.schema fixture
- full 140-case Objective-C fixture group
