### PR TITLE
fix(objective-c): validate typed map values

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -871,6 +871,21 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                                         ".class]) return nil;",
                                     );
                                 }
+                                if (
+                                    property.type instanceof MapType &&
+                                    [
+                                        "bool",
+                                        "integer",
+                                        "double",
+                                        "string",
+                                    ].includes(property.type.values.kind)
+                                ) {
+                                    this.emitLine(
+                                        `for (id value in [dict[@"${objectiveCStringEscape(jsonName)}"] allValues]) if (![value isKindOfClass:`,
+                                        this.jsonType(property.type.values)[0],
+                                        ".class]) return nil;",
+                                    );
+                                }
                             },
                         );
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -915,7 +915,7 @@ export const ObjectiveCLanguage: Language = {
         "blns-object.json",
     ],
     skipMiscJSON: false,
-    skipSchema: ["go-schema-pattern-properties.schema"],
+    skipSchema: [],
     rendererOptions: { functions: "true" },
     quickTestRendererOptions: [],
     sourceFiles: ["src/language/Objective-C/index.ts"],


### PR DESCRIPTION
## Summary

- validate primitive values in typed Objective-C dictionary properties before assignment
- reject mismatched values instead of silently round-tripping them
- enable go-schema-pattern-properties.schema for Objective-C

Production code: 15 added lines.

## Tests

- npm run build
- npx biome check packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts test/languages.ts
- focused go-schema-pattern-properties fixture
- full 140-case Objective-C fixture group

