### PR TITLE
Fix Elixir mutually recursive struct encoding

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -29,6 +29,8 @@ import {
 } from "./utils.js";
 
 export class ElixirRenderer extends ConvenienceRenderer {
+    private readonly _definedClasses = new Set<ClassType>();
+
     public constructor(
         targetLanguage: TargetLanguage,
         renderContext: RenderContext,
@@ -306,9 +308,19 @@ export class ElixirRenderer extends ConvenienceRenderer {
                     "def encode_",
                     attributeName,
                     suffix,
-                    "(%",
-                    this.nameForNamedTypeWithNamespace(classType),
-                    "{} = value), do: ",
+                    "(",
+                    this._definedClasses.has(classType)
+                        ? [
+                              "%",
+                              this.nameForNamedTypeWithNamespace(classType),
+                              "{}",
+                          ]
+                        : [
+                              "%{__struct__: ",
+                              this.nameForNamedTypeWithNamespace(classType),
+                              "}",
+                          ],
+                    " = value), do: ",
                     this.nameForNamedTypeWithNamespace(classType),
                     ".to_map(value)",
                 ];
@@ -833,6 +845,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
                 });
 
                 this.emitLine(["defstruct [", attributeNames, "]"]);
+                this._definedClasses.add(c);
                 this.ensureBlankLine();
 
                 const typeDefinitionTable: Sourcelike[][] = [

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1707,10 +1707,6 @@ export const ElixirLanguage: Language = {
     ],
     skipMiscJSON: false,
     skipSchema: [
-        // The error occurs because a guard clause that references TopLevel is compiled before TopLevel itself. To fix this, put
-        // TopLevel before Bar, but this doesn't address the actual problem if for example a pattern match to Bar was in TopLevel.
-        "mutually-recursive.schema",
-
         // The test incorrectly succeeds due to the emitter being permissive for unions that contain only primitives. A future enhancement
         // for the Elixir emitter could be a user-controlled 'strict' mode that pattern matches even on unions of only primitive types.
         ...skipsMapValueValidation.filter(


### PR DESCRIPTION
Summary:
- use ordinary struct patterns when the referenced module is already defined
- use a forward-safe __struct__ map pattern only for modules declared later
- enable mutually-recursive.schema for Elixir

Production code: 16 added lines.

Validation:
- npm run build
- Biome check on changed files
- generated mutually recursive output uses the forward-safe pattern while ordinary unions retain their existing output