### PR TITLE
Fix Haskell enum members in mixed unions

### DIFF
--- a/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
+++ b/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
@@ -196,7 +196,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
             (_arrayType) => singleWord("Array"),
             (_classType) => singleWord("Object"),
             (_mapType) => singleWord("Object"),
-            (_enumType) => singleWord("Object"),
+            (_enumType) => singleWord("String"),
             (_unionType) => singleWord("Object"),
         );
     }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1533,7 +1533,6 @@ export const HaskellLanguage: Language = {
         "empty-object.schema",
         ...skipsEnumValueValidation,
         "intersection.schema",
-        "multi-type-enum.schema",
         "keyword-unions.schema",
         "optional-any.schema",
         "ie-suffix-singularization.schema",


### PR DESCRIPTION
Summary:
- dispatch Haskell enum union members from JSON strings
- enable multi-type-enum.schema for Haskell

Production code: 1 added line.

Validation:
- npm run build
- Biome check on changed files
- generated mixed union decoder now matches String for its enum member