### PR TITLE
Fix PHP escaping for quoted JSON property names

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -1568,7 +1568,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                         );
                         this.emitLine(
                             "$out->{'",
-                            jsonName,
+                            stringEscape(jsonName),
                             "'} = $this->",
                             names.to,
                             "();",
@@ -1622,7 +1622,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                             "::",
                             names.from,
                             "($obj->{'",
-                            jsonName,
+                            stringEscape(jsonName),
                             "'})",
                         );
                         comma = ",";

--- a/packages/quicktype-core/src/language/Php/utils.ts
+++ b/packages/quicktype-core/src/language/Php/utils.ts
@@ -2,20 +2,21 @@ import {
     allLowerWordStyle,
     allUpperWordStyle,
     combineWords,
-    escapeNonPrintableMapper,
     firstUpperWordStyle,
     isAscii,
     isDigit,
     isLetter,
     splitIntoWords,
-    standardUnicodeHexEscape,
     utf16ConcatMap,
     utf16LegalizeCharacters,
 } from "../../support/Strings.js";
 
-export const stringEscape = utf16ConcatMap(
-    escapeNonPrintableMapper(isAscii, standardUnicodeHexEscape),
-);
+export const stringEscape = utf16ConcatMap((codePoint) => {
+    const character = String.fromCharCode(codePoint);
+    return codePoint === 0x27 || codePoint === 0x5c
+        ? `\\${character}`
+        : character;
+});
 
 function isStartCharacter(codePoint: number): boolean {
     if (codePoint === 0x5f) return true; // underscore

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1568,7 +1568,6 @@ export const PHPLanguage: Language = {
         "keywords.json",
         "no-classes.json",
         "null-safe.json",
-        "simple-identifiers.json",
         "00c36.json",
         "0a358.json",
         "2df80.json",


### PR DESCRIPTION
Summary:
- escape apostrophes and backslashes for PHP single-quoted literals
- apply escaping to property reads and writes
- enable simple-identifiers.json for PHP

Production code: 8 added lines.

Validation:
- npm run build
- Biome check on changed files
- PHP 8.4 fixture passes for simple-identifiers.json