### PR TITLE
fix(kotlin): preserve generic union member types

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -412,13 +412,13 @@ private fun <T> ObjectMapper.convert(k: kotlin.reflect.KClass<*>, fromJson: (Jso
                     );
                     let expr: Sourcelike = [
                         ordered[ordered.length - 1].name,
-                        "(mapper.treeToValue(jn))",
+                        "(mapper.convertValue(jn))",
                     ];
                     for (let i = ordered.length - 2; i >= 0; i--) {
                         expr = [
                             "try { ",
                             ordered[i].name,
-                            "(mapper.treeToValue(jn)) } catch (e: Exception) { ",
+                            "(mapper.convertValue(jn)) } catch (e: Exception) { ",
                             expr,
                             " }",
                         ];

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1281,7 +1281,6 @@ export const KotlinJacksonLanguage: Language = {
         "nst-test-suite.json",
     ],
     skipSchema: [
-        "implicit-class-array-union.schema",
         // KlaxonException: Couldn't find a suitable constructor for class UnionValue to initialize with {}
         "direct-union.schema",
         "keyword-unions.schema",


### PR DESCRIPTION
Kotlin/Jackson union deserialization used `treeToValue`, whose generic collection element type is erased. As a result, an invalid string array was accepted for a `List<Long>` union member.

Use the Kotlin module's reified `convertValue` extension so generic member types are preserved, and enable the existing `implicit-class-array-union.schema` fixture.

Production code: 2 added lines.

Validation:
- `npm run build`
- `npx biome check packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts test/languages.ts`
- `CPUs=1 QUICKTEST=true FIXTURE=schema-kotlin-jackson npm run test:fixtures -- test/inputs/schema/implicit-class-array-union.schema`
- `CPUs=4 QUICKTEST=true FIXTURE=kotlin-jackson,schema-kotlin-jackson npm run test:fixtures` (136/136)