### PR TITLE
fix(cjson): validate union-valued maps

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -1,3 +1,5 @@
+import { arrayIntercalate } from "collection-utils";
+
 // FIXME: NEEDS REFACTOR
 /* eslint-disable @typescript-eslint/no-shadow */
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -659,6 +661,18 @@ export class CJSONRenderer extends ConvenienceRenderer {
      */
     protected emitUnionPrototypes(unionType: UnionType): void {
         const unionName = this.nameForNamedType(unionType);
+        const checks: Sourcelike[] = Array.from(
+            removeNullFromUnion(unionType)[1],
+            (type) => [this.quicktypeTypeToCJSON(type, false).isType, "(j)"],
+        );
+
+        this.emitLine(
+            "#define cJSON_Is",
+            unionName,
+            "(j) (",
+            arrayIntercalate(" || ", checks),
+            ")",
+        );
 
         this.emitLine(
             "struct ",
@@ -2411,7 +2425,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                 () => {
                                                     if (cJSON.isType !== "") {
                                                         this.emitLine(
-                                                            `if (!${cJSON.isType}(${value})) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                            `if (!${this.sourcelikeToString(cJSON.isType)}(${value})) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
                                                         );
                                                     }
                                                     if (
@@ -2789,7 +2803,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                                             ""
                                                                         ) {
                                                                             this.emitLine(
-                                                                                `if (${nullable}!${items.isType}(${element})) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                                                `if (${nullable}!${this.sourcelikeToString(items.isType)}(${element})) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
                                                                             );
                                                                         }
                                                                         const add =
@@ -5665,7 +5679,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
                     cType: ["struct ", this.nameForNamedType(unionType)],
                     optionalQualifier: "*",
                     cjsonType: "cJSON_Union",
-                    isType: "",
+                    isType: ["cJSON_Is", this.nameForNamedType(unionType)],
                     getValue: [
                         "cJSON_Get",
                         this.nameForNamedType(unionType),

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -564,7 +564,6 @@ export const CJSONLanguage: Language = {
         /* Union with Number and Integer are not supported; min/max constraints on numbers rely on the same distinction */
         ...skipsIntFloatUnions,
         /* Union, Map and Arrays with invalid types are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
-        "class-with-additional.schema",
         ...skipsMapValueValidation.filter(
             (schema) => schema !== "go-schema-pattern-properties.schema",
         ),


### PR DESCRIPTION
CJSON only supplied concrete type predicates for primitive, class, array, and map types. A map whose values formed a union therefore skipped the existing value-type guard and accepted invalid JSON.

Emit a compact predicate macro for each named union and reuse it through the existing property/map validation paths. This enables the existing `class-with-additional.schema` fixture and rejects its invalid string value for a number-or-boolean map.

Production code: 17 added lines.

Validation:
- `npm run build`
- `npx biome check packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts test/languages.ts`
- focused `schema-cjson` fixture passed both positive and negative cases using a local direct-exec Valgrind shim
- full 140-case CJSON JSON+schema lane reached 139/140; only untouched `empty-object.schema` failed because the direct-exec shim does not reproduce Valgrind's memory-error exit behavior on that existing case. Real Valgrind CI is authoritative for the full lane.