### PR TITLE
fix(pike): restrict generated identifiers to ASCII

### DIFF
--- a/packages/quicktype-core/src/language/Pike/utils.ts
+++ b/packages/quicktype-core/src/language/Pike/utils.ts
@@ -1,11 +1,14 @@
 import { funPrefixNamer } from "../../Naming.js";
 import {
+    isAscii,
     isLetterOrUnderscoreOrDigit,
     legalizeCharacters,
     makeNameStyle,
 } from "../../support/Strings.js";
 
-const legalizeName = legalizeCharacters(isLetterOrUnderscoreOrDigit);
+const legalizeName = legalizeCharacters(
+    (cp) => isAscii(cp) && isLetterOrUnderscoreOrDigit(cp),
+);
 export const enumNamingFunction = funPrefixNamer(
     "enumNamer",
     makeNameStyle("upper-underscore", legalizeName),

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1484,9 +1484,7 @@ export const PikeLanguage: Language = {
     output: "TopLevel.pmod",
     topLevel: "TopLevel",
     skipJSON: [
-        "blns-object.json", // illegal characters in expressions
         "identifiers.json", // quicktype internal error
-        "7eb30.json", // illegal characters in expressions
     ],
     skipMiscJSON: false,
     skipSchema: [


### PR DESCRIPTION
Pike's identifier namer accepted every Unicode letter, but the Pike compiler rejects non-ASCII source identifiers. This produced uncompilable enum cases for inferred values such as the Thai text in `7eb30.json`.

Intersect the existing identifier predicate with `isAscii`. ASCII-only generated output is unchanged; only proposed identifiers containing non-ASCII characters take the existing fallback/deduplication path. This enables both `7eb30.json` and `blns-object.json`.

Production code: 4 added lines.

Validation:
- `npm run build`
- `npx biome check packages/quicktype-core/src/language/Pike/utils.ts test/languages.ts`
- focused Pike `7eb30.json` passed in the repository's Pike Docker image
- focused Pike `blns-object.json` passed in the same image
- `CPUs=4 QUICKTEST=true FIXTURE=pike npm run test:fixtures` passed 51/51 using that image