### PR TITLE
Fix Effect Schema integer validation

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -114,7 +114,7 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
             (_anyType) => "S.Any",
             (_nullType) => "S.Null",
             (_boolType) => "S.Boolean",
-            (_integerType) => "S.Number",
+            (_integerType) => "S.Int",
             (_doubleType) => "S.Number",
             (_stringType) => "S.String",
             (arrayType) => [

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1698,7 +1698,7 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         "26b49.json",
     ],
     allowMissingNull: false,
-    features: ["enum", "union", "no-defaults"],
+    features: ["enum", "union", "no-defaults", "integer"],
     output: "TopLevel.ts",
     topLevel: "TopLevel",
     skipJSON: [],


### PR DESCRIPTION
## Summary
- emit `S.Int` for inferred integer types in TypeScript Effect Schema output
- enable the existing integer schema fixture failure coverage for Effect Schema

## Validation
- `npm run build`
- `FIXTURE=schema-typescript-effect-schema CPUs=1 npm run test:fixtures -- test/inputs/schema/integer-type.schema`
- `QUICKTEST=true FIXTURE=typescript-effect-schema,schema-typescript-effect-schema CPUs=2 npm run test:fixtures` (136/136)
- `npm run lint`