### PR TITLE
fix(csharp): type transformed top-level unions

### DIFF
--- a/packages/quicktype-core/src/language/CSharp/NewtonSoftCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/NewtonSoftCSharpRenderer.ts
@@ -355,9 +355,12 @@ export class NewtonsoftCSharpRenderer extends CSharpRenderer {
 
     // The "this" type can't be `dynamic`, so we have to force it to `object`.
     private topLevelResultType(t: Type): Sourcelike {
-        return t.kind === "any" || t.kind === "none"
-            ? "object"
-            : this.csType(t);
+        const targetType = followTargetType(t);
+        return targetType instanceof UnionType
+            ? this.csType(targetType)
+            : t.kind === "any" || t.kind === "none"
+              ? "object"
+              : this.csType(t);
     }
 
     private emitFromJsonForTopLevel(t: Type, name: Name): void {

--- a/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
+++ b/packages/quicktype-core/src/language/CSharp/SystemTextJsonCSharpRenderer.ts
@@ -334,9 +334,12 @@ export class SystemTextJsonCSharpRenderer extends CSharpRenderer {
 
     // The "this" type can't be `dynamic`, so we have to force it to `object`.
     private topLevelResultType(t: Type): Sourcelike {
-        return t.kind === "any" || t.kind === "none"
-            ? "object"
-            : this.csType(t);
+        const targetType = followTargetType(t);
+        return targetType instanceof UnionType
+            ? this.csType(targetType)
+            : t.kind === "any" || t.kind === "none"
+              ? "object"
+              : this.csType(t);
     }
 
     private emitFromJsonForTopLevel(t: Type, name: Name): void {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -133,9 +133,7 @@ export const CSharpLanguage: Language = {
     topLevel: "TopLevel",
     skipJSON: [],
     skipMiscJSON: false,
-    skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
-    ],
+    skipSchema: [],
     // The default framework is SystemTextJson; this fixture deliberately
     // pins NewtonSoft so the Newtonsoft renderer keeps end-to-end coverage.
     rendererOptions: { "check-required": "true", framework: "NewtonSoft" },
@@ -186,7 +184,6 @@ export const CSharpLanguageSystemTextJson: Language = {
     skipJSON: [],
     skipMiscJSON: false,
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         // The following skips are pre-existing System.Text.Json renderer issues,
         // found when first enabling the schema fixture for this language:
         // minmaxlength.schema, optional-constraints.schema, and


### PR DESCRIPTION
Follow top-level transformations before choosing the generated C# result type.

This keeps numeric unions typed as their generated union struct instead of exposing them as `object`, so invalid strings are rejected. It enables `integer-before-number.schema` for Newtonsoft, records, and System.Text.Json.

Production change: 6 added lines across the two C# framework renderers.

Validation:
- `npm run build`
- `npx biome check ...`
- `DOTNET_ROLL_FORWARD=Major CPUs=3 FIXTURE=schema-csharp,schema-csharp-records,schema-csharp-SystemTextJson npm run test:fixtures -- test/inputs/schema/integer-before-number.schema`