### PR TITLE
fix(java): avoid case-insensitive type name collisions

### DIFF
--- a/packages/quicktype-core/src/Naming.ts
+++ b/packages/quicktype-core/src/Naming.ts
@@ -92,6 +92,7 @@ export class Namer {
         public readonly name: string,
         public readonly nameStyle: NameStyle,
         public prefixes: string[],
+        private readonly _caseInsensitiveStyledNames = false,
     ) {
         this._prefixes = new Set(prefixes);
     }
@@ -104,6 +105,16 @@ export class Namer {
         namesToAssignIterable: Iterable<Name>,
     ): ReadonlyMap<Name, string> {
         const forbiddenNames = new Set(forbiddenNamesIterable);
+        const isForbidden = (candidate: string): boolean =>
+            iterableSome(
+                forbiddenNames,
+                (name) =>
+                    name === candidate ||
+                    (this._caseInsensitiveStyledNames &&
+                        name === this.nameStyle(name) &&
+                        candidate === this.nameStyle(candidate) &&
+                        name.toLowerCase() === candidate.toLowerCase()),
+            );
         const namesToAssign = Array.from(namesToAssignIterable);
 
         assert(
@@ -122,7 +133,7 @@ export class Namer {
             const maybeUniqueName = iterableFind(
                 proposedNames,
                 (proposed) =>
-                    !forbiddenNames.has(namingFunction.nameStyle(proposed)) &&
+                    !isForbidden(namingFunction.nameStyle(proposed)) &&
                     namesToAssign.every(
                         (n) =>
                             n === name ||

--- a/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
@@ -29,6 +29,7 @@ export class JacksonRenderer extends JavaRenderer {
         "JsonProcessingException",
         "DeserializationContext",
         "SerializerProvider",
+        "None",
     ];
 
     private mapperType(t: Type): Sourcelike {

--- a/packages/quicktype-core/src/language/Java/JavaRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaRenderer.ts
@@ -9,7 +9,7 @@ import {
 import {
     DependencyName,
     type Name,
-    type Namer,
+    Namer,
     funPrefixNamer,
 } from "../../Naming.js";
 import type { RenderContext } from "../../Renderer.js";
@@ -101,7 +101,8 @@ export class JavaRenderer extends ConvenienceRenderer {
     }
 
     protected makeNamedTypeNamer(): Namer {
-        return this.getNameStyling("typeNamingFunction");
+        const namer = this.getNameStyling("typeNamingFunction");
+        return new Namer(namer.name, namer.nameStyle, namer.prefixes, true);
     }
 
     protected namerForObjectProperty(): Namer {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -232,11 +232,7 @@ export const JavaLanguage: Language = {
     topLevel: "TopLevel",
     skipJSON: [],
     skipMiscJSON: false,
-    skipSchema: [
-        "keyword-unions.schema", // generates classes with names that are case-insensitively equal
-        // The generated converter deserializes a top-level array with a raw
-        // `List`, so a mistyped element round-trips instead of failing.
-    ],
+    skipSchema: [],
     rendererOptions: {},
     // The default is array-type=list; this keeps the T[] code path
     // covered.


### PR DESCRIPTION
Java emits each named type into its own source file, but the shared namer only detects exact spelling collisions. Case-only type names therefore overwrite each other on case-insensitive filesystems.

Allow a namer to compare already-styled names case-insensitively and enable that behavior only for Java named types. Literal lowercase Java keywords remain exact/case-sensitive, so valid names such as `Abstract` are unchanged. Reserve Jackson's inherited `None` sentinel so the disambiguated union name cannot resolve to `JsonDeserializer.None`. This enables the existing `keyword-unions.schema` fixture.

Production additions: 16 lines.

Validation:
- `npm ci`
- `npm run build`
- `npm run lint`
- focused `schema-java` `keyword-unions.schema` fixture (1/1)