### PR TITLE
fix(core): stabilize class-derived property fallback names

### DIFF
--- a/packages/quicktype-core/src/ConvenienceRenderer.ts
+++ b/packages/quicktype-core/src/ConvenienceRenderer.ts
@@ -531,25 +531,31 @@ export abstract class ConvenienceRenderer extends Renderer {
     ): Name | undefined {
         const namer = this.namerForObjectProperty(o, p);
         if (namer === null) return undefined;
-        // FIXME: This alternative should really depend on what the
-        // actual name of the class ends up being.  We can do this
-        // with a DependencyName.
         // Also, we currently don't have any languages where properties
         // are global, so collisions here could only occur where two
         // properties of the same class have the same name, in which case
         // the alternative would also be the same, i.e. useless.  But
         // maybe we'll need global properties for some weird language at
         // some point.
-        const alternative = `${o.getCombinedName()}_${jsonName}`;
         const order =
             assignedName === undefined
                 ? classPropertyNameOrder
                 : assignedClassPropertyNameOrder;
-        const names =
-            assignedName === undefined
-                ? [jsonName, alternative]
-                : [assignedName];
-        return new SimpleName(names, namer, order);
+        if (assignedName !== undefined) {
+            return new SimpleName([assignedName], namer, order);
+        }
+        const styledName = namer.nameStyle(jsonName);
+        const collisions = Array.from(o.getProperties().keys())
+            .filter((name) => namer.nameStyle(name) === styledName)
+            .sort();
+        if (collisions.length === 1 || collisions[0] === jsonName) {
+            return new SimpleName([jsonName], namer, order);
+        }
+        return new DependencyName(
+            namer,
+            order,
+            (lookup) => `${lookup(_className)}_${jsonName}`,
+        );
     }
 
     protected makePropertyDependencyNames(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -323,7 +323,6 @@ export const RustLanguage: Language = {
     diffViaSchema: true,
     skipDiffViaSchema: [
         "bug427.json",
-        "keywords.json",
         "recursive.json",
         "github-events.json",
         "0a91a.json",
@@ -828,7 +827,6 @@ export const SwiftLanguage: Language = {
         "bug427.json",
         "blns-object.json",
         "github-events.json",
-        "keywords.json",
         "null-safe.json",
         "0a358.json", // date-time issues
         "0a91a.json",
@@ -1194,7 +1192,6 @@ export const KotlinLanguage: Language = {
     diffViaSchema: true,
     skipDiffViaSchema: [
         "bug427.json",
-        "keywords.json",
         // TODO Investigate these
         "34702.json",
         "76ae1.json",
@@ -1277,7 +1274,6 @@ export const KotlinJacksonLanguage: Language = {
     diffViaSchema: true,
     skipDiffViaSchema: [
         "bug427.json",
-        "keywords.json",
         "blns-object.json",
         // TODO Investigate these
         "34702.json",


### PR DESCRIPTION
Class property collision fallbacks currently interpolate `getCombinedName()`, which can differ between direct JSON inference and schema-regenerated inference even after the class itself receives the same final name. This makes equivalent inputs produce different property identifiers.

For actual groups of sibling properties that normalize to the same identifier, choose the lexicographically first raw JSON name as the stable winner and make only the remaining fallbacks depend on the assigned class name. Non-colliding properties stay on the original naming path. This enables the existing `keywords.json` schema-diff coverage for Rust, Swift, Kotlin/Klaxon, and Kotlin/Jackson.

Production additions: 15 lines.

Validation:
- `npm ci`
- `npm run build`
- `npm run lint`
- focused Rust/Swift/Kotlin/Kotlin-Jackson `keywords.json` fixture (4/4)