### PR TITLE
fix(pike): escape JSON names in generated comments

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -159,7 +159,7 @@ export class PikeRenderer extends ConvenienceRenderer {
             this.forEachEnumCase(e, "none", (name, jsonName) => {
                 table.push([
                     [name, ' = "', stringEscape(jsonName), '", '],
-                    ['// json: "', jsonName, '"'],
+                    ['// json: "', stringEscape(jsonName), '"'],
                 ]);
             });
             this.emitTable(table);
@@ -229,7 +229,7 @@ export class PikeRenderer extends ConvenienceRenderer {
             table.push([
                 [pikeType, " "],
                 [name, "; "],
-                ['// json: "', jsonName, '"'],
+                ['// json: "', stringEscape(jsonName), '"'],
             ]);
         });
         this.emitTable(table);

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1483,9 +1483,7 @@ export const PikeLanguage: Language = {
     features: [],
     output: "TopLevel.pmod",
     topLevel: "TopLevel",
-    skipJSON: [
-        "identifiers.json", // quicktype internal error
-    ],
+    skipJSON: [],
     skipMiscJSON: false,
     skipSchema: [
         // no implicit cast int <-> float in Pike


### PR DESCRIPTION
## Summary

- escape raw JSON names before emitting them in generated Pike comments
- enable the existing `identifiers.json` fixture for Pike
- prevent embedded newlines in identifiers from violating the renderer line invariant

Production change: 2 added lines.

## Validation

- `npm ci` (isolated worktree)
- `npm run build`
- `npm run test:unit` (52 files, 236 tests; no type errors)
- `PATH=/tmp/pike-wrapper-comments:$PATH CPUs=1 QUICKTEST=true FIXTURE=pike npm run test:fixtures -- test/inputs/json/priority/identifiers.json`
- `PATH=/tmp/pike-wrapper-comments:$PATH CPUs=4 QUICKTEST=true FIXTURE=pike npm run test:fixtures` (51 fixtures; containerized Pike stable)
- `npm run lint`
- `git diff --check`