### PR TITLE
fix(pike): validate top-level integer arrays

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -265,7 +265,12 @@ export class PikeRenderer extends ConvenienceRenderer {
             if (t instanceof PrimitiveType) {
                 this.emitLine(["return json;"]);
             } else if (t instanceof ArrayType) {
-                if (t.items instanceof PrimitiveType)
+                if (t.items.kind === "integer") {
+                    this.emitMultiline(`return map(json, lambda(mixed value) {
+    if (!intp(value)) error("Expected integer");
+    return (int)value;
+});`);
+                } else if (t.items instanceof PrimitiveType)
                     this.emitLine(["return json;"]);
                 else
                     this.emitLine([

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1497,7 +1497,6 @@ export const PikeLanguage: Language = {
         "const-non-string.schema",
         "multi-type-enum.schema",
         "optional-any.schema",
-        "issue2680-top-level-array.schema",
         ...skipsUntypedUnions,
     ],
     rendererOptions: {},


### PR DESCRIPTION
## Summary

- validate elements while decoding top-level integer arrays
- reject non-integer elements instead of silently round-tripping them
- enable the existing `issue2680-top-level-array.schema` fixture for Pike

Production change: 6 added lines.

## Validation

- `npm ci` (isolated worktree)
- `npm run build`
- `npm run test:unit` (52 files, 236 tests; no type errors)
- `PATH=/tmp/pike-wrapper-array:$PATH CPUs=1 FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/issue2680-top-level-array.schema`
- `PATH=/tmp/pike-wrapper-array:$PATH CPUs=4 FIXTURE=schema-pike npm run test:fixtures` (85 fixtures; containerized Pike stable)
- `npm run lint`
- `git diff --check`