### PR TITLE
fix(kotlin): reject fractional values for integers

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -152,6 +152,16 @@ import com.fasterxml.jackson.module.kotlin.*`);
             this.emitLine(
                 "setSerializationInclusion(JsonInclude.Include.NON_NULL)",
             );
+            if (
+                iterableSome(
+                    this.typeGraph.allTypesUnordered(),
+                    (t) => t.kind === "integer",
+                )
+            ) {
+                this.emitLine(
+                    "disable(DeserializationFeature.ACCEPT_FLOAT_AS_INT)",
+                );
+            }
         });
 
         if (converters.length > 0) {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1284,7 +1284,7 @@ export const KotlinJacksonLanguage: Language = {
         "76ae1.json",
     ],
     allowMissingNull: true,
-    features: ["enum", "union", "no-defaults", "date-time"],
+    features: ["enum", "union", "no-defaults", "date-time", "integer"],
     output: "TopLevel.kt",
     topLevel: "TopLevel",
     skipJSON: [


### PR DESCRIPTION
Jackson coerces floating-point JSON values into Kotlin `Long` properties by default, so generated models accept values that violate a schema's `integer` type.

Disable `DeserializationFeature.ACCEPT_FLOAT_AS_INT` in the generated Kotlin/Jackson mapper and declare integer validation support. This enables the existing negative sample in `integer-type.schema`.

Production additions: 3 lines.

Validation:
- `npm ci`
- `npm run build`
- `npm run lint`
- focused `schema-kotlin-jackson` `integer-type.schema` fixture (1/1, including `.2.fail.integer.json`)