### PR TITLE
fix(kotlin): deserialize nested union arrays with Klaxon

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -5,7 +5,7 @@ import { type Sourcelike, modifySource } from "../../Source.js";
 import { camelCase } from "../../support/Strings.js";
 import { mustNotHappen } from "../../support/Support.js";
 import {
-    type ArrayType,
+    ArrayType,
     type ClassProperty,
     ClassType,
     type EnumType,
@@ -467,6 +467,13 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
     }
 
     private emitGenericConverter(): void {
+        const hasNestedUnionArrays = iterableSome(
+            this.typeGraph.allTypesUnordered(),
+            (t) =>
+                t instanceof ArrayType &&
+                t.items instanceof ArrayType &&
+                t.items.items instanceof UnionType,
+        );
         this.ensureBlankLine();
         this.emitLine(
             "private fun <T> Klaxon.convert(k: kotlin.reflect.KClass<*>, fromJson: (JsonValue) -> T, toJson: (T) -> String, isUnion: Boolean = false) =",
@@ -482,7 +489,9 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
                     ],
                     [
                         "override fun fromJson(jv: JsonValue)",
-                        " = fromJson(jv) as Any",
+                        hasNestedUnionArrays
+                            ? " = if (isUnion && jv.inside is JsonArray<*>) (jv.inside as JsonArray<*>).map { fromJson(JsonValue(it, null, null, this@convert)) } else fromJson(jv) as Any"
+                            : " = fromJson(jv) as Any",
                     ],
                     [
                         "override fun canConvert(cls: Class<*>)",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1230,7 +1230,6 @@ export const KotlinLanguage: Language = {
         "php-mixed-union.json",
         "nst-test-suite.json",
         // These should be enabled
-        "nbl-stats.json",
         // TODO Investigate these
         "af2d1.json",
     ],


### PR DESCRIPTION
## Summary

- deserialize `JsonArray` values element-by-element when Klaxon invokes a union converter for nested union arrays
- emit the workaround only for type graphs containing `Array<Array<Union>>`
- enable the existing `nbl-stats.json` Kotlin fixture

## Validation

- `npm run build`
- `npm run lint`
- focused `FIXTURE=kotlin npm run test:fixtures -- test/inputs/json/priority/nbl-stats.json`
- `CPUs=8 QUICKTEST=true FIXTURE=kotlin,schema-kotlin npm run test:fixtures` (136/136)
- output snapshot across 302 Kotlin/Kotlin-schema cases: only `nbl-stats.json/default/TopLevel.kt` contains the conditional generated code

Production change: 11 additions, 2 deletions.