### PR TITLE
fix(javascript-prop-types): validate integers

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -114,7 +114,7 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
             (_anyType) => "PropTypes.any",
             (_nullType) => "PropTypes.oneOf([null])",
             (_boolType) => "PropTypes.bool",
-            (_integerType) => "PropTypes.number",
+            (_integerType) => "Integer",
             (_doubleType) => "PropTypes.number",
             (_stringType) => "PropTypes.string",
             (arrayType) => [
@@ -205,6 +205,14 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
     protected emitImports(): void {
         this.ensureBlankLine();
         this.emitLine(this.importStatement("PropTypes", '"prop-types"'));
+        if (
+            [...this.typeGraph.allTypesUnordered()].some(
+                (t) => t.kind === "integer",
+            )
+        )
+            this.emitLine(
+                'const Integer = (props, name) => props[name] == null || Number.isInteger(props[name]) ? null : new Error("Expected integer");',
+            );
     }
 
     private emitExport(name: Sourcelike, value: Sourcelike): void {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -995,7 +995,7 @@ export const JavaScriptPropTypesLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: false,
-    features: ["enum", "union"],
+    features: ["enum", "union", "integer"],
     output: "toplevel.js",
     topLevel: "TopLevel",
     skipJSON: [],


### PR DESCRIPTION
Use a custom PropTypes validator for integer values.

Enables `integer-type.schema`, including its fractional-value failure sample.

Production change: 2 added lines.

Validation:
- `npm run build`
- `npx biome check packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts test/languages.ts`
- `CPUs=4 QUICKTEST=true FIXTURE=javascript-prop-types,schema-javascript-prop-types npm run test:fixtures` (140/140)