### PR TITLE
fix(javascript-prop-types): validate dates

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -203,6 +203,9 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
                 if (transformedStringType.kind === "uuid") {
                     return '(props, name) => props[name] == null || /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(props[name]) ? null : new Error("Expected UUID")';
                 }
+                if (transformedStringType.kind === "date-time") {
+                    return '(props, name) => props[name] == null || !Number.isNaN(Date.parse(props[name])) ? null : new Error("Expected date-time")';
+                }
                 return "PropTypes.string";
             },
         );

--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/language.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/language.ts
@@ -55,6 +55,8 @@ export class JavaScriptPropTypesTargetLanguage extends TargetLanguage<
         const mapping: Map<TransformedStringTypeKind, PrimitiveStringTypeKind> =
             new Map();
         mapping.set("uuid", "uuid");
+        mapping.set("date", "date-time");
+        mapping.set("date-time", "date-time");
         return mapping;
     }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1058,6 +1058,7 @@ export const JavaScriptPropTypesLanguage: Language = {
         "enum",
         "union",
         "integer",
+        "date-time",
         "minmaxlength",
         "minmax",
         "minmaxitems",


### PR DESCRIPTION
Preserve date and date-time formats in the PropTypes type graph and validate them with `Date.parse`.

Enables the existing `date-time` failure fixtures.

Production change: 17 added lines.

Validation:
- `npm run build`
- Biome on changed files
- `CPUs=4 QUICKTEST=true FIXTURE=javascript-prop-types,schema-javascript-prop-types npm run test:fixtures` (140/140)