### PR TITLE
fix(javascript-prop-types): validate UUIDs

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -183,7 +183,10 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
                     "])",
                 ];
             },
-            (_transformedStringType) => {
+            (transformedStringType) => {
+                if (transformedStringType.kind === "uuid") {
+                    return '(props, name) => props[name] == null || /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i.test(props[name]) ? null : new Error("Expected UUID")';
+                }
                 return "PropTypes.string";
             },
         );

--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/language.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/language.ts
@@ -7,6 +7,11 @@ import {
     type IntegerRange,
 } from "../../support/IntegerRange.js";
 import { TargetLanguage } from "../../TargetLanguage.js";
+import type { StringTypeMapping } from "../../Type/TypeBuilderUtils.js";
+import type {
+    PrimitiveStringTypeKind,
+    TransformedStringTypeKind,
+} from "../../Type/index.js";
 import type { LanguageName, RendererOptions } from "../../types.js";
 
 import { JavaScriptPropTypesRenderer } from "./JavaScriptPropTypesRenderer.js";
@@ -44,6 +49,13 @@ export class JavaScriptPropTypesTargetLanguage extends TargetLanguage<
 
     public getOptions(): typeof javaScriptPropTypesOptions {
         return javaScriptPropTypesOptions;
+    }
+
+    public get stringTypeMapping(): StringTypeMapping {
+        const mapping: Map<TransformedStringTypeKind, PrimitiveStringTypeKind> =
+            new Map();
+        mapping.set("uuid", "uuid");
+        return mapping;
     }
 
     protected makeRenderer<Lang extends LanguageName = "javascript-prop-types">(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1058,6 +1058,7 @@ export const JavaScriptPropTypesLanguage: Language = {
         "minmaxlength",
         "minmaxitems",
         "pattern",
+        "uuid",
     ],
     output: "toplevel.js",
     topLevel: "TopLevel",


### PR DESCRIPTION
Preserve UUID formats in the PropTypes type graph and validate their shape.

Enables `uuid.schema`, including its invalid-value sample.

Production change: 16 added lines.

Validation:
- `npm run build`
- Biome on changed files
- `CPUs=4 QUICKTEST=true FIXTURE=javascript-prop-types,schema-javascript-prop-types npm run test:fixtures` (140/140)