### PR TITLE
fix(javascript-prop-types): validate array cardinality

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -1,5 +1,6 @@
 import { arrayIntercalate } from "collection-utils";
 
+import { minMaxItemsForType } from "../../attributes/Constraints.js";
 import { ConvenienceRenderer } from "../../ConvenienceRenderer.js";
 import { type Name, type Namer, funPrefixNamer } from "../../Naming.js";
 import type { RenderContext } from "../../Renderer.js";
@@ -117,11 +118,25 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
             (_integerType) => "Integer",
             (_doubleType) => "PropTypes.number",
             (_stringType) => "PropTypes.string",
-            (arrayType) => [
-                "PropTypes.arrayOf(",
-                this.typeMapTypeFor(arrayType.items, false),
-                ")",
-            ],
+            (arrayType) => {
+                const item = this.typeMapTypeFor(arrayType.items, false);
+                const [min, max] = minMaxItemsForType(arrayType) ?? [];
+                if (min === undefined && max === undefined)
+                    return ["PropTypes.arrayOf(", item, ")"];
+                return [
+                    "(props, name, ...args) => { const value = props[name]; if (value != null && (",
+                    min === undefined
+                        ? "false"
+                        : ["value.length < ", String(min)],
+                    " || ",
+                    max === undefined
+                        ? "false"
+                        : ["value.length > ", String(max)],
+                    ')) return new Error("Expected bounded array"); return PropTypes.arrayOf(',
+                    item,
+                    ")(props, name, ...args); }",
+                ];
+            },
             (_classType) => panic("Should already be handled."),
             (mapType) => [
                 "PropTypes.objectOf(",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1030,7 +1030,7 @@ export const JavaScriptPropTypesLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: false,
-    features: ["enum", "union", "integer"],
+    features: ["enum", "union", "integer", "minmaxitems"],
     output: "toplevel.js",
     topLevel: "TopLevel",
     skipJSON: [],


### PR DESCRIPTION
Wrap constrained array validators with minItems/maxItems checks while leaving unconstrained arrays unchanged.

Enables `min-max-items.schema`, including both failure samples.

Production change: 20 added lines.

Validation:
- `npm run build`
- Biome on changed files
- `CPUs=4 QUICKTEST=true FIXTURE=javascript-prop-types,schema-javascript-prop-types npm run test:fixtures` (140/140)