### PR TITLE
fix(php): escape multiline JSON names

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -1434,7 +1434,10 @@ export class PhpRenderer extends ConvenienceRenderer {
                     " $",
                     name,
                     "; // json:",
-                    jsonName,
+                    jsonName
+                        .replace(/\n/g, "\\n")
+                        .replace(/\r/g, "\\r")
+                        .replace(/\?>/g, "? >"),
                     " ",
                     p.type.isNullable ? "Optional" : "Required",
                 );

--- a/packages/quicktype-core/src/language/Php/utils.ts
+++ b/packages/quicktype-core/src/language/Php/utils.ts
@@ -13,6 +13,8 @@ import {
 
 export const stringEscape = utf16ConcatMap((codePoint) => {
     const character = String.fromCharCode(codePoint);
+    if (codePoint === 0x0a) return `' . "\\n" . '`;
+    if (codePoint === 0x0d) return `' . "\\r" . '`;
     return codePoint === 0x27 || codePoint === 0x5c
         ? `\\${character}`
         : character;

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1594,7 +1594,6 @@ export const PHPLanguage: Language = {
         "blns-object.json",
         "bug855-short.json",
         "bug863.json",
-        "identifiers.json",
         "issue2680-scalar-array.json",
         "keywords.json",
         "no-classes.json",


### PR DESCRIPTION
Keep multiline JSON names intact in PHP string literals and one-line in generated comments.

Tests: `npm run build`; focused `identifiers.json`; `QUICKTEST=true FIXTURE=php npm run test:fixtures` using PHP 8.4.