### PR TITLE
fix(typescript-zod): validate UUIDs

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/language.ts
@@ -44,6 +44,7 @@ export class TypeScriptZodTargetLanguage extends TargetLanguage<
             new Map();
         const dateTimeType = "date-time";
         mapping.set("date-time", dateTimeType);
+        mapping.set("uuid", "uuid");
         return mapping;
     }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1653,6 +1653,7 @@ export const TypeScriptZodLanguage: Language = {
         "union",
         "no-defaults",
         "date-time",
+        "uuid",
         "integer",
         "minmaxitems",
         "strict-optional",


### PR DESCRIPTION
Preserve UUID transformed strings so the renderer’s existing `z.string().uuid()` branch is reachable.

Enables `uuid.schema`, including its invalid-value sample.

Production change: 1 added line.

Validation:
- `npm run build`
- Biome on changed files
- `CPUs=4 QUICKTEST=true FIXTURE=typescript-zod,schema-typescript-zod npm run test:fixtures` (136/136)