### PR TITLE
fix(effect-schema): validate UUID strings

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -167,6 +167,7 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
                 ];
             },
             (_transformedStringType) => {
+                if (_transformedStringType.kind === "uuid") return "S.UUID";
                 return "S.String";
             },
         );

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/language.ts
@@ -5,6 +5,11 @@ import {
     type IntegerRange,
 } from "../../support/IntegerRange.js";
 import { TargetLanguage } from "../../TargetLanguage.js";
+import type {
+    PrimitiveStringTypeKind,
+    TransformedStringTypeKind,
+} from "../../Type/index.js";
+import type { StringTypeMapping } from "../../Type/TypeBuilderUtils.js";
 import type { LanguageName, RendererOptions } from "../../types.js";
 
 import { TypeScriptEffectSchemaRenderer } from "./TypeScriptEffectSchemaRenderer.js";
@@ -24,6 +29,15 @@ export class TypeScriptEffectSchemaTargetLanguage extends TargetLanguage<
 > {
     public getSupportedIntegerRange(): IntegerRange | null {
         return JS_SAFE_INTEGER_RANGE;
+    }
+
+    public get stringTypeMapping(): StringTypeMapping {
+        const mapping = new Map<
+            TransformedStringTypeKind,
+            PrimitiveStringTypeKind
+        >();
+        mapping.set("uuid", "uuid");
+        return mapping;
     }
 
     public constructor() {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1692,6 +1692,7 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         "integer",
         "strict-optional",
         "minmaxitems",
+        "uuid",
     ],
     output: "TopLevel.ts",
     topLevel: "TopLevel",


### PR DESCRIPTION
Preserve UUID transformed strings and emit `S.UUID`.

Tests: `npm run build`; focused Effect Schema UUID fixture.