### PR TITLE
Require nullable Objective-C properties

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -862,6 +862,14 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                             (_name, jsonName, property) => {
                                 if (
                                     !property.isOptional &&
+                                    property.type.isNullable
+                                ) {
+                                    this.emitLine(
+                                        `if (!dict[@"${objectiveCStringEscape(jsonName)}"]) return nil;`,
+                                    );
+                                }
+                                if (
+                                    !property.isOptional &&
                                     (property.type.kind === "bool" ||
                                         property.type instanceof ArrayType)
                                 ) {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -900,7 +900,7 @@ export const ObjectiveCLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["enum"],
+    features: ["enum", "strict-optional"],
     output: "QTTopLevel.m",
     topLevel: "QTTopLevel",
     skipJSON: [


### PR DESCRIPTION
## Summary
- reject missing required nullable properties
- enable strict-optional coverage

## Tests
- npm run build
- focused strict-optional schema fixture
- Objective-C QUICKTEST fixture suite
