### PR TITLE
Reject fractional Objective-C integers

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -907,6 +907,11 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                                         ".class]) return nil;",
                                     );
                                 }
+                                if (property.type.kind === "integer") {
+                                    this.emitLine(
+                                        `if ([dict[@"${objectiveCStringEscape(jsonName)}"] doubleValue] != [dict[@"${objectiveCStringEscape(jsonName)}"] longLongValue]) return nil;`,
+                                    );
+                                }
                                 if (
                                     property.type instanceof MapType &&
                                     [

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -930,6 +930,7 @@ export const ObjectiveCLanguage: Language = {
     allowMissingNull: true,
     features: [
         "enum",
+        "integer",
         "minmax",
         "minmaxInteger",
         "minmaxitems",


### PR DESCRIPTION
## Summary
- reject fractional numbers for integer properties
- enable Objective-C integer coverage

## Tests
- npm run build
- focused integer schema fixture
- Objective-C QUICKTEST fixture suite
