### PR TITLE
Reject fractional JSON for Java integer fields

### DIFF
--- a/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaJacksonRenderer.ts
@@ -1,3 +1,5 @@
+import { iterableSome } from "collection-utils";
+
 import type { Name } from "../../Naming.js";
 import type { Sourcelike } from "../../Source.js";
 import { assertNever, panic } from "../../support/Support.js";
@@ -737,6 +739,16 @@ export class JacksonRenderer extends JavaRenderer {
                             this.emitLine(
                                 "mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);",
                             );
+                            if (
+                                iterableSome(
+                                    this.typeGraph.allTypesUnordered(),
+                                    (t) => t.kind === "integer",
+                                )
+                            ) {
+                                this.emitLine(
+                                    "mapper.configure(DeserializationFeature.ACCEPT_FLOAT_AS_INT, false);",
+                                );
+                            }
                             this.emitLine(
                                 "mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);",
                             );

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -237,7 +237,7 @@ export const JavaLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: false,
-    features: ["enum", "union", "uuid", "date-time"],
+    features: ["enum", "union", "uuid", "date-time", "integer"],
     output: "src/main/java/io/quicktype/TopLevel.java",
     topLevel: "TopLevel",
     skipJSON: [],


### PR DESCRIPTION
## Summary
- disable Jackson float-to-integer coercion for integer graphs
- enable the Java integer fixture

## Tests
- npm run build
- focused integer schema fixture
- Java QUICKTEST fixture suite
