### PR TITLE
fix(typescript-zod): parse integer string unions

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -165,9 +165,14 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
                     })
                     .map((type: Type) => {
                         const schema = this.typeMapTypeFor(type, false);
-                        return type.kind === "bool-string" &&
+                        if (
+                            type.kind === "bool-string" &&
                             unionType.findMember("bool") !== undefined
-                            ? [schema, '.transform(x => x === "true")']
+                        )
+                            return [schema, '.transform(x => x === "true")'];
+                        return type.kind === "integer-string" &&
+                            unionType.findMember("integer") !== undefined
+                            ? [schema, ".transform(Number)"]
                             : schema;
                     });
                 return ["z.union([", ...arrayIntercalate(", ", children), "])"];
@@ -181,6 +186,9 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
                 }
                 if (_transformedStringType.kind === "bool-string") {
                     return 'z.enum(["true", "false"])';
+                }
+                if (_transformedStringType.kind === "integer-string") {
+                    return "z.string().regex(/^-?\\d+$/)";
                 }
 
                 return "z.string()";

--- a/packages/quicktype-core/src/language/TypeScriptZod/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/language.ts
@@ -46,6 +46,7 @@ export class TypeScriptZodTargetLanguage extends TargetLanguage<
         mapping.set("date-time", dateTimeType);
         mapping.set("uuid", "uuid");
         mapping.set("bool-string", "bool-string");
+        mapping.set("integer-string", "integer-string");
         return mapping;
     }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1709,6 +1709,7 @@ export const TypeScriptZodLanguage: Language = {
         "date-time",
         "uuid",
         "bool-string",
+        "integer-string",
         "integer",
         "minmaxitems",
         "pattern",


### PR DESCRIPTION
Enable `integer-string.schema` for TypeScript Zod.

Integer-like strings stay strings outside unions and transform to numbers only when paired with integer members.

Production: 11 added lines.

Tests:
- `npm run build`
- `FIXTURE=schema-typescript-zod npm run test:fixtures -- test/inputs/schema/integer-string.schema`
- `CPUs=4 QUICKTEST=true FIXTURE=typescript-zod,schema-typescript-zod npm run test:fixtures`