### PR TITLE
fix(typescript-zod): parse boolean string unions

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -150,7 +150,13 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
                                   : 1;
                         return rank(a) - rank(b);
                     })
-                    .map((type: Type) => this.typeMapTypeFor(type, false));
+                    .map((type: Type) => {
+                        const schema = this.typeMapTypeFor(type, false);
+                        return type.kind === "bool-string" &&
+                            unionType.findMember("bool") !== undefined
+                            ? [schema, '.transform(x => x === "true")']
+                            : schema;
+                    });
                 return ["z.union([", ...arrayIntercalate(", ", children), "])"];
             },
             (_transformedStringType) => {
@@ -159,6 +165,9 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
                 }
                 if (_transformedStringType.kind === "uuid") {
                     return "z.string().uuid()";
+                }
+                if (_transformedStringType.kind === "bool-string") {
+                    return 'z.enum(["true", "false"])';
                 }
 
                 return "z.string()";

--- a/packages/quicktype-core/src/language/TypeScriptZod/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/language.ts
@@ -45,6 +45,7 @@ export class TypeScriptZodTargetLanguage extends TargetLanguage<
         const dateTimeType = "date-time";
         mapping.set("date-time", dateTimeType);
         mapping.set("uuid", "uuid");
+        mapping.set("bool-string", "bool-string");
         return mapping;
     }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1699,6 +1699,7 @@ export const TypeScriptZodLanguage: Language = {
         "no-defaults",
         "date-time",
         "uuid",
+        "bool-string",
         "integer",
         "minmaxitems",
         "strict-optional",


### PR DESCRIPTION
Enable `bool-string.schema` for TypeScript Zod.

Boolean-like strings stay strings outside unions and transform to booleans only when paired with boolean members.

Production: 11 added lines.

Tests:
- `npm run build`
- `FIXTURE=schema-typescript-zod npm run test:fixtures -- test/inputs/schema/bool-string.schema`
- `CPUs=4 QUICKTEST=true FIXTURE=typescript-zod,schema-typescript-zod npm run test:fixtures`