### PR TITLE
Objective-C: validate string length constraints

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -8,6 +8,7 @@ import {
 
 import {
     minMaxItemsForType,
+    minMaxLengthForType,
     minMaxValueForType,
     patternForType,
 } from "../../attributes/Constraints.js";
@@ -893,6 +894,18 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                                 if (pattern !== undefined) {
                                     this.emitLine(
                                         `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [dict[@"${objectiveCStringEscape(jsonName)}"] rangeOfString:@"${objectiveCStringEscape(pattern)}" options:NSRegularExpressionSearch].location == NSNotFound) return nil;`,
+                                    );
+                                }
+                                const [minLength, maxLength] =
+                                    minMaxLengthForType(property.type) ?? [];
+                                if (minLength !== undefined) {
+                                    this.emitLine(
+                                        `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [dict[@"${objectiveCStringEscape(jsonName)}"] length] < ${minLength}) return nil;`,
+                                    );
+                                }
+                                if (maxLength !== undefined) {
+                                    this.emitLine(
+                                        `if ([dict[@"${objectiveCStringEscape(jsonName)}"] length] > ${maxLength}) return nil;`,
                                     );
                                 }
                                 if (

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -935,6 +935,7 @@ export const ObjectiveCLanguage: Language = {
         "minmaxInteger",
         "minmaxitems",
         "pattern",
+        "minmaxlength",
         "strict-optional",
     ],
     output: "QTTopLevel.m",


### PR DESCRIPTION
Validate minLength and maxLength during model initialization. Enables existing constraint fixtures.\n\nTests: focused constraint schemas; QUICKTEST objective-c and schema-objective-c