### PR TITLE
C++: validate array size constraints

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -15,6 +15,7 @@ import {
 import { getAccessorName } from "../../attributes/AccessorNames.js";
 import { defaultValueForType } from "../../attributes/DefaultValue.js";
 import { enumCaseValues } from "../../attributes/EnumValues.js";
+import { minMaxItemsForType } from "../../attributes/Constraints.js";
 import {
     ConvenienceRenderer,
     type ForbiddenWordsInfo,
@@ -1516,6 +1517,24 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                             key,
                             ').is_number_integer()) throw std::runtime_error("Expected integer");',
                         );
+                    }
+
+                    const minMaxItems = minMaxItemsForType(propType);
+                    if (minMaxItems !== undefined) {
+                        const [minItems, maxItems] = minMaxItems;
+                        const key = this.sourcelikeToString(
+                            this.NarrowString.createStringLiteral([
+                                stringEscape(json),
+                            ]),
+                        );
+                        if (minItems !== undefined)
+                            this.emitLine(
+                                `if (j.at(${key}).size() < ${minItems}) throw std::runtime_error("Too few items");`,
+                            );
+                        if (maxItems !== undefined)
+                            this.emitLine(
+                                `if (j.at(${key}).size() > ${maxItems}) throw std::runtime_error("Too many items");`,
+                            );
                     }
 
                     if (p.isOptional || propType instanceof UnionType) {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -744,6 +744,7 @@ export const CPlusPlusLanguage: Language = {
         "union",
         "no-defaults",
         "integer",
+        "minmaxitems",
     ],
     output: "quicktype.hpp",
     topLevel: "TopLevel",


### PR DESCRIPTION
Validate minItems and maxItems while decoding class properties. Enables min-max-items coverage.\n\nTests: focused min-max-items; QUICKTEST schema-cplusplus