### PR TITLE
C++: reject fractional integers

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1505,6 +1505,19 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         return;
                     }
 
+                    if (propType.kind === "integer") {
+                        const key = this.NarrowString.createStringLiteral([
+                            stringEscape(json),
+                        ]);
+                        this.emitLine(
+                            "if (j.find(",
+                            key,
+                            ") != j.end() && !j.at(",
+                            key,
+                            ').is_number_integer()) throw std::runtime_error("Expected integer");',
+                        );
+                    }
+
                     if (p.isOptional || propType instanceof UnionType) {
                         const [nullOrOptional, typeSet] = ((): [
                             boolean,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -719,6 +719,7 @@ export const CPlusPlusLanguage: Language = {
         "enum",
         "union",
         "no-defaults",
+        "integer",
     ],
     output: "quicktype.hpp",
     topLevel: "TopLevel",


### PR DESCRIPTION
Validate integer-typed JSON fields before deserialization. Enables integer schema coverage.\n\nTests: focused integer-type; QUICKTEST schema-cplusplus