### PR TITLE
C++: enforce required nullable properties

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1537,6 +1537,16 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                             );
                     }
 
+                    if (!p.isOptional && propType.isNullable) {
+                        this.emitLine(
+                            "j.at(",
+                            this.NarrowString.createStringLiteral([
+                                stringEscape(json),
+                            ]),
+                            ");",
+                        );
+                    }
+
                     if (p.isOptional || propType instanceof UnionType) {
                         const [nullOrOptional, typeSet] = ((): [
                             boolean,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -747,6 +747,7 @@ export const CPlusPlusLanguage: Language = {
         "no-defaults",
         "integer",
         "minmaxitems",
+        "strict-optional",
     ],
     output: "quicktype.hpp",
     topLevel: "TopLevel",


### PR DESCRIPTION
Require required nullable JSON keys before optional decoding. Enables strict-optional schema coverage.\n\nTests: focused strict-optional; QUICKTEST schema-cplusplus