### PR TITLE
Objective-C: validate pattern constraints

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -9,6 +9,7 @@ import {
 import {
     minMaxItemsForType,
     minMaxValueForType,
+    patternForType,
 } from "../../attributes/Constraints.js";
 import {
     ConvenienceRenderer,
@@ -886,6 +887,12 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                                 if (maxItems !== undefined) {
                                     this.emitLine(
                                         `if ([(NSArray *)dict[@"${objectiveCStringEscape(jsonName)}"] count] > ${maxItems}) return nil;`,
+                                    );
+                                }
+                                const pattern = patternForType(property.type);
+                                if (pattern !== undefined) {
+                                    this.emitLine(
+                                        `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [dict[@"${objectiveCStringEscape(jsonName)}"] rangeOfString:@"${objectiveCStringEscape(pattern)}" options:NSRegularExpressionSearch].location == NSNotFound) return nil;`,
                                     );
                                 }
                                 if (

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -933,6 +933,7 @@ export const ObjectiveCLanguage: Language = {
         "minmax",
         "minmaxInteger",
         "minmaxitems",
+        "pattern",
         "strict-optional",
     ],
     output: "QTTopLevel.m",


### PR DESCRIPTION
Validate JSON Schema regex patterns during model initialization. Enables existing pattern fixtures.\n\nTests: focused pattern schemas; QUICKTEST objective-c and schema-objective-c