### PR TITLE
fix(effect-schema): validate date-time strings

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -180,6 +180,12 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
                     return coerceStrings
                         ? 'S.transform(S.Literal("true", "false"), S.Boolean, { strict: true, decode: (value) => value === "true", encode: (value) => value ? "true" : "false" })'
                         : 'S.Literal("true", "false")';
+                if (_transformedStringType.kind === "date")
+                    return "S.String.pipe(S.pattern(/^\\d{4}-\\d{2}-\\d{2}$/))";
+                if (_transformedStringType.kind === "time")
+                    return "S.String.pipe(S.pattern(/^\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$/))";
+                if (_transformedStringType.kind === "date-time")
+                    return "S.String.pipe(S.pattern(/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$/))";
                 return "S.String";
             },
         );

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/language.ts
@@ -38,6 +38,9 @@ export class TypeScriptEffectSchemaTargetLanguage extends TargetLanguage<
         >();
         mapping.set("uuid", "uuid");
         mapping.set("bool-string", "bool-string");
+        mapping.set("date", "date");
+        mapping.set("time", "time");
+        mapping.set("date-time", "date-time");
         return mapping;
     }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1763,6 +1763,7 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         "uuid",
         "minmaxlength",
         "bool-string",
+        "date-time",
     ],
     output: "TopLevel.ts",
     topLevel: "TopLevel",


### PR DESCRIPTION
Preserve date, time, and date-time transformed strings and emit matching Effect Schema filters.

Tests: `npm run build`; focused date-time and optional date-time fixtures.