### PR TITLE
Objective-C: validate numeric constraints

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -6,6 +6,7 @@ import {
     mapSome,
 } from "collection-utils";
 
+import { minMaxValueForType } from "../../attributes/Constraints.js";
 import {
     ConvenienceRenderer,
     type ForbiddenWordsInfo,
@@ -860,6 +861,18 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                             t,
                             "none",
                             (_name, jsonName, property) => {
+                                const [min, max] =
+                                    minMaxValueForType(property.type) ?? [];
+                                if (min !== undefined) {
+                                    this.emitLine(
+                                        `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [dict[@"${objectiveCStringEscape(jsonName)}"] doubleValue] < ${min}) return nil;`,
+                                    );
+                                }
+                                if (max !== undefined) {
+                                    this.emitLine(
+                                        `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [dict[@"${objectiveCStringEscape(jsonName)}"] doubleValue] > ${max}) return nil;`,
+                                    );
+                                }
                                 if (
                                     !property.isOptional &&
                                     property.type.isNullable

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -921,7 +921,7 @@ export const ObjectiveCLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["enum", "strict-optional"],
+    features: ["enum", "minmax", "minmaxInteger", "strict-optional"],
     output: "QTTopLevel.m",
     topLevel: "QTTopLevel",
     skipJSON: [


### PR DESCRIPTION
Validate minimum and maximum during model initialization. Enables existing numeric constraint fixtures.\n\nTests: focused constraint schemas; QUICKTEST objective-c and schema-objective-c