### PR TITLE
fix(effect-schema): validate integer strings

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -150,7 +150,9 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
             (_enumType) => panic("Should already be handled."),
             (unionType) => {
                 const types = Array.from(unionType.getChildren());
-                const coerce = types.some((type) => type.kind === "bool");
+                const coerce = types.some(
+                    (type) => type.kind === "bool" || type.kind === "integer",
+                );
                 const rank = (type: Type): number =>
                     type.kind === "class" || type.kind === "object" ? 1 : 0;
                 types.sort((a, b) => rank(a) - rank(b));
@@ -186,6 +188,10 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
                     return "S.String.pipe(S.pattern(/^\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$/))";
                 if (_transformedStringType.kind === "date-time")
                     return "S.String.pipe(S.pattern(/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$/))";
+                if (_transformedStringType.kind === "integer-string")
+                    return coerceStrings
+                        ? "S.NumberFromString.pipe(S.int())"
+                        : "S.String.pipe(S.pattern(/^-?\\d+$/))";
                 return "S.String";
             },
         );

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/language.ts
@@ -41,6 +41,7 @@ export class TypeScriptEffectSchemaTargetLanguage extends TargetLanguage<
         mapping.set("date", "date");
         mapping.set("time", "time");
         mapping.set("date-time", "date-time");
+        mapping.set("integer-string", "integer-string");
         return mapping;
     }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1771,6 +1771,7 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         "minmaxlength",
         "bool-string",
         "date-time",
+        "integer-string",
     ],
     output: "TopLevel.ts",
     topLevel: "TopLevel",


### PR DESCRIPTION
Validate integer-formatted strings and decode them only when disambiguating integer unions.

Tests: `npm run build`; focused Effect Schema integer-string fixture.