### PR TITLE
Objective-C: validate array size constraints

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -6,7 +6,10 @@ import {
     mapSome,
 } from "collection-utils";
 
-import { minMaxValueForType } from "../../attributes/Constraints.js";
+import {
+    minMaxItemsForType,
+    minMaxValueForType,
+} from "../../attributes/Constraints.js";
 import {
     ConvenienceRenderer,
     type ForbiddenWordsInfo,
@@ -871,6 +874,18 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                                 if (max !== undefined) {
                                     this.emitLine(
                                         `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [dict[@"${objectiveCStringEscape(jsonName)}"] doubleValue] > ${max}) return nil;`,
+                                    );
+                                }
+                                const [minItems, maxItems] =
+                                    minMaxItemsForType(property.type) ?? [];
+                                if (minItems !== undefined) {
+                                    this.emitLine(
+                                        `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [(NSArray *)dict[@"${objectiveCStringEscape(jsonName)}"] count] < ${minItems}) return nil;`,
+                                    );
+                                }
+                                if (maxItems !== undefined) {
+                                    this.emitLine(
+                                        `if ([(NSArray *)dict[@"${objectiveCStringEscape(jsonName)}"] count] > ${maxItems}) return nil;`,
                                     );
                                 }
                                 if (

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -925,7 +925,13 @@ export const ObjectiveCLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["enum", "minmax", "minmaxInteger", "strict-optional"],
+    features: [
+        "enum",
+        "minmax",
+        "minmaxInteger",
+        "minmaxitems",
+        "strict-optional",
+    ],
     output: "QTTopLevel.m",
     topLevel: "QTTopLevel",
     skipJSON: [


### PR DESCRIPTION
Validate minItems and maxItems during model initialization. Enables existing array constraint fixtures.\n\nTests: focused min-max-items; QUICKTEST objective-c and schema-objective-c