### PR TITLE
cJSON: validate string length constraints

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -7,6 +7,7 @@ import { arrayIntercalate } from "collection-utils";
 import { getAccessorName } from "../../attributes/AccessorNames.js";
 import {
     minMaxItemsForType,
+    minMaxLengthForType,
     minMaxValueForType,
     patternForType,
 } from "../../attributes/Constraints.js";
@@ -2407,6 +2408,10 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                             const pattern = patternForType(
                                                 property.type,
                                             );
+                                            const [minLength, maxLength] =
+                                                minMaxLengthForType(
+                                                    property.type,
+                                                ) ?? [];
                                             if (!property.isOptional) {
                                                 this.emitLine(
                                                     `if (!cJSON_HasObjectItem(${object}, "${jsonName}")) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
@@ -2467,6 +2472,14 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                             `regex_t regex; regcomp(&regex, "${stringEscape(pattern)}", REG_EXTENDED); if (regexec(&regex, ${value}->valuestring, 0, NULL, 0)) { regfree(&regex); cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; } regfree(&regex);`,
                                                         );
                                                     }
+                                                    if (minLength !== undefined)
+                                                        this.emitLine(
+                                                            `if (strlen(${value}->valuestring) < ${minLength}) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                        );
+                                                    if (maxLength !== undefined)
+                                                        this.emitLine(
+                                                            `if (strlen(${value}->valuestring) > ${maxLength}) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                        );
                                                     if (
                                                         cJSON.cjsonType ===
                                                         "cJSON_Enum"

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -610,7 +610,6 @@ export const CJSONLanguage: Language = {
         "multi-type-enum.schema",
         "prefix-items.schema",
         /* Constraints (min/max and regex) are not supported (for the current implementation, can be added later, should abord parsing and return NULL) */
-        "minmaxlength.schema",
         "schema-constraints.schema",
         "optional-const-ref.schema",
         /* Same unsupported min/max, length and regex constraints, applied to optional properties */


### PR DESCRIPTION
Validate minLength and maxLength while decoding class properties. Enables minmaxlength schema coverage.\n\nTests: focused minmaxlength; QUICKTEST cjson