### PR TITLE
fix(zod): validate UUID strings

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/language.ts
@@ -44,6 +44,7 @@ export class TypeScriptZodTargetLanguage extends TargetLanguage<
             new Map();
         const dateTimeType = "date-time";
         mapping.set("date-time", dateTimeType);
+        mapping.set("uuid", "uuid");
         return mapping;
     }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1656,6 +1656,7 @@ export const TypeScriptZodLanguage: Language = {
         "integer",
         "minmaxitems",
         "strict-optional",
+        "uuid",
     ],
     output: "TopLevel.ts",
     topLevel: "TopLevel",


### PR DESCRIPTION
Enables the existing UUID schema fixture for Zod.

Validation:
- `npm run build`
- `CPUs=1 FIXTURE=schema-typescript-zod npm run test:fixtures -- test/inputs/schema/uuid.schema`