### PR TITLE
fix(typescript-zod): validate number bounds

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -3,6 +3,7 @@ import { arrayIntercalate } from "collection-utils";
 import {
     minMaxItemsForType,
     minMaxLengthForType,
+    minMaxValueForType,
     patternForType,
 } from "../../attributes/Constraints.js";
 import { ConvenienceRenderer } from "../../ConvenienceRenderer.js";
@@ -124,13 +125,23 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
                       ],
             ];
         };
+
+        const numberType = (type: Type, integer: boolean): Sourcelike => {
+            const [min, max] = minMaxValueForType(type) ?? [];
+            return [
+                "z.number()",
+                integer ? ".int()" : "",
+                min === undefined ? "" : [".min(", String(min), ")"],
+                max === undefined ? "" : [".max(", String(max), ")"],
+            ];
+        };
         const match = matchType<Sourcelike>(
             t,
             (_anyType) => "z.any()",
             (_nullType) => "z.null()",
             (_boolType) => "z.boolean()",
-            (_integerType) => "z.number().int()",
-            (_doubleType) => "z.number()",
+            (integerType) => numberType(integerType, true),
+            (doubleType) => numberType(doubleType, false),
             (string) => stringType(string),
             (arrayType) => {
                 const [minItems, maxItems] =

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1720,6 +1720,7 @@ export const TypeScriptZodLanguage: Language = {
         "uuid",
         "bool-string",
         "integer",
+        "minmax",
         "minmaxlength",
         "minmaxitems",
         "pattern",


### PR DESCRIPTION
Enable numeric bound fixtures for TypeScript Zod.

Generated number schemas now apply their minimum and maximum constraints.

Production: 15 added lines.

Tests:
- `npm run build`
- focused min/max schema fixtures
- full 136-case TypeScript Zod quick suite