### PR TITLE
cJSON: validate numeric constraints

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -5,6 +5,7 @@ import { arrayIntercalate } from "collection-utils";
 /* eslint-disable @typescript-eslint/naming-convention */
 
 import { getAccessorName } from "../../attributes/AccessorNames.js";
+import { minMaxValueForType } from "../../attributes/Constraints.js";
 import { enumCaseValues } from "../../attributes/EnumValues.js";
 import {
     ConvenienceRenderer,
@@ -2391,6 +2392,10 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                 );
                                             const object = `j${level > 0 ? level.toString() : ""}`;
                                             const value = `cJSON_GetObjectItemCaseSensitive(${object}, "${jsonName}")`;
+                                            const [minimum, maximum] =
+                                                minMaxValueForType(
+                                                    property.type,
+                                                ) ?? [];
                                             if (!property.isOptional) {
                                                 this.emitLine(
                                                     `if (!cJSON_HasObjectItem(${object}, "${jsonName}")) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
@@ -2426,6 +2431,16 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                     if (cJSON.isType !== "") {
                                                         this.emitLine(
                                                             `if (!${this.sourcelikeToString(cJSON.isType)}(${value})) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                        );
+                                                    }
+                                                    if (minimum !== undefined) {
+                                                        this.emitLine(
+                                                            `if (${value}->valuedouble < ${minimum}) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                        );
+                                                    }
+                                                    if (maximum !== undefined) {
+                                                        this.emitLine(
+                                                            `if (${value}->valuedouble > ${maximum}) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
                                                         );
                                                     }
                                                     if (

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -549,6 +549,7 @@ export const CJSONLanguage: Language = {
     allowMissingNull: false,
     features: [
         "minmax",
+        "minmaxInteger",
         "minmaxlength",
         "pattern",
         "enum",
@@ -574,7 +575,9 @@ export const CJSONLanguage: Language = {
         /* Enum as TopLevel is not supported */
         "top-level-enum.schema",
         /* Union with Number and Integer are not supported; min/max constraints on numbers rely on the same distinction */
-        ...skipsIntFloatUnions,
+        ...skipsIntFloatUnions.filter(
+            (schema) => schema !== "minmax-integer.schema",
+        ),
         /* Union, Map and Arrays with invalid types are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         ...skipsMapValueValidation.filter(
             (schema) => schema !== "go-schema-pattern-properties.schema",


### PR DESCRIPTION
Validate integer minimum and maximum while decoding class properties. Enables minmax-integer schema coverage.\n\nTests: focused minmax-integer; QUICKTEST cjson