### PR TITLE
fix(typescript-zod): validate string lengths

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -2,6 +2,7 @@ import { arrayIntercalate } from "collection-utils";
 
 import {
     minMaxItemsForType,
+    minMaxLengthForType,
     patternForType,
 } from "../../attributes/Constraints.js";
 import { ConvenienceRenderer } from "../../ConvenienceRenderer.js";
@@ -108,14 +109,20 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
         }
 
         const stringType = (type: Type): Sourcelike => {
+            const [min, max] = minMaxLengthForType(type) ?? [];
             const pattern = patternForType(type);
-            return pattern === undefined
-                ? "z.string()"
-                : [
-                      'z.string().regex(new RegExp("',
-                      utf16StringEscape(pattern),
-                      '"))',
-                  ];
+            return [
+                "z.string()",
+                min === undefined ? "" : [".min(", String(min), ")"],
+                max === undefined ? "" : [".max(", String(max), ")"],
+                pattern === undefined
+                    ? ""
+                    : [
+                          '.regex(new RegExp("',
+                          utf16StringEscape(pattern),
+                          '"))',
+                      ],
+            ];
         };
         const match = matchType<Sourcelike>(
             t,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1705,6 +1705,7 @@ export const TypeScriptZodLanguage: Language = {
         "date-time",
         "uuid",
         "integer",
+        "minmaxlength",
         "minmaxitems",
         "pattern",
         "strict-optional",


### PR DESCRIPTION
Enable string-length fixtures for TypeScript Zod.

Generated string schemas now apply their minimum and maximum lengths.

Production: 13 added lines.

Tests:
- `npm run build`
- focused string-length schema fixtures
- full 136-case TypeScript Zod quick suite