### PR TITLE
Enforce required nullable Kotlin/Jackson properties

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -7,6 +7,7 @@ import { camelCase } from "../../support/Strings.js";
 import { mustNotHappen } from "../../support/Support.js";
 import {
     type ArrayType,
+    type ClassProperty,
     ClassType,
     type EnumType,
     type MapType,
@@ -20,6 +21,13 @@ import { KotlinRenderer } from "./KotlinRenderer.js";
 import { stringEscape, unionMemberMatchPriority } from "./utils.js";
 
 export class KotlinJacksonRenderer extends KotlinRenderer {
+    protected propertyDefault(
+        p: ClassProperty,
+        _nullableOrOptional: boolean,
+    ): Sourcelike {
+        return p.isOptional || p.type.kind === "null" ? " = null" : "";
+    }
+
     private unionMemberJsonValueGuard(t: Type, _e: Sourcelike): Sourcelike {
         return matchType<Sourcelike>(
             t,

--- a/packages/quicktype-core/src/language/Kotlin/KotlinRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinRenderer.ts
@@ -331,13 +331,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
                     meta.push(() => this.emitDescription(description));
                 }
 
-                this.renameAttribute(
-                    name,
-                    jsonName,
-                    !nullableOrOptional,
-                    meta,
-                    p,
-                );
+                this.renameAttribute(name, jsonName, !p.isOptional, meta, p);
 
                 if (meta.length > 0 && !first) {
                     this.ensureBlankLine();
@@ -352,7 +346,7 @@ export class KotlinRenderer extends ConvenienceRenderer {
                     name,
                     ": ",
                     kotlinType(p),
-                    nullableOrOptional ? " = null" : "",
+                    this.propertyDefault(p, nullableOrOptional),
                     last ? "" : ",",
                 );
 
@@ -376,6 +370,13 @@ export class KotlinRenderer extends ConvenienceRenderer {
 
     protected emitClassAnnotations(_c: Type, _className: Name): void {
         // to be overridden
+    }
+
+    protected propertyDefault(
+        _p: ClassProperty,
+        nullableOrOptional: boolean,
+    ): Sourcelike {
+        return nullableOrOptional ? " = null" : "";
     }
 
     protected renameAttribute(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1320,6 +1320,7 @@ export const KotlinJacksonLanguage: Language = {
         "enum",
         "union",
         "no-defaults",
+        "strict-optional",
         "date-time",
         "integer",
         "minmaxitems",


### PR DESCRIPTION
Required nullable constructor properties no longer get defaults. Jackson now marks them required while optional properties retain null defaults.\n\nEnables strict-optional schema tests.\n\nTests:\n- npm run build\n- focused strict-optional.schema\n- full schema-kotlin-jackson (85/85)\n\nOutput scope: five existing schema outputs change; other Kotlin frameworks retain current defaults.