### PR TITLE
Validate string lengths in Kotlin/Jackson output

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -2,6 +2,7 @@ import { arrayIntercalate, iterableSome } from "collection-utils";
 
 import {
     minMaxItemsForType,
+    minMaxLengthForType,
     minMaxValueForType,
 } from "../../attributes/Constraints.js";
 import type { Name } from "../../Naming.js";
@@ -309,6 +310,15 @@ import com.fasterxml.jackson.module.kotlin.*`);
                         checks.push(`${numberBefore} >= ${numberMin}${after}`);
                     if (numberMax !== undefined)
                         checks.push(`${numberBefore} <= ${numberMax}${after}`);
+                    const [lengthMin, lengthMax] =
+                        minMaxLengthForType(p.type) ?? [];
+                    const lengthBefore = p.isOptional
+                        ? `${n}?.let { require(it.length`
+                        : `require(${n}.length`;
+                    if (lengthMin !== undefined)
+                        checks.push(`${lengthBefore} >= ${lengthMin}${after}`);
+                    if (lengthMax !== undefined)
+                        checks.push(`${lengthBefore} <= ${lengthMax}${after}`);
                 });
                 if (checks.length > 0)
                     this.emitBlock("init", () =>

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1327,6 +1327,7 @@ export const KotlinJacksonLanguage: Language = {
         "integer",
         "minmaxitems",
         "minmax",
+        "minmaxlength",
     ],
     output: "TopLevel.kt",
     topLevel: "TopLevel",


### PR DESCRIPTION
Generate Kotlin require checks for JSON Schema string-length bounds.\n\nEnables minmaxlength failure cases.\n\nTests:\n- npm run build\n- focused minmaxlength.schema and optional-constraints.schema\n- full schema-kotlin-jackson (85/85)\n\nOutput scope: only classes with string-length constraints gain validation.