### PR TITLE
fix(test): make the unit suite pass on native Windows

### DIFF
--- a/script/output-diff.ts
+++ b/script/output-diff.ts
@@ -33,7 +33,13 @@ function filesBelow(root: string, current = root): string[] {
     return fs.readdirSync(current, { withFileTypes: true }).flatMap((entry) => {
         const fullPath = path.join(current, entry.name);
         if (entry.isDirectory()) return filesBelow(root, fullPath);
-        return entry.isFile() ? [path.relative(root, fullPath)] : [];
+        // Always "/"-separated: these paths are matched against the paths in
+        // `git diff` output, which uses forward slashes on every platform,
+        // and are split on "/" when the report is rendered. `path.relative`
+        // would hand back backslashes on Windows.
+        return entry.isFile()
+            ? [path.relative(root, fullPath).split(path.sep).join("/")]
+            : [];
     });
 }
 

--- a/test/unit/core-package.test.ts
+++ b/test/unit/core-package.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -205,11 +205,14 @@ describe("quicktype-core package", () => {
     // — without the marker the ESM build would be loaded as CommonJS and
     // every import would fail at runtime.
     test("npm pack includes both builds and the ESM marker", () => {
-        const packOutput = execFileSync(
-            "npm",
-            ["pack", "--dry-run", "--json"],
-            { cwd: coreDirectory, encoding: "utf8" },
-        );
+        // Run through a shell: on Windows npm is a "npm.cmd" batch shim,
+        // which Node refuses to spawn directly and cannot resolve under the
+        // bare name "npm". The command is a fixed literal, so there is
+        // nothing for the shell to interpolate.
+        const packOutput = execSync("npm pack --dry-run --json", {
+            cwd: coreDirectory,
+            encoding: "utf8",
+        });
         const [{ files }] = JSON.parse(packOutput) as Array<{
             files: Array<{ path: string }>;
         }>;

--- a/test/unit/missing-schema-path.test.ts
+++ b/test/unit/missing-schema-path.test.ts
@@ -10,6 +10,8 @@ import {
 } from "quicktype-core";
 import { expect, test } from "vitest";
 
+import { fixWindowsPath } from "../../packages/quicktype-core/src/support/WindowsPaths.js";
+
 // Regression test for issue #2812: shells such as PowerShell pass wildcard
 // arguments through literally, so a schema wildcard with no matching file must
 // report a normal missing-file error rather than an internal error.
@@ -25,10 +27,15 @@ test("missing JSON Schema paths report the fetch error", async () => {
         const inputData = new InputData();
         inputData.addInput(schemaInput);
 
+        // Windows absolute paths are carried through the address machinery
+        // as "file:" URIs (issue #2869), so the address quoted back in the
+        // error is the normalized form, not the path as it was passed in.
+        const reportedAddress = fixWindowsPath(missingPath);
+
         await expect(
             quicktype({ inputData, lang: "typescript" }),
         ).rejects.toThrow(
-            `Could not fetch schema #, referred to from ${missingPath}#`,
+            `Could not fetch schema #, referred to from ${reportedAddress}#`,
         );
     } finally {
         fs.rmSync(tempDir, { recursive: true, force: true });

--- a/test/unit/windows-schema-paths.test.ts
+++ b/test/unit/windows-schema-paths.test.ts
@@ -50,16 +50,30 @@ interface SchemaPathCase {
     schemaDir: string;
 }
 
+// On Windows the temp directory already is a real drive-letter path, so
+// the cases below use it directly. The literal "C:/Users/quicktype" tree
+// the POSIX runs rely on cannot be created there at all: a path segment
+// may not contain a colon, so mkdir fails with ENOENT.
+const isWindows = process.platform === "win32";
+
 const cases: SchemaPathCase[] = [
     {
         description: "Windows absolute path with backslashes",
-        schemaDir: "C:/Users/quicktype",
-        schemaArg: () => "C:\\Users\\quicktype\\top.schema.json",
+        schemaDir: isWindows ? "backslashes" : "C:/Users/quicktype",
+        schemaArg: (tempDir) =>
+            isWindows
+                ? path.join(tempDir, "backslashes", "top.schema.json")
+                : "C:\\Users\\quicktype\\top.schema.json",
     },
     {
         description: "Windows absolute path with forward slashes",
-        schemaDir: "C:/Users/quicktype",
-        schemaArg: () => "C:/Users/quicktype/top.schema.json",
+        schemaDir: isWindows ? "forward-slashes" : "C:/Users/quicktype",
+        schemaArg: (tempDir) =>
+            isWindows
+                ? path
+                      .join(tempDir, "forward-slashes", "top.schema.json")
+                      .replace(/\\/g, "/")
+                : "C:/Users/quicktype/top.schema.json",
     },
     {
         // Must keep working exactly as before the fix.


### PR DESCRIPTION
## What

Six unit tests fail on native Windows on a clean checkout of `master`. This makes them pass, without changing behaviour on POSIX.

CI runs `ubuntu-22.04` and `macos-latest` only, so none of this is visible there.

## Before / after

On Windows 11, Node 24, clean `master`:

```
Test Files  4 failed | 48 passed (52)
     Tests  6 failed | 230 passed (236)
```

With this change:

```
Test Files  52 passed (52)
     Tests  236 passed (236)
```

## The four causes

**`script/output-diff.ts` — 2 failures.** `filesBelow` returns `path.relative` output, which is backslash-separated on Windows. Those relative paths are then looked up against the paths parsed out of `git diff` output, which are forward-slash-separated on every platform, so every lookup missed and the run aborted with `Unexpected generated-output patch section: ...`. The rendering code splits the same paths on `"/"` too. Normalized to `"/"` where they are produced. This is the one non-test fix — the script backs the output-diffs workflow.

**`test/unit/core-package.test.ts` — 1 failure.** `execFileSync("npm", ...)` fails with `spawnSync npm ENOENT`: on Windows npm is a `npm.cmd` batch shim. Naming it `npm.cmd` explicitly then fails with `EINVAL`, because Node refuses to spawn `.cmd` files without a shell (CVE-2024-27980). Switched to `execSync` with a fixed literal command, which avoids both, and avoids the `DEP0190` warning that `shell: true` plus an args array now emits.

**`test/unit/missing-schema-path.test.ts` — 1 failure.** The expected message hardcoded the path as it was passed in. Windows absolute paths are carried through the address machinery as `file:` URIs (#2869), so the address quoted back in the error is `file:///C:/...`, not the input path. The expectation is now built with the same `fixWindowsPath` the implementation uses, so it tracks the normalization instead of duplicating an assumption about it.

**`test/unit/windows-schema-paths.test.ts` — 2 failures.** The two Windows cases fabricate a literal `C:/Users/quicktype` directory *inside* a temp dir so the drive-letter address can be exercised on POSIX. On Windows that path cannot exist — a path segment may not contain a colon — so `mkdirSync` fails with `ENOENT`. On Windows the temp dir already is a real drive-letter path, so the cases now use it directly, in backslash and forward-slash form. The POSIX cases are untouched and still run exactly as before.

Worth noting these last two are both regression tests for Windows-specific reports (#2869 and #2812, the latter about PowerShell passing wildcards through literally) that could not themselves run on Windows.

## Testing

- `npm run test:unit` on Windows 11 / Node 24.16: 236 passed, 0 failed, no type errors.
- `npx biome check` on the four changed files: clean.
- POSIX paths through the changed code are unchanged: every new branch is guarded on `process.platform === "win32"`, and the `output-diff.ts` normalization is a no-op where `path.sep` is already `/`.
- I could not run `npm run test:fixtures` here — it needs the full set of language toolchains — so that suite is unverified from my side. It does not exercise any of the changed code.

Per CONTRIBUTING: written with an Opus-class model, reviewed and tested locally.
