### PR TITLE
fix(elixir): transform class arrays in maps

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -470,7 +470,11 @@ export class ElixirRenderer extends ConvenienceRenderer {
             (_integerType) => [`${mode}_`, name, prefix],
             (_doubleType) => [`${mode}_`, name, prefix],
             (_stringType) => [`${mode}_`, name, prefix],
-            (_arrayType) => [],
+            (arrayType) => [
+                "(fn value -> Enum.map(value, &",
+                this.nameOfTransformFunction(arrayType.items, name, encode),
+                "/1) end).",
+            ],
             (classType) => [
                 this.nameForNamedTypeWithNamespace(classType),
                 `.${encode ? "to" : "from"}_map`,
@@ -576,6 +580,8 @@ export class ElixirRenderer extends ConvenienceRenderer {
                 if (
                     mapType.values instanceof EnumType ||
                     mapType.values instanceof ClassType ||
+                    (mapType.values instanceof ArrayType &&
+                        mapType.values.items instanceof ClassType) ||
                     (mapType.values.isPrimitive() && !optional)
                 ) {
                     return [
@@ -728,7 +734,9 @@ export class ElixirRenderer extends ConvenienceRenderer {
                 }
                 if (
                     mapType.values instanceof EnumType ||
-                    mapType.values instanceof ClassType
+                    mapType.values instanceof ClassType ||
+                    (mapType.values instanceof ArrayType &&
+                        mapType.values.items instanceof ClassType)
                 ) {
                     return [
                         "struct.",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1849,10 +1849,6 @@ export const ElixirLanguage: Language = {
     skipSchema: [
         // The test incorrectly succeeds due to the emitter being permissive for unions that contain only primitives. A future enhancement
         // for the Elixir emitter could be a user-controlled 'strict' mode that pattern matches even on unions of only primitive types.
-        ...skipsMapValueValidation.filter(
-            (schema) => schema !== "go-schema-pattern-properties.schema",
-        ),
-
         // A top-level array is deserialized without enforcing its element
         // type, so a mistyped element round-trips instead of failing.
     ],


### PR DESCRIPTION
Transform arrays of generated classes stored as map values during decoding and encoding.

Elixir previously left those arrays as raw maps, so valid values could not serialize as generated structs and invalid non-arrays passed into the model. This enables `unevaluated-properties.schema`, including its negative sample.

Production additions: 10 lines.

Validation:
- `npm run build`
- Biome check
- Elixir 1.18: positive round trip and negative rejection in Docker