### PR TITLE
fix(ruby): validate array cardinality

### DIFF
--- a/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
+++ b/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
@@ -3,6 +3,7 @@ import {
     type ForbiddenWordsInfo,
 } from "../../ConvenienceRenderer.js";
 import {
+    minMaxItemsForType,
     minMaxLengthForType,
     minMaxValueForType,
     patternForType,
@@ -114,6 +115,16 @@ export class RubyRenderer extends ConvenienceRenderer {
                 ? ""
                 : `.constrained(format: Regexp.new("${stringEscape(regex)}"))`;
         };
+        const cardinality = (type: Type): string => {
+            const [min, max] = minMaxItemsForType(type) ?? [];
+            const constraints = [
+                min === undefined ? undefined : `min_size: ${min}`,
+                max === undefined ? undefined : `max_size: ${max}`,
+            ].filter((x): x is string => x !== undefined);
+            return constraints.length === 0
+                ? ""
+                : `.constrained(${constraints.join(", ")})`;
+        };
         const minMax = (type: Type): string => {
             const [min, max] = minMaxValueForType(type) ?? [];
             const constraints = [
@@ -151,6 +162,7 @@ export class RubyRenderer extends ConvenienceRenderer {
                 "Types.Array(",
                 this.dryType(arrayType.items),
                 ")",
+                cardinality(arrayType),
                 optional,
             ],
             (classType) => [this.nameForNamedType(classType), optional],

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -106,6 +106,7 @@ export const JSONSchemaLanguage: Language = {
         "uuid",
         "integer",
         "minmax",
+        "minmaxitems",
         "minmaxlength",
         "minmaxitems",
         "pattern",


### PR DESCRIPTION
## What

Emit Dry Types min_size/max_size constraints and enable the min-max-items schema fixture.

## Why

Ruby accepted arrays outside JSON Schema cardinality bounds.

## Tests

- npm run build
- npm run lint
- focused min-max-items fixture
- Ruby fixture sweep: 136/137; recursive-union-flattening fails unchanged under local Ruby 3.4