### PR TITLE
fix(php): dedupe type names case-insensitively

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -11,7 +11,7 @@ import {
 import {
     DependencyName,
     type Name,
-    type Namer,
+    Namer,
     funPrefixNamer,
 } from "../../Naming.js";
 import type { RenderContext } from "../../Renderer.js";
@@ -80,7 +80,8 @@ export class PhpRenderer extends ConvenienceRenderer {
     }
 
     protected makeNamedTypeNamer(): Namer {
-        return this.getNameStyling("typeNamingFunction");
+        const namer = this.getNameStyling("typeNamingFunction");
+        return new Namer(namer.name, namer.nameStyle, namer.prefixes, true);
     }
 
     protected namerForObjectProperty(): Namer {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1711,10 +1711,6 @@ export const PHPLanguage: Language = {
         // The renderer does not support a bare top-level map.
         "empty-object.schema",
         "integer-before-number.schema", // Python-specific union-order regression.
-        // PHP class names are case-insensitive, but the namer dedups
-        // case-sensitively, so this declares classes that collide (same
-        // reason Java and Python skip it).
-        "keyword-unions.schema",
         // Unions are inlined as PHP union type declarations, so a
         // top-level union produces no named TopLevel class for the driver.
         "recursive-union-flattening.schema",


### PR DESCRIPTION
Deduplicate generated PHP type names without regard to case.

PHP class names are case-insensitive, so names such as `BOOLClass` and `BoolClass` previously compiled into duplicate declarations. This enables `keyword-unions.schema`.

Production additions: 3 lines.

Validation:
- quicktype-core TypeScript build
- Biome check
- both keyword-unions samples round-trip on PHP 8.4