### PR TITLE
fix(kotlin-jackson): validate string patterns

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -4,6 +4,7 @@ import {
     minMaxItemsForType,
     minMaxLengthForType,
     minMaxValueForType,
+    patternForType,
 } from "../../attributes/Constraints.js";
 import type { Name } from "../../Naming.js";
 import { type Sourcelike, modifySource } from "../../Source.js";
@@ -327,6 +328,15 @@ import com.fasterxml.jackson.module.kotlin.*`);
                         checks.push(`${lengthBefore} >= ${lengthMin}${after}`);
                     if (lengthMax !== undefined)
                         checks.push(`${lengthBefore} <= ${lengthMax}${after}`);
+                    const pattern = patternForType(p.type);
+                    if (pattern !== undefined) {
+                        const regex = `Regex("${stringEscape(pattern)}").containsMatchIn`;
+                        checks.push(
+                            p.isOptional
+                                ? `${n}?.let { require(${regex}(it)) }`
+                                : `require(${regex}(${n}))`,
+                        );
+                    }
                 });
                 if (checks.length > 0)
                     this.emitBlock("init", () =>

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1367,6 +1367,7 @@ export const KotlinJacksonLanguage: Language = {
         "minmaxitems",
         "minmax",
         "minmaxlength",
+        "pattern",
     ],
     output: "TopLevel.kt",
     topLevel: "TopLevel",


### PR DESCRIPTION
## What

Emit Regex checks for constrained string properties and declare pattern support.

## Why

Kotlin/Jackson accepted values that violate JSON Schema patterns. This enables the existing pattern failure fixtures.

## Validation

- npm run build
- Biome
- focused pattern and optional-constraints fixtures
- full schema-kotlin-jackson fixture suite