### PR TITLE
fix(go): validate enum values

### DIFF
--- a/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
+++ b/packages/quicktype-core/src/language/Golang/GolangRenderer.ts
@@ -323,13 +323,15 @@ export class GoRenderer extends ConvenienceRenderer {
 
     private emitEnum(e: EnumType, enumName: Name): void {
         this.startFile(enumName);
-        this.emitPackageDefinitons(false);
+        this.emitPackageDefinitons(true);
         this.emitDescription(this.descriptionForType(e));
         this.emitLine("type ", enumName, " string");
         this.ensureBlankLine();
         this.emitLine("const (");
         const columns: Sourcelike[][] = [];
+        const cases: string[] = [];
         this.forEachEnumCase(e, "none", (name, jsonName) => {
+            cases.push(this.sourcelikeToString(name));
             columns.push([
                 [name, " "],
                 [enumName, ' = "', stringEscape(jsonName), '"'],
@@ -337,6 +339,31 @@ export class GoRenderer extends ConvenienceRenderer {
         });
         this.indent(() => this.emitTable(columns));
         this.emitLine(")");
+        const type = this.sourcelikeToString(enumName);
+        const allTypes = Array.from(this.typeGraph.allTypesUnordered());
+        if (
+            allTypes.some(
+                (t) =>
+                    t instanceof UnionType &&
+                    nullableFromUnion(t) === null &&
+                    t.getChildren().has(e),
+            )
+        ) {
+            this.endFile();
+            return;
+        }
+        this.ensureBlankLine();
+        this.emitMultiline(`type invalid${type} string
+func (x invalid${type}) Error() string { return "invalid ${type}: " + string(x) }
+
+func (x *${type}) UnmarshalJSON(data []byte) error {
+    var value string
+    if err := json.Unmarshal(data, &value); err != nil { return err }
+    switch ${type}(value) {
+    case ${cases.join(", ")}: *x = ${type}(value); return nil
+    }
+    return invalid${type}(value)
+}`);
         this.endFile();
     }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -513,7 +513,7 @@ export const GoLanguage: Language = {
         "e8b04.json",
     ],
     allowMissingNull: false,
-    features: ["union", "integer"],
+    features: ["enum", "union", "integer"],
     output: "quicktype.go",
     topLevel: "TopLevel",
     skipJSON: [


### PR DESCRIPTION
## What

Generate `UnmarshalJSON` validation for Go enum types and enable enum failure fixtures.

## Why

Go previously accepted arbitrary strings for generated enums, so schema enum constraints were not enforced.

## Validation

- `npm run build`
- Biome
- full Go and schema-Go fixture suite (139/139)