### PR TITLE
fix(dart): reject invalid nullable enums

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -499,14 +499,15 @@ export class DartRenderer extends ConvenienceRenderer {
                     ),
                 ),
             (enumType) => {
-                return [
+                const value: Sourcelike = [
                     defined(this._enumValues.get(enumType)),
                     ".map[",
                     dynamic,
-                    !isNullable || this._options.requiredProperties
-                        ? "]!"
-                        : "]",
+                    "]!",
                 ];
+                return isNullable && !this._options.requiredProperties
+                    ? [dynamic, " == null ? null : ", value]
+                    : value;
             },
             (unionType) => {
                 const maybeNullable = nullableFromUnion(unionType);

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1520,6 +1520,7 @@ export const DartLanguage: Language = {
         "minmaxlength",
         "pattern",
         "minmax",
+        "enum",
     ],
     output: "TopLevel.dart",
     topLevel: "TopLevel",


### PR DESCRIPTION
## What

Distinguish JSON null from unknown nullable enum values and declare enum support.

## Why

Unknown nullable enum strings were silently converted to null. This enables the existing enum failure fixtures.

## Validation

- npm run build
- Biome
- focused enum, enum-large, and optional-enum fixtures
- full schema-dart fixture suite