### PR TITLE
Validate date-time strings in Objective-C output

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -922,6 +922,11 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                                         `if (dict[@"${objectiveCStringEscape(jsonName)}"] && ![[NSUUID alloc] initWithUUIDString:dict[@"${objectiveCStringEscape(jsonName)}"]]) return nil;`,
                                     );
                                 }
+                                if (property.type.kind === "date-time") {
+                                    this.emitLine(
+                                        `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [dict[@"${objectiveCStringEscape(jsonName)}"] rangeOfString:@"^[0-9]{4}-[0-9]{2}-[0-9]{2}T" options:NSRegularExpressionSearch].location == NSNotFound) return nil;`,
+                                    );
+                                }
                                 if (
                                     !property.isOptional &&
                                     property.type.isNullable

--- a/packages/quicktype-core/src/language/Objective-C/language.ts
+++ b/packages/quicktype-core/src/language/Objective-C/language.ts
@@ -56,7 +56,10 @@ export class ObjectiveCTargetLanguage extends TargetLanguage<
     }
 
     public get stringTypeMapping(): StringTypeMapping {
-        return new Map([["uuid", "uuid"]]);
+        return new Map([
+            ["uuid", "uuid"],
+            ["date-time", "date-time"],
+        ]);
     }
 
     protected makeRenderer<Lang extends LanguageName = "objective-c">(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -932,6 +932,7 @@ export const ObjectiveCLanguage: Language = {
         "no-defaults",
         "strict-optional",
         "uuid",
+        "date-time",
     ],
     output: "QTTopLevel.m",
     topLevel: "QTTopLevel",


### PR DESCRIPTION
Preserve JSON Schema date-time types in the Objective-C renderer, require ISO date-time syntax during deserialization, and enable the existing date-time failure fixture.

Without this, arbitrary strings satisfy date-time fields.