### PR TITLE
Validate date-time strings in C++ output

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1533,6 +1533,19 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         );
                     }
 
+                    if (propType.kind === "date-time") {
+                        const key = this.NarrowString.createStringLiteral([
+                            stringEscape(json),
+                        ]);
+                        this.emitLine(
+                            "if (j.find(",
+                            key,
+                            ") != j.end() && !std::regex_match(j.at(",
+                            key,
+                            ').get<std::string>(), std::regex("^[0-9]{4}-[0-9]{2}-[0-9]{2}T.*$"))) throw std::runtime_error("Expected date-time");',
+                        );
+                    }
+
                     const minMaxItems = minMaxItemsForType(propType);
                     if (minMaxItems !== undefined) {
                         const [minItems, maxItems] = minMaxItems;
@@ -1977,6 +1990,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             ["double", "is_number"],
             ["string", "is_string"],
             ["uuid", "is_string"],
+            ["date-time", "is_string"],
             ["class", "is_object"],
             ["map", "is_object"],
             ["array", "is_array"],

--- a/packages/quicktype-core/src/language/CPlusPlus/language.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/language.ts
@@ -140,7 +140,10 @@ export class CPlusPlusTargetLanguage extends TargetLanguage<
     }
 
     public get stringTypeMapping(): StringTypeMapping {
-        return new Map([["uuid", "uuid"]]);
+        return new Map([
+            ["uuid", "uuid"],
+            ["date-time", "date-time"],
+        ]);
     }
 
     protected makeRenderer<Lang extends LanguageName = "c++">(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -740,6 +740,7 @@ export const CPlusPlusLanguage: Language = {
         "minmaxitems",
         "strict-optional",
         "uuid",
+        "date-time",
     ],
     output: "quicktype.hpp",
     topLevel: "TopLevel",


### PR DESCRIPTION
Preserve JSON Schema date-time types in the C++ renderer, require ISO date-time syntax during deserialization, and enable the existing date-time failure fixture.

Without this, arbitrary strings satisfy date-time fields.