### PR TITLE
Validate date strings in Objective-C output

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -205,6 +205,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                     ? this.memoryAttribute(nullable, true)
                     : "copy";
             },
+            (_transformedStringType) => "copy",
         );
     }
 
@@ -247,6 +248,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                     ? this.objcType(nullable, true)
                     : ["id", ""];
             },
+            (_transformedStringType) => ["NSString", " *"],
         );
     }
 
@@ -275,6 +277,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 const nullable = nullableFromUnion(unionType);
                 return nullable !== null ? this.jsonType(nullable) : ["id", ""];
             },
+            (_transformedStringType) => ["NSString", " *"],
         );
     }
 
@@ -324,6 +327,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                     ? this.fromDynamicExpression(nullable, dynamic)
                     : dynamic;
             },
+            (_transformedStringType) => dynamic,
         );
     }
 
@@ -393,6 +397,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 // TODO support unions
                 return typed;
             },
+            (_transformedStringType) => typed,
         );
     }
 
@@ -910,6 +915,11 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                                 if (maxLength !== undefined) {
                                     this.emitLine(
                                         `if ([dict[@"${objectiveCStringEscape(jsonName)}"] length] > ${maxLength}) return nil;`,
+                                    );
+                                }
+                                if (property.type.kind === "date") {
+                                    this.emitLine(
+                                        `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [dict[@"${objectiveCStringEscape(jsonName)}"] rangeOfString:@"^[0-9]{4}-[0-9]{2}-[0-9]{2}$" options:NSRegularExpressionSearch].location == NSNotFound) return nil;`,
                                     );
                                 }
                                 if (

--- a/packages/quicktype-core/src/language/Objective-C/language.ts
+++ b/packages/quicktype-core/src/language/Objective-C/language.ts
@@ -6,6 +6,7 @@ import {
     getOptionValues,
 } from "../../RendererOptions/index.js";
 import { TargetLanguage } from "../../TargetLanguage.js";
+import type { StringTypeMapping } from "../../Type/TypeBuilderUtils.js";
 import type { LanguageName, RendererOptions } from "../../types.js";
 
 import { ObjectiveCRenderer } from "./ObjectiveCRenderer.js";
@@ -52,6 +53,10 @@ export class ObjectiveCTargetLanguage extends TargetLanguage<
 
     public getOptions(): typeof objectiveCOptions {
         return objectiveCOptions;
+    }
+
+    public get stringTypeMapping(): StringTypeMapping {
+        return new Map([["date", "date"]]);
     }
 
     protected makeRenderer<Lang extends LanguageName = "objective-c">(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -937,6 +937,7 @@ export const ObjectiveCLanguage: Language = {
         "minmaxlength",
         "no-defaults",
         "strict-optional",
+        "date-time",
     ],
     output: "QTTopLevel.m",
     topLevel: "QTTopLevel",


### PR DESCRIPTION
Preserve JSON Schema date types in the Objective-C renderer, require ISO date syntax during deserialization, and enable the existing date-time failure fixture.

Without this, arbitrary strings satisfy date fields.