### PR TITLE
Validate UUID strings in C++ output

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -890,6 +890,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                     this.nameForNamedType(unionType),
                 ];
             },
+            (_transformedStringType) => this._stringType.getType(),
         );
         if (!isOptional) return typeSource;
         return [this.optionalType(t), "<", typeSource, ">"];
@@ -1519,6 +1520,19 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         );
                     }
 
+                    if (propType.kind === "uuid") {
+                        const key = this.NarrowString.createStringLiteral([
+                            stringEscape(json),
+                        ]);
+                        this.emitLine(
+                            "if (j.find(",
+                            key,
+                            ") != j.end() && !std::regex_match(j.at(",
+                            key,
+                            ').get<std::string>(), std::regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"))) throw std::runtime_error("Expected UUID");',
+                        );
+                    }
+
                     const minMaxItems = minMaxItemsForType(propType);
                     if (minMaxItems !== undefined) {
                         const [minItems, maxItems] = minMaxItems;
@@ -1962,6 +1976,7 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
             ["integer", "is_number_integer"],
             ["double", "is_number"],
             ["string", "is_string"],
+            ["uuid", "is_string"],
             ["class", "is_object"],
             ["map", "is_object"],
             ["array", "is_array"],

--- a/packages/quicktype-core/src/language/CPlusPlus/language.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/language.ts
@@ -6,6 +6,7 @@ import {
     getOptionValues,
 } from "../../RendererOptions/index.js";
 import { TargetLanguage } from "../../TargetLanguage.js";
+import type { StringTypeMapping } from "../../Type/TypeBuilderUtils.js";
 import type { LanguageName, RendererOptions } from "../../types.js";
 
 import { CPlusPlusRenderer } from "./CPlusPlusRenderer.js";
@@ -136,6 +137,10 @@ export class CPlusPlusTargetLanguage extends TargetLanguage<
 
     public get supportsOptionalClassProperties(): boolean {
         return true;
+    }
+
+    public get stringTypeMapping(): StringTypeMapping {
+        return new Map([["uuid", "uuid"]]);
     }
 
     protected makeRenderer<Lang extends LanguageName = "c++">(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -746,6 +746,7 @@ export const CPlusPlusLanguage: Language = {
         "integer",
         "minmaxitems",
         "strict-optional",
+        "uuid",
     ],
     output: "quicktype.hpp",
     topLevel: "TopLevel",


### PR DESCRIPTION
Preserve UUID types in the C++ renderer, validate canonical UUID syntax during deserialization, and enable the existing UUID failure fixture.

Without this, invalid UUID strings deserialize successfully.