### PR TITLE
Validate UUID strings in Objective-C output

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -205,6 +205,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                     ? this.memoryAttribute(nullable, true)
                     : "copy";
             },
+            (_transformedStringType) => "copy",
         );
     }
 
@@ -247,6 +248,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                     ? this.objcType(nullable, true)
                     : ["id", ""];
             },
+            (_transformedStringType) => ["NSString", " *"],
         );
     }
 
@@ -275,6 +277,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 const nullable = nullableFromUnion(unionType);
                 return nullable !== null ? this.jsonType(nullable) : ["id", ""];
             },
+            (_transformedStringType) => ["NSString", " *"],
         );
     }
 
@@ -324,6 +327,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                     ? this.fromDynamicExpression(nullable, dynamic)
                     : dynamic;
             },
+            (_transformedStringType) => dynamic,
         );
     }
 
@@ -393,6 +397,7 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                 // TODO support unions
                 return typed;
             },
+            (_transformedStringType) => typed,
         );
     }
 
@@ -910,6 +915,11 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                                 if (maxLength !== undefined) {
                                     this.emitLine(
                                         `if ([dict[@"${objectiveCStringEscape(jsonName)}"] length] > ${maxLength}) return nil;`,
+                                    );
+                                }
+                                if (property.type.kind === "uuid") {
+                                    this.emitLine(
+                                        `if (dict[@"${objectiveCStringEscape(jsonName)}"] && ![[NSUUID alloc] initWithUUIDString:dict[@"${objectiveCStringEscape(jsonName)}"]]) return nil;`,
                                     );
                                 }
                                 if (

--- a/packages/quicktype-core/src/language/Objective-C/language.ts
+++ b/packages/quicktype-core/src/language/Objective-C/language.ts
@@ -6,6 +6,7 @@ import {
     getOptionValues,
 } from "../../RendererOptions/index.js";
 import { TargetLanguage } from "../../TargetLanguage.js";
+import type { StringTypeMapping } from "../../Type/TypeBuilderUtils.js";
 import type { LanguageName, RendererOptions } from "../../types.js";
 
 import { ObjectiveCRenderer } from "./ObjectiveCRenderer.js";
@@ -52,6 +53,10 @@ export class ObjectiveCTargetLanguage extends TargetLanguage<
 
     public getOptions(): typeof objectiveCOptions {
         return objectiveCOptions;
+    }
+
+    public get stringTypeMapping(): StringTypeMapping {
+        return new Map([["uuid", "uuid"]]);
     }
 
     protected makeRenderer<Lang extends LanguageName = "objective-c">(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -937,6 +937,7 @@ export const ObjectiveCLanguage: Language = {
         "minmaxlength",
         "no-defaults",
         "strict-optional",
+        "uuid",
     ],
     output: "QTTopLevel.m",
     topLevel: "QTTopLevel",


### PR DESCRIPTION
Preserve UUID types in the Objective-C renderer, reject values NSUUID cannot parse, and enable the existing UUID failure fixture.

Without this, invalid UUID strings deserialize successfully.