### PR TITLE
fix(dart): validate number bounds

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -5,6 +5,7 @@ import {
 import {
     minMaxItemsForType,
     minMaxLengthForType,
+    minMaxValueForType,
     patternForType,
 } from "../../attributes/Constraints.js";
 import {
@@ -441,13 +442,28 @@ export class DartRenderer extends ConvenienceRenderer {
                 ? [value, " == null ? null : ", checked]
                 : checked;
         };
+        const validateNumber = (type: Type, value: Sourcelike): Sourcelike => {
+            const [min, max] = minMaxValueForType(type) ?? [];
+            if (min === undefined && max === undefined) return value;
+            return [
+                isNullable ? [value, " == null ? null : "] : [],
+                "((x) => ",
+                min === undefined ? "true" : `x >= ${min}`,
+                " && ",
+                max === undefined ? "true" : `x <= ${max}`,
+                ' ? x : throw FormatException("Expected bounded number"))(',
+                value,
+                ")",
+            ];
+        };
         return matchType<Sourcelike>(
             t,
             (_anyType) => dynamic,
             (_nullType) => dynamic, // FIXME: check null
             (_boolType) => dynamic,
-            (_integerType) => dynamic,
-            (_doubleType) => [dynamic, "?.toDouble()"],
+            (integerType) => validateNumber(integerType, dynamic),
+            (doubleType) =>
+                validateNumber(doubleType, [dynamic, "?.toDouble()"]),
             (stringType) =>
                 validatePattern(
                     stringType,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1519,6 +1519,7 @@ export const DartLanguage: Language = {
         "date-time",
         "minmaxlength",
         "pattern",
+        "minmax",
     ],
     output: "TopLevel.dart",
     topLevel: "TopLevel",


### PR DESCRIPTION
What: emit Dart runtime checks for JSON Schema numeric minimum and maximum constraints, and enable the existing minmax fixture coverage.

Why: generated decoders currently accept out-of-range numbers.

Validation: build, Biome, and focused minmax, schema-constraints, optional-constraints, and optional-const-ref fixtures pass.