### PR TITLE
fix(dart): validate array cardinality

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -2,6 +2,7 @@ import {
     anyTypeIssueAnnotation,
     nullTypeIssueAnnotation,
 } from "../../Annotation.js";
+import { minMaxItemsForType } from "../../attributes/Constraints.js";
 import {
     ConvenienceRenderer,
     type ForbiddenWordsInfo,
@@ -313,35 +314,30 @@ export class DartRenderer extends ConvenienceRenderer {
         );
     }
 
+    // biome-ignore format: keep the constraint wrapper compact
     protected mapList(
         isNullable: boolean,
         itemType: Sourcelike,
         list: Sourcelike,
         mapper: Sourcelike,
+        constrained?: Type,
     ): Sourcelike {
+        const [min, max] = constrained === undefined ? [undefined, undefined] : (minMaxItemsForType(constrained) ?? []);
+        const checked = (value: Sourcelike): Sourcelike =>
+            min === undefined && max === undefined ? value : [
+                "(() { final x = ", value, "; if (",
+                [min !== undefined && `x.length < ${min}`, max !== undefined && `x.length > ${max}`].filter(Boolean).join(" || "),
+                ") throw FormatException('Invalid array length'); return x; })()",
+            ];
         if (isNullable && !this._options.requiredProperties) {
             return [
                 list,
                 " == null ? null : ",
-                "List<",
-                itemType,
-                ">.from(",
-                list,
-                "!.map((x) => ",
-                mapper,
-                "))",
+                checked(["List<", itemType, ">.from(", list, "!.map((x) => ", mapper, "))"]),
             ];
         }
 
-        return [
-            "List<",
-            itemType,
-            ">.from(",
-            list,
-            ".map((x) => ",
-            mapper,
-            "))",
-        ];
+        return checked(["List<", itemType, ">.from(", list, ".map((x) => ", mapper, "))"]);
     }
 
     protected mapMap(
@@ -431,6 +427,7 @@ export class DartRenderer extends ConvenienceRenderer {
                         arrayType.items,
                         "x",
                     ),
+                    arrayType,
                 ),
             (classType) =>
                 this.mapClass(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -652,7 +652,7 @@ export const CJSONDefaultLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: false,
-    features: [],
+    features: ["minmaxitems"],
     output: "TopLevel.h",
     topLevel: "TopLevel",
     includeJSON: ["nbl-stats.json"],


### PR DESCRIPTION
What: emit Dart runtime checks for JSON Schema minimum and maximum array lengths, and enable the existing min-max-items fixture coverage.

Why: generated decoders currently accept arrays outside schema cardinality bounds.

Validation: build, Biome, focused constraint fixtures, and the full 85-case schema-dart suite pass.