### PR TITLE
Enforce required properties in Pike output

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -317,7 +317,18 @@ export class PikeRenderer extends ConvenienceRenderer {
             () => {
                 this.emitLine([className, " retval = ", className, "();"]);
                 this.ensureBlankLine();
-                this.forEachClassProperty(c, "none", (name, jsonName) => {
+                this.forEachClassProperty(c, "none", (name, jsonName, p) => {
+                    if (
+                        !p.isOptional &&
+                        p.type.kind === "union" &&
+                        nullableFromUnion(p.type as UnionType) !== null
+                    ) {
+                        this.emitLine(
+                            'if (!has_index(json, "',
+                            stringEscape(jsonName),
+                            '")) error("Missing required property");',
+                        );
+                    }
                     this.emitLine([
                         "retval.",
                         name,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1560,7 +1560,7 @@ export const PikeLanguage: Language = {
         "0cffa.json",
     ],
     allowMissingNull: true,
-    features: [],
+    features: ["strict-optional"],
     output: "TopLevel.pmod",
     topLevel: "TopLevel",
     skipJSON: [],


### PR DESCRIPTION
Check required keys before assigning Pike class properties and enable the existing strict-optional failure fixture.

Pike otherwise accepts missing required nullable properties.