### PR TITLE
fix(php): validate array cardinality

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -8,7 +8,10 @@ import {
     ConvenienceRenderer,
     type ForbiddenWordsInfo,
 } from "../../ConvenienceRenderer.js";
-import { minMaxValueForType } from "../../attributes/Constraints.js";
+import {
+    minMaxItemsForType,
+    minMaxValueForType,
+} from "../../attributes/Constraints.js";
 import {
     DependencyName,
     type Name,
@@ -1087,6 +1090,15 @@ export class PhpRenderer extends ConvenienceRenderer {
             },
             (arrayType) => {
                 is("is_array");
+                const [min, max] = minMaxItemsForType(arrayType) ?? [];
+                if (min !== undefined)
+                    this.emitLine(
+                        `if (count(${scopeAttrName}) < ${min}) throw new Exception("Attribute Error");`,
+                    );
+                if (max !== undefined)
+                    this.emitLine(
+                        `if (count(${scopeAttrName}) > ${max}) throw new Exception("Attribute Error");`,
+                    );
                 this.emitLine(
                     "array_walk(",
                     scopeAttrName,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1673,7 +1673,15 @@ export const PHPLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["enum", "union", "no-defaults", "uuid", "integer", "minmax"],
+    features: [
+        "enum",
+        "union",
+        "no-defaults",
+        "uuid",
+        "integer",
+        "minmax",
+        "minmaxitems",
+    ],
     output: "TopLevel.php",
     topLevel: "TopLevel",
     skipJSON: [


### PR DESCRIPTION
Validate generated PHP arrays against JSON Schema `minItems` and `maxItems`.

PHP previously validated element types but ignored collection size, allowing invalid arrays through. This enables the `minmaxitems` fixture feature.

Production additions: 10 lines.

Validation:
- `npm run build`
- Biome check
- PHP 8.4: two positive round trips and two negative rejections