### PR TITLE
fix(php): validate number bounds

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -8,6 +8,7 @@ import {
     ConvenienceRenderer,
     type ForbiddenWordsInfo,
 } from "../../ConvenienceRenderer.js";
+import { minMaxValueForType } from "../../attributes/Constraints.js";
 import {
     DependencyName,
     type Name,
@@ -1018,6 +1019,17 @@ export class PhpRenderer extends ConvenienceRenderer {
         scopeAttrName: string,
         skipPrimitiveTypeCheck = false,
     ): void {
+        const validateRange = (type: Type): void => {
+            const [min, max] = minMaxValueForType(type) ?? [];
+            if (min !== undefined)
+                this.emitLine(
+                    `if (${scopeAttrName} < ${min}) throw new Exception("Attribute Error");`,
+                );
+            if (max !== undefined)
+                this.emitLine(
+                    `if (${scopeAttrName} > ${max}) throw new Exception("Attribute Error");`,
+                );
+        };
         const is = (isfn: string, myT: Name = className): void => {
             this.emitBlock(["if (!", isfn, "(", scopeAttrName, "))"], () =>
                 this.emitLine(
@@ -1042,10 +1054,11 @@ export class PhpRenderer extends ConvenienceRenderer {
             (_boolType) => {
                 if (!skipPrimitiveTypeCheck) is("is_bool");
             },
-            (_integerType) => {
+            (integerType) => {
                 if (!skipPrimitiveTypeCheck) is("is_integer");
+                validateRange(integerType);
             },
-            (_doubleType) => {
+            (doubleType) => {
                 if (!skipPrimitiveTypeCheck) {
                     // PHP integers are acceptable wherever floats are, and
                     // json_decode gives an int for a whole JSON number.
@@ -1067,6 +1080,7 @@ export class PhpRenderer extends ConvenienceRenderer {
                             ),
                     );
                 }
+                validateRange(doubleType);
             },
             (_stringType) => {
                 if (!skipPrimitiveTypeCheck) is("is_string");

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1677,7 +1677,7 @@ export const PHPLanguage: Language = {
     diffViaSchema: false,
     skipDiffViaSchema: [],
     allowMissingNull: true,
-    features: ["enum", "union", "no-defaults", "uuid", "integer"],
+    features: ["enum", "union", "no-defaults", "uuid", "integer", "minmax"],
     output: "TopLevel.php",
     topLevel: "TopLevel",
     skipJSON: [


### PR DESCRIPTION
Validate generated PHP integers and numbers against JSON Schema minimum and maximum bounds.

PHP previously checked numeric types but ignored their allowed ranges. This enables the `minmax` fixture feature.

Production additions: 16 lines.

Validation:
- `npm run build`
- Biome check
- PHP 8.4: positive round trip and negative rejection