### PR TITLE
fix(typescript): support mixed additional properties

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
@@ -188,11 +188,15 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
 
         const additionalProperties = c.getAdditionalProperties();
         if (additionalProperties) {
+            const indexTypes = [
+                additionalProperties,
+                ...Array.from(c.getProperties().values(), (p) => p.type),
+            ].map((t) => this.sourceFor(t).source);
             this.emitTable([
                 [
                     "[property: string]",
                     ": ",
-                    this.sourceFor(additionalProperties).source,
+                    multiWord(" | ", ...indexTypes).source,
                     ";",
                 ],
             ]);

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -978,16 +978,7 @@ export const TypeScriptLanguage: Language = {
     topLevel: "TopLevel",
     skipJSON: [],
     skipMiscJSON: false,
-    skipSchema: [
-        // Pre-existing failures (this fixture is not in CI yet, and these
-        // fail with unmodified master too): objects with both declared
-        // properties and typed additionalProperties render as an interface
-        // whose properties are not assignable to its index signature
-        // (TS2411).
-        "class-map-union.schema",
-        "class-with-additional.schema",
-        "vega-lite.schema",
-    ],
+    skipSchema: [],
     rendererOptions: { "explicit-unions": "yes" },
     quickTestRendererOptions: [
         { "runtime-typecheck": "false" },


### PR DESCRIPTION
## Summary

- widen generated string index signatures to include declared property types
- enable class-map-union, class-with-additional, and vega-lite schema fixtures
- keep the production change to 6 lines

## Tests

- npm run build
- npm run lint
- npm run test:unit
- full schema-typescript fixture group: 85 passed