### PR TITLE
fix(cjson): reject unmatched union values

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -1242,6 +1242,9 @@ export class CJSONRenderer extends ConvenienceRenderer {
                         );
                         onFirst = false;
                     }
+                    this.emitLine(
+                        "if (0 == x->type) { cJSON_free(x); return NULL; }",
+                    );
                 });
                 this.emitLine("return x;");
             },

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -609,9 +609,6 @@ export const CJSONLanguage: Language = {
                 schema !== "go-schema-pattern-properties.schema" &&
                 schema !== "unevaluated-properties.schema",
         ),
-        /* Top-level array elements with invalid types (e.g. a string where
-         * an integer is expected) are not checked either. */
-        "prefix-items.schema",
         /* Required properties absent are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         /* Pure Any type not supported (for the current implementation, can be added later, should manage a callback to provide the final application a way to handle it at parsing and creation of cJSON) */
         "any.schema",


### PR DESCRIPTION
## Summary

- reject JSON values that match no generated C union branch
- enable prefix-items.schema, including its negative union sample
- keep the production change to 3 lines

## Tests

- npm run build
- npm run lint
- FIXTURE=schema-cjson npm run test:fixtures -- test/inputs/schema/prefix-items.schema