### PR TITLE
fix(java): support empty keys with Lombok

### DIFF
--- a/packages/quicktype-core/src/language/Java/JavaRenderer.ts
+++ b/packages/quicktype-core/src/language/Java/JavaRenderer.ts
@@ -548,11 +548,12 @@ export class JavaRenderer extends ConvenienceRenderer {
                     ";",
                 );
             });
-            if (!this._options.lombok) {
+            if (!this._options.lombok || c.getProperties().has("")) {
                 this.forEachClassProperty(
                     c,
                     "leading-and-interposing",
                     (name, jsonName, p) => {
+                        if (this._options.lombok && jsonName.length > 0) return;
                         this.emitDescription(
                             this.descriptionForClassProperty(c, jsonName),
                         );

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -268,12 +268,7 @@ export const JavaLanguageWithLegacyDateTime: Language = {
 export const JavaLanguageWithLombok: Language = {
     ...JavaLanguage,
     base: "test/fixtures/java-lombok",
-    // Lombok-generated accessors cannot use the empty-key any-getter/setter.
-    skipJSON: [
-        "identifiers.json",
-        "simple-identifiers.json",
-        "nst-test-suite.json",
-    ],
+    skipJSON: [],
     quickTestRendererOptions: [{ "array-type": "array", lombok: "true" }],
 };
 


### PR DESCRIPTION
## Summary

- emit the existing explicit any-getter and any-setter path for empty JSON keys under Lombok
- continue relying on Lombok for every normal property
- enable identifiers.json, simple-identifiers.json, and nst-test-suite.json
- keep the production change to 3 lines

## Tests

- npm run build
- npm run lint
- full QUICKTEST java-lombok fixture group: 55 passed with JDK 8