### PR TITLE
fix(php): reserve Override class name

### DIFF
--- a/packages/quicktype-core/src/language/Php/utils.ts
+++ b/packages/quicktype-core/src/language/Php/utils.ts
@@ -128,6 +128,7 @@ export const phpForbiddenClassNames: readonly string[] = [
     "Null",
     "Object",
     "Or",
+    "Override",
     "Parent",
     "Print",
     "Private",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1699,7 +1699,6 @@ export const PHPLanguage: Language = {
         "bug855-short.json",
         "bug863.json",
         "issue2680-scalar-array.json",
-        "keywords.json",
         "no-classes.json",
         "null-safe.json",
         "00c36.json",


### PR DESCRIPTION
## Summary

- treat Override as a case-insensitive forbidden PHP class name
- enable keywords.json on PHP 8.5
- keep the production change to 1 line

## Tests

- npm run build
- npm run lint
- QUICKTEST=true FIXTURE=php npm run test:fixtures -- test/inputs/json/priority/keywords.json