### PR TITLE
test(php): enable 7eb30 fixture

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1709,7 +1709,6 @@ export const PHPLanguage: Language = {
         "54d32.json",
         "734ad.json",
         "77392.json",
-        "7eb30.json",
         "7fbfb.json",
         "80aff.json",
         "9ac3b.json",


### PR DESCRIPTION
## Summary

- remove the stale PHP skip for 7eb30.json
- keep the test-only cleanup isolated from production fixes

## Tests

- npm run lint
- FIXTURE=php npm run test:fixtures -- test/inputs/json/misc/7eb30.json