### PR TITLE
fix(elm): require nullable schema properties

### DIFF
--- a/packages/quicktype-core/src/language/Elm/utils.ts
+++ b/packages/quicktype-core/src/language/Elm/utils.ts
@@ -14,8 +14,7 @@ import {
     splitIntoWords,
     utf32ConcatMap,
 } from "../../support/Strings.js";
-import { type ClassProperty, UnionType } from "../../Type/index.js";
-import { nullableFromUnion } from "../../Type/TypeUtils.js";
+import type { ClassProperty } from "../../Type/index.js";
 
 const legalizeName = legalizeCharacters(
     (cp) => isAscii(cp) && isLetterOrUnderscoreOrDigit(cp),
@@ -61,16 +60,8 @@ export function requiredOrOptional(p: ClassProperty): RequiredOrOptional {
         return { reqOrOpt: "Jpipe.optional", fallback };
     }
 
-    const t = p.type;
-    if (
-        p.isOptional ||
-        (t instanceof UnionType && nullableFromUnion(t) !== null)
-    ) {
+    if (p.isOptional) {
         return optional(" Nothing");
-    }
-
-    if (t.kind === "null") {
-        return optional(" ()");
     }
 
     return { reqOrOpt: "Jpipe.required", fallback: "" };

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -793,7 +793,7 @@ export const ElmLanguage: Language = {
         "e8b04.json",
     ],
     allowMissingNull: false,
-    features: ["enum", "union", "no-defaults", "integer"],
+    features: ["enum", "union", "no-defaults", "strict-optional", "integer"],
     output: "QuickType.elm",
     topLevel: "QuickType",
     // Elm type aliases cannot be recursive, so all inputs that produce


### PR DESCRIPTION
## Summary
- distinguish required nullable properties from optional properties
- decode required nullable fields with Jpipe.required
- enable strict-optional schema coverage for Elm

Production change: 2 insertions and 10 deletions.

## Tests
- npm run build
- npm run lint
- focused Elm fixture independently verified; the Elm compiler is not installed in this workspace