### PR TITLE
fix(swift): support UUID schema strings

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -210,6 +210,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
                 if (transformedStringType.kind === "date-time") {
                     return "Date";
                 }
+                if (transformedStringType.kind === "uuid") return "UUID";
 
                 return panic(
                     `Transformed string type ${transformedStringType.kind} not supported`,

--- a/packages/quicktype-core/src/language/Swift/language.ts
+++ b/packages/quicktype-core/src/language/Swift/language.ts
@@ -145,6 +145,7 @@ export class SwiftTargetLanguage extends TargetLanguage<
         const mapping: Map<TransformedStringTypeKind, PrimitiveStringTypeKind> =
             new Map();
         mapping.set("date-time", "date-time");
+        mapping.set("uuid", "uuid");
         return mapping;
     }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -858,7 +858,7 @@ export const SwiftLanguage: Language = {
         "fcca3.json",
     ],
     allowMissingNull: true,
-    features: ["enum", "union", "no-defaults", "date-time", "integer"],
+    features: ["enum", "union", "no-defaults", "date-time", "uuid", "integer"],
     output: "quicktype.swift",
     topLevel: "TopLevel",
     skipJSON: [

--- a/test/lib/deepEquals.ts
+++ b/test/lib/deepEquals.ts
@@ -59,6 +59,9 @@ export default function deepEquals(
 
     if (typeof x === "string" && typeof y === "string") {
         if (assumeStringsEqual || x === y) return true;
+        const uuid = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/i;
+        if (uuid.test(x) && uuid.test(y) && x.toLowerCase() === y.toLowerCase())
+            return true;
         const [xMoment, isTime] = tryParseMoment(x);
         const [yMoment] = tryParseMoment(y);
         if (


### PR DESCRIPTION
## Summary
- map UUID schema strings to Foundation UUID
- compare canonical UUID strings case-insensitively in fixture round trips
- enable Swift UUID schema coverage

Production change: 2 lines.

## Tests
- npm run build
- npm run lint
- FIXTURE=schema-swift npm run test:fixtures -- test/inputs/schema/uuid.schema