### PR TITLE
fix(swift): preserve fractional date-times

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -770,7 +770,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
 formatter.calendar = Calendar(identifier: .iso8601)
 formatter.locale = Locale(identifier: "en_US_POSIX")
 formatter.timeZone = TimeZone(secondsFromGMT: 0)
-formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXXXX"
+formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXXXX"
 encoder.dateEncodingStrategy = .formatted(formatter)`);
             }
 

--- a/packages/quicktype-core/src/language/Swift/utils.ts
+++ b/packages/quicktype-core/src/language/Swift/utils.ts
@@ -32,7 +32,8 @@ export const MAX_SAMELINE_PROPERTIES = 4;
 // 2018-08-14T02:45:50z
 // 2018-00008-1T002:45:3Z
 
-const swiftDateTimeRegex = /^\d+-\d+-\d+T\d+:\d+:\d+([zZ]|[+-]\d+(:\d+)?)$/;
+const swiftDateTimeRegex =
+    /^\d+-\d+-\d+T\d+:\d+:\d+(?:\.\d+)?([zZ]|[+-]\d+(:\d+)?)$/;
 
 export class SwiftDateTimeRecognizer extends DefaultDateTimeRecognizer {
     public isDateTime(str: string): boolean {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -837,22 +837,13 @@ export const SwiftLanguage: Language = {
         "blns-object.json",
         "github-events.json",
         "keywords.json",
-        "null-safe.json",
-        "0a358.json", // date-time issues
         "0a91a.json",
         "337ed.json",
         "34702.json",
-        "54d32.json", // date-time issues
-        "77392.json", // date-time issues
         "7f568.json",
         "734ad.json",
         "76ae1.json",
-        "80aff.json", // date-time issues
-        "9ac3b.json", // date-time issues
-        "a0496.json", // date-time issues
-        "b4865.json", // date-time issues
         "c8c7e.json",
-        "d23d5.json", // date-time issues
         "e53b5.json",
         "e8b04.json",
         "fcca3.json",


### PR DESCRIPTION
## Summary
- recognize ISO date-times with fractional seconds
- retain microseconds when Linux Foundation encodes dates
- re-enable nine Swift schema-diff fixtures

Production change: 3 inserted lines and 2 deleted lines.

## Tests
- npm run build
- npm run lint
- FIXTURE=swift npm run test:fixtures -- the nine re-enabled JSON fixtures