### PR TITLE
fix(swift): stabilize keyword property names

### DIFF
--- a/packages/quicktype-core/src/language/Swift/utils.ts
+++ b/packages/quicktype-core/src/language/Swift/utils.ts
@@ -19,6 +19,8 @@ import {
 } from "../../support/Strings.js";
 import type { ClassProperty } from "../../Type/index.js";
 
+import { keywords } from "./constants.js";
+
 export const MAX_SAMELINE_PROPERTIES = 4;
 
 // These are all recognized by Swift as ISO8601 date-times:
@@ -74,6 +76,8 @@ export function swiftNameStyle(
         "",
         isStartCharacter,
     );
+    if (!isUpper && keywords.some((keyword) => keyword === combined))
+        return `${combined}_`;
     return addPrefixIfNecessary(prefix, combined);
 }
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -833,27 +833,19 @@ export const SwiftLanguage: Language = {
     },
     diffViaSchema: true,
     skipDiffViaSchema: [
-        "bug427.json",
-        "blns-object.json",
-        "github-events.json",
-        "keywords.json",
         "null-safe.json",
         "0a358.json", // date-time issues
-        "0a91a.json",
         "337ed.json",
         "34702.json",
         "54d32.json", // date-time issues
         "77392.json", // date-time issues
-        "7f568.json",
         "734ad.json",
         "76ae1.json",
         "80aff.json", // date-time issues
         "9ac3b.json", // date-time issues
         "a0496.json", // date-time issues
         "b4865.json", // date-time issues
-        "c8c7e.json",
         "d23d5.json", // date-time issues
-        "e53b5.json",
         "e8b04.json",
         "fcca3.json",
     ],


### PR DESCRIPTION
## Summary
- suffix Swift keyword-shaped property names before name assignment
- avoid provenance-dependent enclosing-type fallbacks
- re-enable eight Swift schema-diff fixtures

Production change: 4 lines.

## Tests
- npm run build
- npm run lint
- FIXTURE=swift npm run test:fixtures -- the eight re-enabled JSON fixtures