### PR TITLE
fix(php): avoid punctuation property collisions

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -80,7 +80,7 @@ export class PhpRenderer extends ConvenienceRenderer {
     ): ForbiddenWordsInfo {
         // `$this` is the only variable name PHP reserves; a property named
         // "this" would produce an illegal `$this` constructor parameter.
-        return { names: ["this"], includeGlobalForbidden: true };
+        return { names: ["this", "_"], includeGlobalForbidden: true };
     }
 
     protected makeNamedTypeNamer(): Namer {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1679,7 +1679,6 @@ export const PHPLanguage: Language = {
     output: "TopLevel.php",
     topLevel: "TopLevel",
     skipJSON: [
-        "blns-object.json",
         "bug855-short.json",
         "bug863.json",
         "issue2680-scalar-array.json",


### PR DESCRIPTION
## Summary
- reserve the punctuation-only PHP property fallback
- prevent generated accessor names from colliding with class methods
- re-enable the blns-object PHP fixture

Production change: 1 line.

## Tests
- npm run build
- npm run lint
- QUICKTEST=true FIXTURE=php npm run test:fixtures -- test/inputs/json/priority/blns-object.json