### PR TITLE
fix(haskell): escape astral property names

### DIFF
--- a/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
+++ b/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
@@ -29,6 +29,10 @@ import { forbiddenNames } from "./constants.js";
 import type { haskellOptions } from "./language.js";
 import { lowerNamingFunction, upperNamingFunction } from "./utils.js";
 
+function haskellStringEscape(s: string): string {
+    return stringEscape(s).replace(/\\U0*([0-9a-fA-F]+)/g, "\\x$1\\&");
+}
+
 export class HaskellRenderer extends ConvenienceRenderer {
     public constructor(
         targetLanguage: TargetLanguage,
@@ -327,7 +331,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
                         this.emitLine(
                             onFirst ? "[ " : ", ",
                             '"',
-                            stringEscape(jsonName),
+                            haskellStringEscape(jsonName),
                             '" .= ',
                             name,
                             className,
@@ -361,7 +365,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
                             "v ",
                             operator,
                             ' "',
-                            stringEscape(jsonName),
+                            haskellStringEscape(jsonName),
                             '"',
                         );
                         onFirst = false;
@@ -385,7 +389,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
                     "toJSON ",
                     this.enumCaseName(name, enumName),
                     ' = "',
-                    stringEscape(jsonName),
+                    haskellStringEscape(jsonName),
                     '"',
                 );
             });
@@ -402,7 +406,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
                     this.forEachEnumCase(e, "none", (name, jsonName) => {
                         this.emitLine(
                             'parseText "',
-                            stringEscape(jsonName),
+                            haskellStringEscape(jsonName),
                             '" = return ',
                             this.enumCaseName(name, enumName),
                         );

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1630,7 +1630,6 @@ export const HaskellLanguage: Language = {
         "nbl-stats.json",
         "bug855-short.json",
         "combinations4.json",
-        "identifiers.json",
         "blns-object.json",
         "recursive.json",
         "bug427.json",


### PR DESCRIPTION
## Summary
- translate shared astral Unicode escapes to Haskell hexadecimal escapes
- terminate escapes so following identifier characters remain unambiguous
- re-enable the Haskell identifiers fixture

Production change: 8 inserted lines including four call-site replacements.

## Tests
- npm run build
- npm run lint
- QUICKTEST=true FIXTURE=haskell npm run test:fixtures -- test/inputs/json/priority/identifiers.json