### PR TITLE
fix(cjson): preserve arbitrary JSON values

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -5567,14 +5567,14 @@ export class CJSONRenderer extends ConvenienceRenderer {
             t,
             (_anyType) => {
                 return {
-                    cType: "void",
+                    cType: "cJSON",
                     optionalQualifier: "*",
-                    cjsonType: "cJSON_Invalid",
-                    isType: "cJSON_IsInvalid",
-                    getValue: "",
-                    addToObject: "",
-                    createObject: "",
-                    deleteType: "",
+                    cjsonType: "cJSON_Object",
+                    isType: "",
+                    getValue: "quicktype_cJSON_Duplicate",
+                    addToObject: "cJSON_AddItemToObject",
+                    createObject: "quicktype_cJSON_Duplicate",
+                    deleteType: "cJSON_Delete",
                     items: undefined,
                     isNullable,
                 };
@@ -5827,6 +5827,9 @@ export class CJSONRenderer extends ConvenienceRenderer {
             this.ensureBlankLine();
 
             /* Additional cJSON types */
+            this.emitLine(
+                "#define quicktype_cJSON_Duplicate(j) cJSON_Duplicate(j, true)",
+            );
             this.emitLine("#ifndef cJSON_Bool");
             this.emitLine("#define cJSON_Bool (cJSON_True | cJSON_False)");
             this.emitLine("#endif");

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -606,11 +606,8 @@ export const CJSONLanguage: Language = {
         ),
         /* Required properties absent are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         /* Pure Any type not supported (for the current implementation, can be added later, should manage a callback to provide the final application a way to handle it at parsing and creation of cJSON) */
-        "any.schema",
         "direct-union.schema",
-        "optional-any.schema",
         "recursive-union-flattening.schema",
-        "required-non-properties.schema",
         /* Class elements with invalid type are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         ...skipsUntypedUnions,
     ],


### PR DESCRIPTION
## Summary
- represent quicktype any values as owned cJSON trees
- duplicate values during parsing and serialization
- enable any, optional-any, and required-non-properties schema coverage

Production change: 10 inserted lines including seven field replacements.

## Tests
- npm run build
- npm run lint
- CPUs=1 FIXTURE=schema-cjson npm run test:fixtures -- test/inputs/schema/any.schema test/inputs/schema/optional-any.schema test/inputs/schema/required-non-properties.schema