### PR TITLE
fix(cjson): distinguish integers from doubles

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -5611,8 +5611,8 @@ export class CJSONRenderer extends ConvenienceRenderer {
                 return {
                     cType: this.typeIntegerSize,
                     optionalQualifier: isOptional === true ? "*" : "",
-                    cjsonType: "cJSON_Number",
-                    isType: "cJSON_IsNumber",
+                    cjsonType: "cJSON_Integer",
+                    isType: "quicktype_cJSON_IsInteger",
                     getValue: "cJSON_GetNumberValue",
                     addToObject: "cJSON_AddNumberToObject",
                     createObject: "cJSON_CreateNumber",
@@ -5827,6 +5827,10 @@ export class CJSONRenderer extends ConvenienceRenderer {
             this.ensureBlankLine();
 
             /* Additional cJSON types */
+            this.emitLine("#define cJSON_Integer (1 << 18)");
+            this.emitLine(
+                "#define quicktype_cJSON_IsInteger(j) (cJSON_IsNumber(j) && (j)->valuedouble == (int64_t)(j)->valuedouble)",
+            );
             this.emitLine("#ifndef cJSON_Bool");
             this.emitLine("#define cJSON_Bool (cJSON_True | cJSON_False)");
             this.emitLine("#endif");

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -594,10 +594,6 @@ export const CJSONLanguage: Language = {
         "integer-before-number.schema", // Python-specific union-order regression.
         /* Enum as TopLevel is not supported */
         "top-level-enum.schema",
-        /* Union with Number and Integer are not supported; min/max constraints on numbers rely on the same distinction */
-        ...skipsIntFloatUnions.filter(
-            (schema) => schema !== "minmax-integer.schema",
-        ),
         /* Union, Map and Arrays with invalid types are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         ...skipsMapValueValidation.filter(
             (schema) =>


### PR DESCRIPTION
## Summary
- add a generated cJSON integer discriminator
- select integer and double union members without truncation
- enable three numeric schema fixtures

Production change: 6 inserted lines including two field replacements.

## Tests
- npm run build
- npm run lint
- CPUs=1 FIXTURE=schema-cjson npm run test:fixtures -- test/inputs/schema/integer-float-union.schema test/inputs/schema/minmax.schema test/inputs/schema/union-int-double.schema