### PR TITLE
fix(scala3): require nullable uPickle properties

### DIFF
--- a/packages/quicktype-core/src/language/Scala3/Scala3Renderer.ts
+++ b/packages/quicktype-core/src/language/Scala3/Scala3Renderer.ts
@@ -292,7 +292,8 @@ export class Scala3Renderer extends ConvenienceRenderer {
                     scalaType(p),
                     p.isOptional
                         ? " = None"
-                        : nullableOrOptional
+                        : nullableOrOptional &&
+                            this._scalaOptions.framework !== "Upickle"
                           ? " = None"
                           : "",
                     last ? "" : ",",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1157,7 +1157,7 @@ export const Scala3UpickleLanguage: Language = {
         "af2d1.json",
     ],
     allowMissingNull: true,
-    features: ["enum", "union", "no-defaults"],
+    features: ["enum", "union", "no-defaults", "strict-optional"],
     output: "TopLevel.scala",
     topLevel: "TopLevel",
     skipJSON: [],


### PR DESCRIPTION
## Summary
- omit defaults for required nullable uPickle constructor fields
- preserve existing Circe behavior and optional-field defaults
- enable strict-optional uPickle schema coverage

Production change: 2 inserted lines and 1 deleted line.

## Tests
- npm run build
- npm run lint
- focused scala-cli fixture independently verified; scala-cli is not installed in this workspace