### PR TITLE
fix(pike): cast whole JSON numbers to float

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -346,7 +346,10 @@ export class PikeRenderer extends ConvenienceRenderer {
                                   this.nameForNamedType(enumType),
                                   '_from_JSON(json["',
                               ]
-                            : 'json["',
+                            : [
+                                  p.type.kind === "double" ? "(float)" : "",
+                                  'json["',
+                              ],
                         stringEscape(jsonName),
                         enumType instanceof EnumType ? '"])' : '"]',
                         ";",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1555,12 +1555,12 @@ export const PikeLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [
         // no implicit cast int <-> float in Pike
-        ...skipsIntFloatUnions,
+        ...skipsIntFloatUnions.filter(
+            (schema) => schema !== "integer-float-union.schema",
+        ),
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.
         ...skipsMapValueValidation,
-        "all-of-additional-properties-false.schema",
         "class-with-additional.schema",
-        "const-non-string.schema",
         "multi-type-enum.schema",
         "optional-any.schema",
         ...skipsUntypedUnions,


### PR DESCRIPTION
## Summary
- cast decoded JSON values for generated float properties
- accept mathematically whole JSON numbers where schemas require number
- enable three Pike schema fixtures

Production change: 4 inserted lines and 1 deleted line.

## Tests
- npm run build
- npm run lint
- FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/integer-float-union.schema test/inputs/schema/all-of-additional-properties-false.schema test/inputs/schema/const-non-string.schema