### PR TITLE
fix(pike): reject arrays for non-array unions

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -321,6 +321,17 @@ export class PikeRenderer extends ConvenienceRenderer {
                 this.emitLine([className, " retval = ", className, "();"]);
                 this.ensureBlankLine();
                 this.forEachClassProperty(c, "none", (name, jsonName, p) => {
+                    const rejectsArray =
+                        p.type instanceof UnionType &&
+                        nullableFromUnion(p.type) === null &&
+                        !Array.from(p.type.members).some(
+                            (t) => t instanceof ArrayType,
+                        );
+                    if (rejectsArray) {
+                        this.emitLine(
+                            `if (arrayp(json["${stringEscape(jsonName)}"])) error("Unexpected array");`,
+                        );
+                    }
                     if (
                         !p.isOptional &&
                         p.type.kind === "union" &&

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1400,7 +1400,6 @@ export const KotlinXLanguage: Language = {
         "integer-string.schema",
         "min-max-items.schema", // unionItems is an int|string union array
         "minmaxlength.schema",
-        "multi-type-enum.schema",
         "mutually-recursive.schema",
         "prefix-items.schema",
         "recursive-union-flattening.schema",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1400,6 +1400,7 @@ export const KotlinXLanguage: Language = {
         "integer-string.schema",
         "min-max-items.schema", // unionItems is an int|string union array
         "minmaxlength.schema",
+        "multi-type-enum.schema",
         "mutually-recursive.schema",
         "prefix-items.schema",
         "recursive-union-flattening.schema",
@@ -1512,7 +1513,6 @@ export const PikeLanguage: Language = {
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.
         ...skipsMapValueValidation,
         "class-with-additional.schema",
-        "multi-type-enum.schema",
         "optional-any.schema",
         ...skipsUntypedUnions,
     ],


### PR DESCRIPTION
## Summary
- reject JSON arrays when a Pike union has no array member
- enable `multi-type-enum.schema` for Pike

Production change: 11 lines.

## Tests
- `npm run build`
- `npm run lint`
- `CPUs=1 FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/multi-type-enum.schema test/inputs/schema/enum.schema`