### PR TITLE
fix(pike): validate integer map values

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -323,6 +323,15 @@ export class PikeRenderer extends ConvenienceRenderer {
                 this.forEachClassProperty(c, "none", (name, jsonName, p) => {
                     if (
                         !p.isOptional &&
+                        p.type instanceof MapType &&
+                        p.type.values.kind === "integer"
+                    ) {
+                        this.emitLine(
+                            `foreach (json["${stringEscape(jsonName)}"]; mixed _; mixed value) if (!intp(value)) error("Expected integer");`,
+                        );
+                    }
+                    if (
+                        !p.isOptional &&
                         p.type.kind === "union" &&
                         nullableFromUnion(p.type as UnionType) !== null
                     ) {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1266,7 +1266,9 @@ export const KotlinLanguage: Language = {
         // instead of rejecting it.
         "nested-intersection-union.schema",
         "class-with-additional.schema",
-        ...skipsMapValueValidation,
+        ...skipsMapValueValidation.filter(
+            (schema) => schema !== "go-schema-pattern-properties.schema",
+        ),
         // IllegalArgumentException
         // KlaxonException: Need to extract inside
         "bool-string.schema",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1266,9 +1266,7 @@ export const KotlinLanguage: Language = {
         // instead of rejecting it.
         "nested-intersection-union.schema",
         "class-with-additional.schema",
-        ...skipsMapValueValidation.filter(
-            (schema) => schema !== "go-schema-pattern-properties.schema",
-        ),
+        ...skipsMapValueValidation,
         // IllegalArgumentException
         // KlaxonException: Need to extract inside
         "bool-string.schema",
@@ -1513,7 +1511,9 @@ export const PikeLanguage: Language = {
             (schema) => schema !== "integer-float-union.schema",
         ),
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.
-        ...skipsMapValueValidation,
+        ...skipsMapValueValidation.filter(
+            (schema) => schema !== "go-schema-pattern-properties.schema",
+        ),
         "class-with-additional.schema",
         "multi-type-enum.schema",
         "optional-any.schema",


### PR DESCRIPTION
## Summary
- reject non-integer JSON values in required Pike integer maps
- enable `go-schema-pattern-properties.schema` for Pike

Production change: 9 lines.

## Tests
- `npm run build`
- `npm run lint:fix`
- `CPUs=1 FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/go-schema-pattern-properties.schema`