### PR TITLE
fix(pike): reject strings in map unions

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -341,6 +341,21 @@ export class PikeRenderer extends ConvenienceRenderer {
                             `foreach (json["${stringEscape(jsonName)}"]; mixed _; mixed value) if (!intp(value)) error("Expected integer");`,
                         );
                     }
+                    const mapType =
+                        p.type instanceof UnionType
+                            ? nullableFromUnion(p.type)
+                            : p.type;
+                    const rejectsStringMap =
+                        mapType instanceof MapType &&
+                        mapType.values instanceof UnionType &&
+                        !Array.from(mapType.values.members).some(
+                            (t) => t.kind === "string",
+                        );
+                    if (rejectsStringMap) {
+                        this.emitLine(
+                            `foreach (json["${stringEscape(jsonName)}"]; mixed _; mixed value) if (stringp(value)) error("Unexpected string");`,
+                        );
+                    }
                     if (
                         !p.isOptional &&
                         p.type.kind === "union" &&

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1283,6 +1283,7 @@ export const KotlinLanguage: Language = {
         // Deserializes an array where a union of two classes is expected
         // instead of rejecting it.
         "nested-intersection-union.schema",
+        "class-with-additional.schema",
         ...skipsMapValueValidation,
         // IllegalArgumentException
         // KlaxonException: Need to extract inside
@@ -1505,7 +1506,6 @@ export const PikeLanguage: Language = {
         ...skipsMapValueValidation.filter(
             (schema) => schema !== "go-schema-pattern-properties.schema",
         ),
-        "class-with-additional.schema",
         "optional-any.schema",
         ...skipsUntypedUnions,
     ],

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1283,7 +1283,6 @@ export const KotlinLanguage: Language = {
         // Deserializes an array where a union of two classes is expected
         // instead of rejecting it.
         "nested-intersection-union.schema",
-        "class-with-additional.schema",
         ...skipsMapValueValidation,
         // IllegalArgumentException
         // KlaxonException: Need to extract inside


### PR DESCRIPTION
## Summary
- reject string map values when the generated Pike union has no string member
- enable `class-with-additional.schema` for Pike

Production change: 15 lines.

## Tests
- `npm run build`
- `npm run lint`
- `CPUs=1 FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/class-with-additional.schema`