### PR TITLE
fix(pike): validate required booleans

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -341,6 +341,11 @@ export class PikeRenderer extends ConvenienceRenderer {
                             `foreach (json["${stringEscape(jsonName)}"]; mixed _; mixed value) if (!intp(value)) error("Expected integer");`,
                         );
                     }
+                    if (!p.isOptional && p.type.kind === "bool") {
+                        this.emitLine(
+                            `if (json["${stringEscape(jsonName)}"] != Standards.JSON.true && json["${stringEscape(jsonName)}"] != Standards.JSON.false) error("Expected bool");`,
+                        );
+                    }
                     if (
                         !p.isOptional &&
                         p.type.kind === "union" &&

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1507,7 +1507,6 @@ export const PikeLanguage: Language = {
             (schema) => schema !== "go-schema-pattern-properties.schema",
         ),
         "class-with-additional.schema",
-        "optional-any.schema",
         ...skipsUntypedUnions,
     ],
     rendererOptions: {},


### PR DESCRIPTION
## Summary
- reject non-boolean JSON values assigned to required Pike boolean properties
- enable `optional-any.schema` for Pike

Production change: 5 lines.

## Tests
- `npm run build`
- `npm run lint`
- `CPUs=1 FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/optional-any.schema`