### PR TITLE
fix(php): support top-level typed maps

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -28,6 +28,7 @@ import {
     type ClassProperty,
     type ClassType,
     type EnumType,
+    MapType,
     type Type,
     UnionType,
 } from "../../Type/index.js";
@@ -107,6 +108,8 @@ export class PhpRenderer extends ConvenienceRenderer {
     }
 
     protected namedTypeToNameForTopLevel(type: Type): Type | undefined {
+        if (type instanceof MapType && type.values.kind === "class")
+            return undefined;
         return directlyReachableSingleNamedType(type);
     }
 
@@ -1850,6 +1853,17 @@ export class PhpRenderer extends ConvenienceRenderer {
     protected emitSourceStructure(givenFilename: string): void {
         this.emitLine("<?php");
         this.emitLine("declare(strict_types=1);");
+        this.forEachTopLevel("none", (t, name) => {
+            if (!(t instanceof MapType) || t.values.kind !== "class") return;
+            const topLevel = this.sourcelikeToString(name);
+            const valueType = this.sourcelikeToString(
+                this.nameForNamedType(t.values),
+            );
+            this.emitMultiline(`class ${topLevel} { private array $value;
+public function __construct(array $value) { $this->value = $value; }
+public static function from(stdClass $obj): ${topLevel} { return new ${topLevel}(array_map(fn($value) => ${valueType}::from($value), (array)$obj)); }
+public function to(): stdClass { return (object)array_map(fn($value) => $value->to(), $this->value); } }`);
+        });
         this.forEachNamedType(
             "leading-and-interposing",
             (c: ClassType, n: Name) => this.emitClassDefinition(c, n),

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1612,7 +1612,6 @@ export const PHPLanguage: Language = {
     output: "TopLevel.php",
     topLevel: "TopLevel",
     skipJSON: [
-        "bug855-short.json",
         "bug863.json",
         "issue2680-scalar-array.json",
         "no-classes.json",


### PR DESCRIPTION
Emits a top-level adapter for maps whose values are generated classes.\n\nTests: php bug855-short.json