### PR TITLE
fix(cjson): accept null in direct unions

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -678,10 +678,10 @@ export class CJSONRenderer extends ConvenienceRenderer {
      */
     protected emitUnionPrototypes(unionType: UnionType): void {
         const unionName = this.nameForNamedType(unionType);
-        const checks: Sourcelike[] = Array.from(
-            removeNullFromUnion(unionType)[1],
-            (type) => [this.quicktypeTypeToCJSON(type, false).isType, "(j)"],
-        );
+        const checks: Sourcelike[] = Array.from(unionType.members, (type) => [
+            this.quicktypeTypeToCJSON(type, false).isType,
+            "(j)",
+        ]);
 
         this.emitLine(
             "#define cJSON_Is",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -586,7 +586,6 @@ export const CJSONLanguage: Language = {
         ),
         /* Required properties absent are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         /* Pure Any type not supported (for the current implementation, can be added later, should manage a callback to provide the final application a way to handle it at parsing and creation of cJSON) */
-        "direct-union.schema",
         "recursive-union-flattening.schema",
         /* Class elements with invalid type are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         ...skipsUntypedUnions,


### PR DESCRIPTION
Includes null in generated direct-union type predicates, matching the existing null decode branch.\n\nTests: schema-cjson direct-union.schema