### PR TITLE
fix(cjson): add top-level union APIs

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -678,6 +678,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
      */
     protected emitUnionPrototypes(unionType: UnionType): void {
         const unionName = this.nameForNamedType(unionType);
+        const renderedUnionName = this.sourcelikeToString(unionName);
         const checks: Sourcelike[] = Array.from(
             removeNullFromUnion(unionType)[1],
             (type) => [this.quicktypeTypeToCJSON(type, false).isType, "(j)"],
@@ -712,6 +713,12 @@ export class CJSONRenderer extends ConvenienceRenderer {
             unionName,
             " * x);",
         );
+        this.emitLine(
+            `struct ${renderedUnionName} * cJSON_Parse${renderedUnionName}(const char * s);`,
+        );
+        this.emitLine(
+            `char * cJSON_Print${renderedUnionName}(const struct ${renderedUnionName} * x);`,
+        );
         this.ensureBlankLine();
     }
 
@@ -722,6 +729,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
     protected emitUnionFunctions(unionType: UnionType): void {
         const [hasNull, nonNulls] = removeNullFromUnion(unionType);
         const unionName = this.nameForNamedType(unionType);
+        const renderedUnionName = this.sourcelikeToString(unionName);
 
         /* Create cJSON to unionType generator function */
         this.emitBlock(
@@ -1259,6 +1267,12 @@ export class CJSONRenderer extends ConvenienceRenderer {
                 });
                 this.emitLine("return x;");
             },
+        );
+        this.emitLine(
+            `struct ${renderedUnionName} * cJSON_Parse${renderedUnionName}(const char * s) { cJSON * j = cJSON_Parse(s); struct ${renderedUnionName} * x = j ? cJSON_Get${renderedUnionName}Value(j) : NULL; cJSON_Delete(j); return x; }`,
+        );
+        this.emitLine(
+            `char * cJSON_Print${renderedUnionName}(const struct ${renderedUnionName} * x) { cJSON * j = cJSON_Create${renderedUnionName}(x); char * s = j ? cJSON_Print(j) : NULL; cJSON_Delete(j); return s; }`,
         );
         this.ensureBlankLine();
 

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -575,7 +575,6 @@ export const CJSONLanguage: Language = {
     ],
     skipMiscJSON: false,
     skipSchema: [
-        "integer-before-number.schema", // Python-specific union-order regression.
         /* Enum as TopLevel is not supported */
         "top-level-enum.schema",
         /* Union, Map and Arrays with invalid types are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
@@ -587,7 +586,6 @@ export const CJSONLanguage: Language = {
         /* Required properties absent are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         /* Pure Any type not supported (for the current implementation, can be added later, should manage a callback to provide the final application a way to handle it at parsing and creation of cJSON) */
         "direct-union.schema",
-        "recursive-union-flattening.schema",
         /* Class elements with invalid type are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
         ...skipsUntypedUnions,
     ],


### PR DESCRIPTION
Emits Parse and Print convenience APIs for named top-level unions.\n\nTests: schema-cjson integer-before-number.schema and recursive-union-flattening.schema