### PR TITLE
fix(cjson): validate class-map union values

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -1250,12 +1250,7 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                     );
                                     if (cJSON.cjsonType === "cJSON_Object") {
                                         this.emitLine(
-                                            "if (NULL == x->value.",
-                                            this.nameForUnionMember(
-                                                unionType,
-                                                type,
-                                            ),
-                                            ") x->type = 0;",
+                                            `if (NULL == x->value.${this.sourcelikeToString(this.nameForUnionMember(unionType, type))}) x->type = 0;`,
                                         );
                                     }
                                 }
@@ -2989,8 +2984,14 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                                                         ?.cjsonType ===
                                                                                         "cJSON_Union"
                                                                                 ) {
-                                                                                    this.emitLine(
-                                                                                        `${this.sourcelikeToString(cJSON.items?.cType ?? "")} * validated = ${this.sourcelikeToString(cJSON.items?.getValue ?? "")}(${element}); if (NULL == validated) { x${level > 0 ? level.toString() : ""}->${this.sourcelikeToString(name)} = x${child_level}; cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; } ${this.sourcelikeToString(cJSON.items?.deleteType ?? "")}(validated);`,
+                                                                                    this.emitMultiline(
+                                                                                        `${this.sourcelikeToString(cJSON.items?.cType ?? "")} * validated = ${this.sourcelikeToString(cJSON.items?.getValue ?? "")}(${element});
+if (NULL == validated) {
+    x${level > 0 ? level.toString() : ""}->${this.sourcelikeToString(name)} = x${child_level};
+    cJSON_Delete${this.sourcelikeToString(className)}(x);
+    return NULL;
+}
+${this.sourcelikeToString(cJSON.items?.deleteType ?? "")}(validated);`,
                                                                                     );
                                                                                     this.emitLine(
                                                                                         "hashtable_add(x",

--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -1248,6 +1248,16 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                         cJSON.getValue,
                                         "(j);",
                                     );
+                                    if (cJSON.cjsonType === "cJSON_Object") {
+                                        this.emitLine(
+                                            "if (NULL == x->value.",
+                                            this.nameForUnionMember(
+                                                unionType,
+                                                type,
+                                            ),
+                                            ") x->type = 0;",
+                                        );
+                                    }
                                 }
                             },
                         );
@@ -2979,6 +2989,9 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                                                         ?.cjsonType ===
                                                                                         "cJSON_Union"
                                                                                 ) {
+                                                                                    this.emitLine(
+                                                                                        `${this.sourcelikeToString(cJSON.items?.cType ?? "")} * validated = ${this.sourcelikeToString(cJSON.items?.getValue ?? "")}(${element}); if (NULL == validated) { x${level > 0 ? level.toString() : ""}->${this.sourcelikeToString(name)} = x${child_level}; cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; } ${this.sourcelikeToString(cJSON.items?.deleteType ?? "")}(validated);`,
+                                                                                    );
                                                                                     this.emitLine(
                                                                                         "hashtable_add(x",
                                                                                         child_level.toString(),

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -589,7 +589,9 @@ export const CJSONLanguage: Language = {
         "direct-union.schema",
         "recursive-union-flattening.schema",
         /* Class elements with invalid type are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
-        ...skipsUntypedUnions,
+        ...skipsUntypedUnions.filter(
+            (schema) => schema !== "class-map-union.schema",
+        ),
     ],
     rendererOptions: { "header-only": "false" },
     quickTestRendererOptions: [


### PR DESCRIPTION
Rejects class/map union branches when nested object decoding fails and cleans up partial maps.\n\nTests: schema-cjson class-map-union.schema