### PR TITLE
fix(kotlinx): alias unsupported named unions

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinXRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinXRenderer.ts
@@ -38,6 +38,14 @@ const dateTimeSerializers = [
  * TODO: Union, Any, Top Level Array, Top Level Map
  */
 export class KotlinXRenderer extends KotlinRenderer {
+    protected override emitUnionDefinition(u: UnionType, name: Name): void {
+        if (nullableFromUnion(u) === null) {
+            this.emitLine(["typealias ", name, " = JsonElement"]);
+            return;
+        }
+        super.emitUnionDefinition(u, name);
+    }
+
     protected override kotlinType(
         t: Type,
         withIssues = false,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1397,13 +1397,9 @@ export const KotlinXLanguage: Language = {
         // deserialization fails at runtime (documented TODO in
         // KotlinXRenderer.ts).
         "enum.schema", // enum.3.json contains an int|string union
-        "recursive-union-flattening.schema",
-        "rust-cycle-breaker-union.schema",
-        "tuple.schema",
         // Additionally exceeds the JVM's 255-parameter limit when the
         // serialization plugin generates the synthesized constructors.
         "keyword-unions.schema",
-        "union.schema",
     ],
     skipMiscJSON: false,
     rendererOptions: { framework: "kotlinx" },


### PR DESCRIPTION
Emits JsonElement aliases for non-nullable named unions, matching KotlinX's existing type fallback and serializer support.\n\nTests: schema-kotlinx recursive-union-flattening, rust-cycle-breaker-union, tuple, and union schemas