### PR TITLE
fix(haskell): escape BMP and astral code points

### DIFF
--- a/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
+++ b/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
@@ -30,7 +30,11 @@ import type { haskellOptions } from "./language.js";
 import { lowerNamingFunction, upperNamingFunction } from "./utils.js";
 
 function haskellStringEscape(s: string): string {
-    return stringEscape(s).replace(/\\U0*([0-9a-fA-F]+)/g, "\\x$1\\&");
+    return stringEscape(s).replace(
+        /\\u([0-9a-fA-F]{4})|\\U([0-9a-fA-F]{8})/g,
+        (_match, bmp: string | undefined, astral: string | undefined) =>
+            `\\x${bmp ?? astral}\\&`,
+    );
 }
 
 export class HaskellRenderer extends ConvenienceRenderer {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1582,7 +1582,7 @@ export const HaskellLanguage: Language = {
     features: ["enum", "union", "no-defaults"],
     output: "QuickType.hs",
     topLevel: "QuickType",
-    skipJSON: ["combinations4.json", "blns-object.json", "nst-test-suite.json"],
+    skipJSON: ["combinations4.json", "nst-test-suite.json"],
     skipMiscJSON: false,
     skipSchema: [...skipsUntypedUnions, "keyword-unions.schema"],
     rendererOptions: {},


### PR DESCRIPTION
Uses fixed-width Unicode escape matching so BMP escapes are converted and astral escapes do not consume following hex characters.\n\nTests: haskell blns-object.json