### PR TITLE
fix(php): support primitive top levels

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -25,6 +25,7 @@ import { acronymStyle } from "../../support/Acronyms.js";
 import { defined } from "../../support/Support.js";
 import type { TargetLanguage } from "../../TargetLanguage.js";
 import {
+    ArrayType,
     type ClassProperty,
     type ClassType,
     type EnumType,
@@ -1863,6 +1864,20 @@ export class PhpRenderer extends ConvenienceRenderer {
 public function __construct(array $value) { $this->value = $value; }
 public static function from(stdClass $obj): ${topLevel} { return new ${topLevel}(array_map(fn($value) => ${valueType}::from($value), (array)$obj)); }
 public function to(): stdClass { return (object)array_map(fn($value) => $value->to(), $this->value); } }`);
+        });
+        this.forEachTopLevel("none", (t, name) => {
+            const topLevel = this.sourcelikeToString(name);
+            const isPrimitiveArray =
+                t instanceof ArrayType && t.items.isPrimitive();
+            if (t.isPrimitive()) {
+                this.emitMultiline(`class ${topLevel} { public static function from($obj) { return $obj; }
+public static function to($obj) { return $obj; } }`);
+            } else if (isPrimitiveArray) {
+                this.emitMultiline(`class ${topLevel} { private $value;
+public function __construct($value) { $this->value = $value; }
+public static function from($obj): ${topLevel} { return new ${topLevel}($obj); }
+public function to() { return $this->value; } }`);
+            }
         });
         this.forEachNamedType(
             "leading-and-interposing",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1606,8 +1606,6 @@ export const PHPLanguage: Language = {
     topLevel: "TopLevel",
     skipJSON: [
         "bug863.json",
-        "issue2680-scalar-array.json",
-        "no-classes.json",
         "00c36.json",
         "2df80.json",
         "7fbfb.json",
@@ -1622,7 +1620,6 @@ export const PHPLanguage: Language = {
         // top-level union produces no named TopLevel class for the driver.
         "recursive-union-flattening.schema",
         // The driver does not support top-level arrays.
-        "top-level-primitive-array.schema",
         "issue2680-top-level-array.schema",
     ],
     rendererOptions: {},


### PR DESCRIPTION
Emits lightweight top-level adapters for primitive values and arrays of primitives.\n\nTests: php no-classes.json, issue2680-scalar-array.json; schema-php top-level-primitive-array.schema