### PR TITLE
fix(elm): validate array cardinality

### DIFF
--- a/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
+++ b/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
@@ -4,6 +4,7 @@ import {
     anyTypeIssueAnnotation,
     nullTypeIssueAnnotation,
 } from "../../Annotation.js";
+import { minMaxItemsForType } from "../../attributes/Constraints.js";
 import { minMaxValueForType } from "../../attributes/Constraints.js";
 import {
     ConvenienceRenderer,
@@ -244,6 +245,15 @@ export class ElmRenderer extends ConvenienceRenderer {
         );
     }
 
+    private arrayConstraint(t: Type): string {
+        const [min, max] = minMaxItemsForType(t) ?? [];
+        if (min === undefined && max === undefined) return "";
+        const length = `${this.arrayType}.length x`;
+        const minCheck = min === undefined ? "True" : `${length} >= ${min}`;
+        const maxCheck = max === undefined ? "True" : `${length} <= ${max}`;
+        return `|> Jdec.andThen (\\x -> if ${minCheck} && ${maxCheck} then Jdec.succeed x else Jdec.fail "Array length out of range")`;
+    }
+
     private decoderNameForType(t: Type, noOptional = false): MultiWord {
         return matchType<MultiWord>(
             t,
@@ -258,6 +268,7 @@ export class ElmRenderer extends ConvenienceRenderer {
                     " ",
                     ["Jdec.", decapitalize(this.arrayType)],
                     parenIfNeeded(this.decoderNameForType(arrayType.items)),
+                    this.arrayConstraint(arrayType),
                 ),
             (classType) => singleWord(this.decoderNameForNamedType(classType)),
             (mapType) =>

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -781,6 +781,7 @@ export const ElmLanguage: Language = {
         "integer",
         "minmax",
         "minmaxInteger",
+        "minmaxitems",
     ],
     output: "QuickType.elm",
     topLevel: "QuickType",


### PR DESCRIPTION
Adds decoder checks for schema minItems and maxItems constraints for List and Array output.\n\nTests: schema-elm min-max-items.schema