### PR TITLE
fix(cjson): validate union array elements

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -803,6 +803,14 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                     ")",
                                                 ],
                                                 () => {
+                                                    if (
+                                                        cJSON.items?.isType !==
+                                                        ""
+                                                    ) {
+                                                        this.emitLine(
+                                                            `if (!${this.sourcelikeToString(cJSON.items?.isType ?? "")}(e${child_level})) { x->value.${this.sourcelikeToString(this.nameForUnionMember(unionType, type))} = x${child_level}; cJSON_Delete${this.sourcelikeToString(unionName)}(x); return NULL; }`,
+                                                        );
+                                                    }
                                                     const add = (
                                                         cJSON: TypeCJSON,
                                                         level: number,
@@ -1248,6 +1256,11 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                         cJSON.getValue,
                                         "(j);",
                                     );
+                                    if (cJSON.cjsonType === "cJSON_Object") {
+                                        this.emitLine(
+                                            `if (NULL == x->value.${this.sourcelikeToString(this.nameForUnionMember(unionType, type))}) x->type = 0;`,
+                                        );
+                                    }
                                 }
                             },
                         );

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -589,7 +589,9 @@ export const CJSONLanguage: Language = {
         "direct-union.schema",
         "recursive-union-flattening.schema",
         /* Class elements with invalid type are not checked (for the current implementation, can be added later, should abord parsing and return NULL) */
-        ...skipsUntypedUnions,
+        ...skipsUntypedUnions.filter(
+            (schema) => schema !== "implicit-class-array-union.schema",
+        ),
     ],
     rendererOptions: { "header-only": "false" },
     quickTestRendererOptions: [


### PR DESCRIPTION
Validates union array elements before storing them and cleans partial lists on failure.\n\nTests: schema-cjson implicit-class-array-union.schema