### PR TITLE
fix(ruby): validate date-time schema strings

### DIFF
--- a/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
+++ b/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
@@ -190,8 +190,10 @@ export class RubyRenderer extends ConvenienceRenderer {
                     optional,
                 ];
             },
-            (_transformed) => [
-                "Types::String.constrained(format: /\\A[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\\z/i)",
+            (transformed) => [
+                transformed.kind === "uuid"
+                    ? "Types::String.constrained(format: /\\A[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\\z/i)"
+                    : "Types::String.constrained(format: /\\A\\d{4}-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d(?:\\.\\d+)?(?:Z|[+-]\\d\\d:\\d\\d)\\z/i)",
                 optional,
             ],
         );

--- a/packages/quicktype-core/src/language/Ruby/language.ts
+++ b/packages/quicktype-core/src/language/Ruby/language.ts
@@ -56,7 +56,10 @@ export class RubyTargetLanguage extends TargetLanguage<
     }
 
     public get stringTypeMapping() {
-        return new Map([["uuid", "uuid"] as const]);
+        return new Map([
+            ["uuid", "uuid"] as const,
+            ["date-time", "date-time"] as const,
+        ]);
     }
 
     public get supportsOptionalClassProperties(): boolean {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -471,6 +471,7 @@ export const RubyLanguage: Language = {
         "pattern",
         "strict-optional",
         "uuid",
+        "date-time",
     ],
     output: "TopLevel.rb",
     topLevel: "TopLevel",


### PR DESCRIPTION
Maps date-time schema strings to constrained RFC 3339 Dry strings so invalid timestamps are rejected.\n\nTests: schema-ruby date-time.schema