### PR TITLE
fix(ruby): validate UUID schema strings

### DIFF
--- a/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
+++ b/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
@@ -190,6 +190,10 @@ export class RubyRenderer extends ConvenienceRenderer {
                     optional,
                 ];
             },
+            (_transformed) => [
+                "Types::String.constrained(format: /\\A[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\\z/i)",
+                optional,
+            ],
         );
     }
 
@@ -279,6 +283,7 @@ export class RubyRenderer extends ConvenienceRenderer {
 
                 return exp;
             },
+            (_transformed) => exp,
         );
     }
 
@@ -368,6 +373,7 @@ export class RubyRenderer extends ConvenienceRenderer {
                 ];
                 return optional ? [e, " ? ", expression, " : nil"] : expression;
             },
+            (_transformed) => primitive,
         );
     }
 
@@ -412,6 +418,7 @@ export class RubyRenderer extends ConvenienceRenderer {
 
                 return [e, optional ? "&" : "", ".to_dynamic"];
             },
+            (_transformed) => e,
         );
     }
 
@@ -436,6 +443,7 @@ export class RubyRenderer extends ConvenienceRenderer {
 
                 return false;
             },
+            (_transformed) => true,
         );
     }
 
@@ -467,6 +475,7 @@ export class RubyRenderer extends ConvenienceRenderer {
 
                 return false;
             },
+            (_transformed) => true,
         );
     }
 

--- a/packages/quicktype-core/src/language/Ruby/language.ts
+++ b/packages/quicktype-core/src/language/Ruby/language.ts
@@ -55,6 +55,10 @@ export class RubyTargetLanguage extends TargetLanguage<
         return rubyOptions;
     }
 
+    public get stringTypeMapping() {
+        return new Map([["uuid", "uuid"] as const]);
+    }
+
     public get supportsOptionalClassProperties(): boolean {
         return true;
     }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -468,6 +468,7 @@ export const RubyLanguage: Language = {
         "minmaxlength",
         "pattern",
         "strict-optional",
+        "uuid",
     ],
     output: "TopLevel.rb",
     topLevel: "TopLevel",


### PR DESCRIPTION
Maps UUID schema strings to constrained Dry strings so malformed UUIDs are rejected while preserving string round trips.\n\nTests: schema-ruby uuid.schema