### PR TITLE
fix(haskell): preserve double precision

### DIFF
--- a/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
+++ b/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
@@ -141,7 +141,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
             (_nullType) => multiWord(" ", "Maybe", "Text"),
             (_boolType) => singleWord("Bool"),
             (_integerType) => singleWord("Int"),
-            (_doubleType) => singleWord("Float"),
+            (_doubleType) => singleWord("Double"),
             (_stringType) => singleWord("Text"),
             (arrayType) => {
                 if (this._options.useList) {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1582,7 +1582,7 @@ export const HaskellLanguage: Language = {
     features: ["enum", "union", "no-defaults"],
     output: "QuickType.hs",
     topLevel: "QuickType",
-    skipJSON: ["combinations4.json", "nst-test-suite.json"],
+    skipJSON: ["combinations4.json"],
     skipMiscJSON: false,
     skipSchema: [...skipsUntypedUnions, "keyword-unions.schema"],
     rendererOptions: {},


### PR DESCRIPTION
Uses Haskell Double for JSON numbers so large and high-precision values round-trip without becoming null or losing digits. This is stacked on the Unicode-escape fix in #3397 because the enabled fixture exercises both.\n\nTests: haskell nst-test-suite.json