### PR TITLE
fix(pike): decode nested class properties

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -362,6 +362,14 @@ export class PikeRenderer extends ConvenienceRenderer {
                         );
                     }
                     if (
+                        mapType instanceof MapType &&
+                        mapType.values instanceof ArrayType
+                    ) {
+                        this.emitLine(
+                            `foreach (json["${stringEscape(jsonName)}"]; mixed _; mixed value) if (!arrayp(value)) error("Expected array");`,
+                        );
+                    }
+                    if (
                         !p.isOptional &&
                         p.type.kind === "union" &&
                         nullableFromUnion(p.type as UnionType) !== null

--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -13,7 +13,7 @@ import {
 import { stringEscape } from "../../support/Strings.js";
 import {
     ArrayType,
-    type ClassType,
+    ClassType,
     EnumType,
     MapType,
     PrimitiveType,
@@ -377,6 +377,17 @@ export class PikeRenderer extends ConvenienceRenderer {
                         p.type instanceof UnionType
                             ? nullableFromUnion(p.type)
                             : p.type;
+                    if (enumType instanceof ClassType) {
+                        const nestedTypeName = this.sourcelikeToString(
+                            this.nameForNamedType(enumType),
+                        );
+                        const nestedValue = `json["${stringEscape(jsonName)}"]`;
+                        this.emitLine(
+                            p.type instanceof UnionType
+                                ? `if (has_index(json, "${stringEscape(jsonName)}") && ${nestedValue} != Val.null) ${nestedTypeName}_from_JSON(${nestedValue});`
+                                : `${nestedTypeName}_from_JSON(${nestedValue});`,
+                        );
+                    }
                     this.emitLine([
                         "retval.",
                         name,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1504,7 +1504,9 @@ export const PikeLanguage: Language = {
         ),
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.
         ...skipsMapValueValidation.filter(
-            (schema) => schema !== "go-schema-pattern-properties.schema",
+            (schema) =>
+                schema !== "go-schema-pattern-properties.schema" &&
+                schema !== "unevaluated-properties.schema",
         ),
         ...skipsUntypedUnions,
     ],


### PR DESCRIPTION
Summary
- validate nested object properties through their generated class decoder
- preserve nullable and missing nested-class behavior
- retain Pike mappings for reliable JSON serialization

Tests
- npm run build
- npm run lint
- QUICKTEST=true FIXTURE=pike,schema-pike npm run test:fixtures