### PR TITLE
fix(pike): validate array-valued maps

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -362,6 +362,14 @@ export class PikeRenderer extends ConvenienceRenderer {
                         );
                     }
                     if (
+                        mapType instanceof MapType &&
+                        mapType.values instanceof ArrayType
+                    ) {
+                        this.emitLine(
+                            `foreach (json["${stringEscape(jsonName)}"]; mixed _; mixed value) if (!arrayp(value)) error("Expected array");`,
+                        );
+                    }
+                    if (
                         !p.isOptional &&
                         p.type.kind === "union" &&
                         nullableFromUnion(p.type as UnionType) !== null

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1504,7 +1504,9 @@ export const PikeLanguage: Language = {
         ),
         // all below: not failing on expected failure. That's because Pike's quite tolerant with assignments.
         ...skipsMapValueValidation.filter(
-            (schema) => schema !== "go-schema-pattern-properties.schema",
+            (schema) =>
+                schema !== "go-schema-pattern-properties.schema" &&
+                schema !== "unevaluated-properties.schema",
         ),
         ...skipsUntypedUnions,
     ],


### PR DESCRIPTION
Summary
- validate map values whose schema type is an array
- enable the unevaluated-properties schema fixture

Tests
- npm run build
- npm run lint
- FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/unevaluated-properties.schema