### PR TITLE
fix(pike): validate array cardinality

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -3,6 +3,7 @@ import {
     type ForbiddenWordsInfo,
 } from "../../ConvenienceRenderer.js";
 import {
+    minMaxItemsForType,
     minMaxLengthForType,
     minMaxValueForType,
 } from "../../attributes/Constraints.js";
@@ -347,6 +348,16 @@ export class PikeRenderer extends ConvenienceRenderer {
                     if (maxLength !== undefined)
                         this.emitLine(
                             `if (${optionalGuard}sizeof(${jsonValue}) > ${maxLength}) error("String too long");`,
+                        );
+                    const [minItems, maxItems] =
+                        minMaxItemsForType(p.type) ?? [];
+                    if (minItems !== undefined)
+                        this.emitLine(
+                            `if (${optionalGuard}sizeof(${jsonValue}) < ${minItems}) error("Array too short");`,
+                        );
+                    if (maxItems !== undefined)
+                        this.emitLine(
+                            `if (${optionalGuard}sizeof(${jsonValue}) > ${maxItems}) error("Array too long");`,
                         );
                     const rejectsArray =
                         p.type instanceof UnionType &&

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1499,6 +1499,7 @@ export const PikeLanguage: Language = {
         "minmax",
         "minmaxInteger",
         "minmaxlength",
+        "minmaxitems",
     ],
     output: "TopLevel.pmod",
     topLevel: "TopLevel",


### PR DESCRIPTION
Summary
- enforce schema minimum and maximum item counts
- enable the array-cardinality schema fixture

Tests
- npm run build
- npm run lint
- FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/min-max-items.schema