### PR TITLE
fix(pike): validate string patterns

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -6,6 +6,7 @@ import {
     minMaxItemsForType,
     minMaxLengthForType,
     minMaxValueForType,
+    patternForType,
 } from "../../attributes/Constraints.js";
 import type { Name, Namer } from "../../Naming.js";
 import {
@@ -358,6 +359,11 @@ export class PikeRenderer extends ConvenienceRenderer {
                     if (maxItems !== undefined)
                         this.emitLine(
                             `if (${optionalGuard}sizeof(${jsonValue}) > ${maxItems}) error("Array too long");`,
+                        );
+                    const pattern = patternForType(p.type);
+                    if (pattern !== undefined)
+                        this.emitLine(
+                            `if (${optionalGuard}!Regexp("${stringEscape(pattern)}")->match(${jsonValue})) error("String does not match pattern");`,
                         );
                     const rejectsArray =
                         p.type instanceof UnionType &&

--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -365,6 +365,14 @@ export class PikeRenderer extends ConvenienceRenderer {
                         this.emitLine(
                             `if (${optionalGuard}!Regexp("${stringEscape(pattern)}")->match(${jsonValue})) error("String does not match pattern");`,
                         );
+                    const requiredType =
+                        p.type instanceof UnionType
+                            ? nullableFromUnion(p.type)
+                            : p.type;
+                    if (!p.isOptional && requiredType?.kind === "integer")
+                        this.emitLine(
+                            `if (!intp(${jsonValue})) error("Expected integer");`,
+                        );
                     const rejectsArray =
                         p.type instanceof UnionType &&
                         nullableFromUnion(p.type) === null &&

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1500,6 +1500,7 @@ export const PikeLanguage: Language = {
         "minmaxInteger",
         "minmaxlength",
         "minmaxitems",
+        "pattern",
     ],
     output: "TopLevel.pmod",
     topLevel: "TopLevel",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1496,6 +1496,7 @@ export const PikeLanguage: Language = {
     features: [
         "strict-optional",
         "enum",
+        "integer",
         "minmax",
         "minmaxInteger",
         "minmaxlength",


### PR DESCRIPTION
Summary
- enforce schema regex patterns in generated decoders
- enable the pattern schema fixture

Tests
- npm run build
- npm run lint
- FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/pattern.schema