### PR TITLE
fix(pike): reject fractional integers

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -365,6 +365,14 @@ export class PikeRenderer extends ConvenienceRenderer {
                         this.emitLine(
                             `if (${optionalGuard}!Regexp("${stringEscape(pattern)}")->match(${jsonValue})) error("String does not match pattern");`,
                         );
+                    const requiredType =
+                        p.type instanceof UnionType
+                            ? nullableFromUnion(p.type)
+                            : p.type;
+                    if (!p.isOptional && requiredType?.kind === "integer")
+                        this.emitLine(
+                            `if (!intp(${jsonValue})) error("Expected integer");`,
+                        );
                     const rejectsArray =
                         p.type instanceof UnionType &&
                         nullableFromUnion(p.type) === null &&

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1496,6 +1496,7 @@ export const PikeLanguage: Language = {
     features: [
         "strict-optional",
         "enum",
+        "integer",
         "minmax",
         "minmaxInteger",
         "minmaxlength",


### PR DESCRIPTION
Summary
- reject fractional values where schemas require integers
- cover nullable integer unions through the same validation path

Tests
- npm run build
- npm run lint
- FIXTURE=schema-pike npm run test:fixtures -- test/inputs/schema/integer-type.schema
- QUICKTEST=true FIXTURE=pike npm run test:fixtures