### PR TITLE
fix(php): validate string lengths

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -10,6 +10,7 @@ import {
 } from "../../ConvenienceRenderer.js";
 import {
     minMaxItemsForType,
+    minMaxLengthForType,
     minMaxValueForType,
 } from "../../attributes/Constraints.js";
 import {
@@ -1085,8 +1086,19 @@ export class PhpRenderer extends ConvenienceRenderer {
                 }
                 validateRange(doubleType);
             },
-            (_stringType) => {
+            (stringType) => {
                 if (!skipPrimitiveTypeCheck) is("is_string");
+                const invalid = () =>
+                    this.emitLine('throw new Exception("Attribute Error");');
+                const validateLength = (operator: string, bound: number) => {
+                    this.emitBlock(
+                        `if (preg_match_all('/./us', ${scopeAttrName}) ${operator} ${bound})`,
+                        invalid,
+                    );
+                };
+                const [min, max] = minMaxLengthForType(stringType) ?? [];
+                if (min !== undefined) validateLength("<", min);
+                if (max !== undefined) validateLength(">", max);
             },
             (arrayType) => {
                 is("is_array");

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1599,6 +1599,7 @@ export const PHPLanguage: Language = {
         "minmax",
         "minmaxitems",
         "date-time",
+        "minmaxlength",
     ],
     output: "TopLevel.php",
     topLevel: "TopLevel",


### PR DESCRIPTION
Summary
- enforce schema minimum and maximum string lengths
- count Unicode code points in generated validation

Tests
- npm run build
- npm run lint
- FIXTURE=schema-php npm run test:fixtures -- test/inputs/schema/minmaxlength.schema