### PR TITLE
fix(php): reject missing required properties

### DIFF
--- a/packages/quicktype-core/src/language/Php/PhpRenderer.ts
+++ b/packages/quicktype-core/src/language/Php/PhpRenderer.ts
@@ -1640,6 +1640,20 @@ export class PhpRenderer extends ConvenienceRenderer {
                     className,
                 ],
                 () => {
+                    this.forEachClassProperty(
+                        c,
+                        "none",
+                        (_name, jsonName, p) => {
+                            if (!p.isOptional)
+                                this.emitBlock(
+                                    `if (!property_exists($obj, '${stringEscape(jsonName)}'))`,
+                                    () =>
+                                        this.emitLine(
+                                            'throw new Exception("Missing required property");',
+                                        ),
+                                );
+                        },
+                    );
                     if (this._options.fastGet) {
                         this.forEachClassProperty(c, "none", (name) => {
                             const names = defined(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1601,6 +1601,7 @@ export const PHPLanguage: Language = {
         "date-time",
         "minmaxlength",
         "pattern",
+        "strict-optional",
     ],
     output: "TopLevel.php",
     topLevel: "TopLevel",


### PR DESCRIPTION
Summary
- distinguish missing required properties from present nullable values
- enable strict-optional schema coverage

Tests
- npm run build
- npm run lint
- FIXTURE=schema-php npm run test:fixtures -- test/inputs/schema/strict-optional.schema