### PR TITLE
fix(kotlin): validate Klaxon numeric bounds

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -1,6 +1,9 @@
 import { arrayIntercalate, iterableSome } from "collection-utils";
 
-import { minMaxValueForType } from "../../attributes/Constraints.js";
+import {
+    minMaxLengthForType,
+    minMaxValueForType,
+} from "../../attributes/Constraints.js";
 import type { Name } from "../../Naming.js";
 import { type Sourcelike, modifySource } from "../../Source.js";
 import { camelCase } from "../../support/Strings.js";
@@ -399,6 +402,17 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
                     const [min, max] = minMaxValueForType(p.type) ?? [];
                     if (min !== undefined) emitValidation(validate(">=", min));
                     if (max !== undefined) emitValidation(validate("<=", max));
+                    const length = p.isOptional
+                        ? `${value}?.let { require(it.length`
+                        : `require(${value}.length`;
+                    const emitLength = (operator: string, bound: number) =>
+                        emitValidation(
+                            `${length} ${operator} ${bound}${p.isOptional ? ") }" : ")"}`,
+                        );
+                    const [minLength, maxLength] =
+                        minMaxLengthForType(p.type) ?? [];
+                    if (minLength !== undefined) emitLength(">=", minLength);
+                    if (maxLength !== undefined) emitLength("<=", maxLength);
                 });
                 this.emitLine(
                     "public fun toJson() = klaxon.toJsonString(this)",

--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -1,5 +1,6 @@
 import { arrayIntercalate, iterableSome } from "collection-utils";
 
+import { minMaxValueForType } from "../../attributes/Constraints.js";
 import type { Name } from "../../Naming.js";
 import { type Sourcelike, modifySource } from "../../Source.js";
 import { camelCase } from "../../support/Strings.js";
@@ -387,6 +388,18 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
         );
         if (isTopLevel) {
             this.emitBlock(")", () => {
+                this.forEachClassProperty(c, "none", (name, _jsonName, p) => {
+                    const value = this.sourcelikeToString(name);
+                    const validate = (operator: string, bound: number) =>
+                        p.isOptional
+                            ? `${value}?.let { require(it ${operator} ${bound}) }`
+                            : `require(${value} ${operator} ${bound})`;
+                    const emitValidation = (condition: string) =>
+                        this.emitBlock("init", () => this.emitLine(condition));
+                    const [min, max] = minMaxValueForType(p.type) ?? [];
+                    if (min !== undefined) emitValidation(validate(">=", min));
+                    if (max !== undefined) emitValidation(validate("<=", max));
+                });
                 this.emitLine(
                     "public fun toJson() = klaxon.toJsonString(this)",
                 );

--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -1,6 +1,7 @@
 import { arrayIntercalate, iterableSome } from "collection-utils";
 
 import {
+    minMaxItemsForType,
     minMaxLengthForType,
     minMaxValueForType,
 } from "../../attributes/Constraints.js";
@@ -413,6 +414,17 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
                         minMaxLengthForType(p.type) ?? [];
                     if (minLength !== undefined) emitLength(">=", minLength);
                     if (maxLength !== undefined) emitLength("<=", maxLength);
+                    const array = p.isOptional
+                        ? `${value}?.let { require(it.size`
+                        : `require(${value}.size`;
+                    const emitItems = (operator: string, bound: number) =>
+                        emitValidation(
+                            `${array} ${operator} ${bound}${p.isOptional ? ") }" : ")"}`,
+                        );
+                    const [minItems, maxItems] =
+                        minMaxItemsForType(p.type) ?? [];
+                    if (minItems !== undefined) emitItems(">=", minItems);
+                    if (maxItems !== undefined) emitItems("<=", maxItems);
                 });
                 this.emitLine(
                     "public fun toJson() = klaxon.toJsonString(this)",

--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -4,6 +4,7 @@ import {
     minMaxItemsForType,
     minMaxLengthForType,
     minMaxValueForType,
+    patternForType,
 } from "../../attributes/Constraints.js";
 import type { Name } from "../../Naming.js";
 import { type Sourcelike, modifySource } from "../../Source.js";
@@ -425,6 +426,15 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
                         minMaxItemsForType(p.type) ?? [];
                     if (minItems !== undefined) emitItems(">=", minItems);
                     if (maxItems !== undefined) emitItems("<=", maxItems);
+                    const pattern = patternForType(p.type);
+                    if (pattern !== undefined) {
+                        const target = p.isOptional ? "it" : value;
+                        const match = `Regex("${stringEscape(pattern)}").containsMatchIn(${target})`;
+                        const check = p.isOptional
+                            ? `${value}?.let { require(${match}) }`
+                            : `require(${match})`;
+                        emitValidation(check);
+                    }
                 });
                 this.emitLine(
                     "public fun toJson() = klaxon.toJsonString(this)",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1255,6 +1255,7 @@ export const KotlinLanguage: Language = {
         "minmax",
         "minmaxInteger",
         "minmaxlength",
+        "minmaxitems",
     ],
     output: "TopLevel.kt",
     topLevel: "TopLevel",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1254,6 +1254,7 @@ export const KotlinLanguage: Language = {
         "integer",
         "minmax",
         "minmaxInteger",
+        "minmaxlength",
     ],
     output: "TopLevel.kt",
     topLevel: "TopLevel",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1246,7 +1246,15 @@ export const KotlinLanguage: Language = {
         "76ae1.json",
     ],
     allowMissingNull: true,
-    features: ["enum", "union", "no-defaults", "date-time", "integer"],
+    features: [
+        "enum",
+        "union",
+        "no-defaults",
+        "date-time",
+        "integer",
+        "minmax",
+        "minmaxInteger",
+    ],
     output: "TopLevel.kt",
     topLevel: "TopLevel",
     skipJSON: [

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1256,6 +1256,7 @@ export const KotlinLanguage: Language = {
         "minmaxInteger",
         "minmaxlength",
         "minmaxitems",
+        "pattern",
     ],
     output: "TopLevel.kt",
     topLevel: "TopLevel",


### PR DESCRIPTION
Summary
- enforce schema numeric bounds in Klaxon models
- validate optional constrained values only when present

Tests
- npm run build
- npm run lint
- FIXTURE=schema-kotlin npm run test:fixtures -- test/inputs/schema/minmax.schema test/inputs/schema/minmax-integer.schema test/inputs/schema/optional-constraints.schema