### PR TITLE
fix(kotlin): validate Klaxon string patterns

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -4,6 +4,7 @@ import {
     minMaxItemsForType,
     minMaxLengthForType,
     minMaxValueForType,
+    patternForType,
 } from "../../attributes/Constraints.js";
 import type { Name } from "../../Naming.js";
 import { type Sourcelike, modifySource } from "../../Source.js";
@@ -425,6 +426,15 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
                         minMaxItemsForType(p.type) ?? [];
                     if (minItems !== undefined) emitItems(">=", minItems);
                     if (maxItems !== undefined) emitItems("<=", maxItems);
+                    const pattern = patternForType(p.type);
+                    if (pattern !== undefined) {
+                        const target = p.isOptional ? "it" : value;
+                        const match = `Regex("${stringEscape(pattern)}").containsMatchIn(${target})`;
+                        const check = p.isOptional
+                            ? `${value}?.let { require(${match}) }`
+                            : `require(${match})`;
+                        emitValidation(check);
+                    }
                 });
                 this.emitLine(
                     "public fun toJson() = klaxon.toJsonString(this)",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1256,6 +1256,7 @@ export const KotlinLanguage: Language = {
         "minmaxInteger",
         "minmaxlength",
         "minmaxitems",
+        "pattern",
     ],
     output: "TopLevel.kt",
     topLevel: "TopLevel",


### PR DESCRIPTION
Summary
- enforce schema regex patterns in Klaxon models
- preserve optional constrained properties

Tests
- npm run build
- npm run lint
- FIXTURE=schema-kotlin npm run test:fixtures -- test/inputs/schema/pattern.schema test/inputs/schema/optional-constraints.schema