### PR TITLE
fix(dart): require nullable schema properties

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -772,15 +772,19 @@ export class DartRenderer extends ConvenienceRenderer {
         );
         this.indent(() => {
             this.forEachClassProperty(c, "none", (name, jsonName, property) => {
+                const key = stringEscape(jsonName);
+                const value = `json["${key}"]`;
+                const input =
+                    !property.isOptional && property.type.isNullable
+                        ? `(json.containsKey("${key}") ? ${value} : throw FormatException('Missing required property'))`
+                        : value;
                 this.emitLine(
                     name,
                     ": ",
                     this.fromDynamicExpression(
                         property.type.isNullable,
                         property.type,
-                        'json["',
-                        stringEscape(jsonName),
-                        '"]',
+                        input,
                     ),
                     ",",
                 );

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1444,6 +1444,7 @@ export const DartLanguage: Language = {
         "integer",
         "no-defaults",
         "date-time",
+        "strict-optional",
         "minmaxlength",
         "pattern",
         "minmax",


### PR DESCRIPTION
Summary
- require nullable properties when the schema marks them required
- retain null as an accepted present value

Tests
- npm run build
- npm run lint
- FIXTURE=schema-dart npm run test:fixtures -- test/inputs/schema/strict-optional.schema
- QUICKTEST=true FIXTURE=dart npm run test:fixtures