### PR TITLE
fix(typescript): expose schema-only renderer options

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/language.ts
@@ -49,8 +49,8 @@ export class TypeScriptEffectSchemaTargetLanguage extends TargetLanguage<
         super(typeScriptEffectSchemaLanguageConfig);
     }
 
-    public getOptions(): Record<string, never> {
-        return {};
+    public getOptions(): typeof typeScriptEffectSchemaOptions {
+        return typeScriptEffectSchemaOptions;
     }
 
     protected makeRenderer<

--- a/packages/quicktype-core/src/language/TypeScriptZod/language.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/language.ts
@@ -35,8 +35,8 @@ export class TypeScriptZodTargetLanguage extends TargetLanguage<
         super(typeScriptZodLanguageConfig);
     }
 
-    public getOptions(): Record<string, never> {
-        return {};
+    public getOptions(): typeof typeScriptZodOptions {
+        return typeScriptZodOptions;
     }
 
     public get stringTypeMapping(): StringTypeMapping {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1694,7 +1694,7 @@ export const TypeScriptZodLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [],
     rendererOptions: {},
-    quickTestRendererOptions: [],
+    quickTestRendererOptions: [{ "just-schema": "true" }],
     sourceFiles: ["src/language/TypeScriptZod/index.ts"],
 };
 
@@ -1738,7 +1738,7 @@ export const TypeScriptEffectSchemaLanguage: Language = {
     skipMiscJSON: false,
     skipSchema: [],
     rendererOptions: {},
-    quickTestRendererOptions: [],
+    quickTestRendererOptions: [{ "just-schema": "true" }],
     sourceFiles: ["src/language/TypeScriptEffectSchema/index.ts"],
 };
 

--- a/test/unit/cli-options.test.ts
+++ b/test/unit/cli-options.test.ts
@@ -12,4 +12,13 @@ describe("CLI option parsing", () => {
             parseCLIOptions(["-o", "list.go", "-o", "list.ts"]),
         ).not.toThrow("Internal error");
     });
+
+    test.each([
+        "typescript-zod",
+        "typescript-effect-schema",
+    ])("%s accepts --just-schema", (lang) => {
+        expect(
+            parseCLIOptions(["--lang", lang, "--just-schema"]).rendererOptions,
+        ).toMatchObject({ "just-schema": true });
+    });
 });


### PR DESCRIPTION
The Zod and Effect Schema renderers implement `just-schema`, but advertise no options, so the CLI rejects `--just-schema`. Expose their existing options and enable schema-only combination fixtures.

Production change: 8 lines (4 added, 4 removed).

Validation: build; CLI parsing regression; all four combination fixtures with `just-schema` for both renderers; Biome.
