### PR TITLE
fix(dart): remove unnecessary meta dependency

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -209,9 +209,6 @@ export class DartRenderer extends ConvenienceRenderer {
         }
 
         this.ensureBlankLine();
-        if (this._options.requiredProperties) {
-            this.emitLine("import 'package:meta/meta.dart';");
-        }
 
         if (this._options.useFreezed) {
             this.emitLine(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1484,6 +1484,7 @@ export const DartLanguage: Language = {
     quickTestRendererOptions: [
         { "final-props": "false" },
         ["simple-object.json", { "from-map": "true" }],
+        ["simple-object.json", { "required-props": "true" }],
     ],
     sourceFiles: ["src/language/Dart/index.ts"],
 };


### PR DESCRIPTION
`--required-props` uses Dart's `required` keyword but still imported `package:meta`, making standalone output fail without that dependency. Remove the unused import and enable the option's JSON round-trip fixture.

Validation: the new option fixture fails before the fix; `CPUs=4 QUICKTEST=true FIXTURE=dart npm run test:fixtures` passes all 57 cases. Production change: 3 deleted lines.
