### PR TITLE
fix(dart): validate UUID strings

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -523,6 +523,14 @@ export class DartRenderer extends ConvenienceRenderer {
             },
             (transformedStringType) => {
                 switch (transformedStringType.kind) {
+                    case "uuid":
+                        return [
+                            isNullable ? [dynamic, " == null ? null : "] : [],
+                            "((String x) => RegExp(r'^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$').hasMatch(x)",
+                            " ? x : throw FormatException('Invalid UUID'))(",
+                            dynamic,
+                            ")",
+                        ];
                     case "date-time":
                     case "date":
                         if (

--- a/packages/quicktype-core/src/language/Dart/language.ts
+++ b/packages/quicktype-core/src/language/Dart/language.ts
@@ -94,6 +94,7 @@ export class DartTargetLanguage extends TargetLanguage<
         const mapping: Map<TransformedStringTypeKind, PrimitiveStringTypeKind> =
             new Map();
         mapping.set("date", "date");
+        mapping.set("uuid", "uuid");
         mapping.set("date-time", "date-time");
         return mapping;
     }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1460,6 +1460,7 @@ export const DartLanguage: Language = {
     allowMissingNull: true,
     features: [
         "integer",
+        "uuid",
         "no-defaults",
         "date-time",
         "strict-optional",


### PR DESCRIPTION
Dart treated UUID schemas as unchecked strings, so invalid values passed. Preserve the UUID format and reject malformed values while retaining nullable fields and arrays. Enables the existing UUID failure fixture.

Validation: the UUID failure fixture fails before the fix; all 85 schema-dart fixtures pass afterward. Production change: 9 added lines.
