### PR TITLE
fix(dart): reserve the generated copyWith member

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -78,7 +78,10 @@ export class DartRenderer extends ConvenienceRenderer {
         _c: ClassType,
         _className: Name,
     ): ForbiddenWordsInfo {
-        return { names: [], includeGlobalForbidden: true };
+        return {
+            names: this._options.generateCopyWith ? ["copyWith"] : [],
+            includeGlobalForbidden: true,
+        };
     }
 
     protected makeNamedTypeNamer(): Namer {

--- a/test/inputs/json/samples/copy-with-property.json
+++ b/test/inputs/json/samples/copy-with-property.json
@@ -1,0 +1,4 @@
+{
+    "copyWith": 42,
+    "name": "sample"
+}

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1484,6 +1484,8 @@ export const DartLanguage: Language = {
     quickTestRendererOptions: [
         { "final-props": "false" },
         ["simple-object.json", { "from-map": "true" }],
+        { "copy-with": "true" },
+        ["copy-with-property.json", { "copy-with": "true" }],
     ],
     sourceFiles: ["src/language/Dart/index.ts"],
 };


### PR DESCRIPTION
A JSON property named `copyWith` collides with the generated `--copy-with` method. Reserve that member when the option is enabled. Adds the reproducer and enables copy-with round-trip fixtures.

Validation: the reproducer fails compilation before the fix; all 62 QUICKTEST Dart JSON fixtures pass afterward. Production change: 4 added lines, 1 deleted line.
