### PR TITLE
fix(typescript): reserve the converter class name

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptRenderer.ts
@@ -30,7 +30,7 @@ export class TypeScriptRenderer extends TypeScriptFlowBaseRenderer {
     }
 
     protected forbiddenNamesForGlobalNamespace(): string[] {
-        return ["Array", "Date"];
+        return ["Array", "Date", "Convert"];
     }
 
     // An array with `minItems` >= 1 becomes a tuple that spells out the

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -962,6 +962,7 @@ export const TypeScriptLanguage: Language = {
         { "runtime-typecheck-ignore-unknown-properties": "true" },
         { "nice-property-names": "true" },
         ["pokedex.json", { "prefer-types": "true" }],
+        ["keywords.json", { "prefer-types": "true" }],
         { "acronym-style": "pascal" },
         { converters: "all-objects" },
         { readonly: "true" },


### PR DESCRIPTION
With `prefer-types`, the keyword fixture generated both a `Convert` type alias and the `Convert` class, causing duplicate-identifier errors. Reserve the helper name and cover this option with the existing keyword fixture.

Production change: 2 lines (1 added, 1 removed).

Validation: reproduced the TypeScript compiler failure; build; keyword fixture with `prefer-types` (compile, round trip, source comparison); Biome.
