### PR TITLE
fix(effect): reserve the schema import namespace

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -51,7 +51,16 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
     }
 
     protected forbiddenNamesForGlobalNamespace(): string[] {
-        return ["Class", "Date", "Object", "String", "Array", "JSON", "Error"];
+        return [
+            "S",
+            "Class",
+            "Date",
+            "Object",
+            "String",
+            "Array",
+            "JSON",
+            "Error",
+        ];
     }
 
     protected nameStyle(original: string, upper: boolean): string {

--- a/test/inputs/json/priority/keywords.json
+++ b/test/inputs/json/priority/keywords.json
@@ -222,6 +222,7 @@
       "return": { "return": 123 },
       "right": { "right": 123 },
       "sbyte": { "sbyte": 123 },
+      "s": { "s": 123 },
       "sealed": { "sealed": 123 },
       "SEL": { "SEL": 123 },
       "select": { "select": 123 },


### PR DESCRIPTION
A property named `s` generated class `S`, shadowing the Effect Schema import and failing at initialization. Reserve `S` and extend the existing keyword fixture.

Production change: 11 lines (10 added, 1 removed).

Validation: reproduced `Cannot access 'S' before initialization`; build; keyword fixture (round trip and source comparison); Biome.
