### PR TITLE
fix(swift): make null helpers Sendable when requested

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -1166,18 +1166,23 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
             this.ensureBlankLine();
             this.emitMark("Encode/decode helpers", true);
             this.ensureBlankLine();
+            const final = this._options.finalClasses || this._options.sendable;
             if (this._options.objcSupport) {
                 this.emitLine(
                     this.objcMembersDeclaration,
                     this.accessLevel,
-                    this._options.finalClasses ? "final " : "",
-                    "class JSONNull: NSObject, Codable {",
+                    final ? "final " : "",
+                    "class JSONNull: NSObject, Codable",
+                    this._options.sendable ? ", Sendable" : "",
+                    " {",
                 );
             } else {
                 this.emitLine(
                     this.accessLevel,
-                    this._options.finalClasses ? "final " : "",
-                    "class JSONNull: Codable, Hashable {",
+                    final ? "final " : "",
+                    "class JSONNull: Codable, Hashable",
+                    this._options.sendable ? ", Sendable" : "",
+                    " {",
                 );
             }
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1656,11 +1656,6 @@ export const allFixtures: Fixture[] = [
     new JSONFixture(languages.PythonLanguage),
     new JSONFixture(languages.ElmLanguage),
     new JSONFixture(languages.SwiftLanguage),
-    new (class extends JSONFixture {
-        runForName(name: string): boolean {
-            return name === "swift" || super.runForName(name);
-        }
-    })(languages.SwiftSendableLanguage, "swift-sendable"),
     new JSONFixture(
         languages.SwiftSendableObjectiveCSupportLanguage,
         "swift-sendable-objective-c",

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1656,6 +1656,11 @@ export const allFixtures: Fixture[] = [
     new JSONFixture(languages.PythonLanguage),
     new JSONFixture(languages.ElmLanguage),
     new JSONFixture(languages.SwiftLanguage),
+    new (class extends JSONFixture {
+        runForName(name: string): boolean {
+            return name === "swift" || super.runForName(name);
+        }
+    })(languages.SwiftSendableLanguage, "swift-sendable"),
     new JSONFixture(
         languages.SwiftSendableObjectiveCSupportLanguage,
         "swift-sendable-objective-c",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -855,6 +855,8 @@ export const SwiftLanguage: Language = {
     quickTestRendererOptions: [
         { "support-linux": "false" },
         { "struct-or-class": "class" },
+        { sendable: "true" },
+        { sendable: "true", "struct-or-class": "class" },
         [
             "simple-object.json",
             { "struct-or-class": "class", "final-classes": "true" },
@@ -868,20 +870,6 @@ export const SwiftLanguage: Language = {
         ["simple-object.json", { protocol: "hashable" }],
     ],
     sourceFiles: ["src/language/Swift/index.ts"],
-};
-
-export const SwiftSendableLanguage: Language = {
-    ...SwiftLanguage,
-    compileCommand:
-        "swiftc -strict-concurrency=complete -warnings-as-errors -o quicktype main.swift quicktype.swift",
-    includeJSON: [
-        "combinations1.json",
-        "combinations2.json",
-        "combinations3.json",
-        "combinations4.json",
-    ],
-    rendererOptions: { ...SwiftLanguage.rendererOptions, sendable: "true" },
-    quickTestRendererOptions: [{ "struct-or-class": "class" }],
 };
 
 export const SwiftSendableObjectiveCSupportLanguage: Language = {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -870,11 +870,25 @@ export const SwiftLanguage: Language = {
     sourceFiles: ["src/language/Swift/index.ts"],
 };
 
+export const SwiftSendableLanguage: Language = {
+    ...SwiftLanguage,
+    compileCommand:
+        "swiftc -strict-concurrency=complete -warnings-as-errors -o quicktype main.swift quicktype.swift",
+    includeJSON: [
+        "combinations1.json",
+        "combinations2.json",
+        "combinations3.json",
+        "combinations4.json",
+    ],
+    rendererOptions: { ...SwiftLanguage.rendererOptions, sendable: "true" },
+    quickTestRendererOptions: [{ "struct-or-class": "class" }],
+};
+
 export const SwiftSendableObjectiveCSupportLanguage: Language = {
     ...SwiftLanguage,
     compileCommand: "node verify-sendable.cjs",
     diffViaSchema: false,
-    includeJSON: ["pokedex.json"],
+    includeJSON: ["pokedex.json", "combinations1.json"],
     rendererOptions: {
         ...SwiftLanguage.rendererOptions,
         sendable: "true",


### PR DESCRIPTION
`--sendable` models containing null-only fields fail concurrency checks because JSONNull lacks Sendable. Make the immutable helper final and Sendable when requested, including Objective-C output.

Exercise struct/class Sendable options on all four combination inputs through the existing Swift fixture. Extend the existing Objective-C declaration test with combinations1.json, which fails before this fix.

Validation: build, Biome; eight existing Swift option cases compiled locally with strict concurrency and warnings as errors; three existing Objective-C declaration cases. Production diff: 13 lines (9 added, 4 removed).
