### PR TITLE
fix(python): reject missing required nullable properties

### DIFF
--- a/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
@@ -1091,7 +1091,9 @@ export class JSONPythonRenderer extends PythonRenderer {
                 this.emitLine("assert isinstance(obj, dict)");
                 this.forEachClassProperty(t, "none", (name, jsonName, cp) => {
                     const property = {
-                        value: ["obj.get(", this.string(jsonName), ")"],
+                        value: cp.isOptional
+                            ? ["obj.get(", this.string(jsonName), ")"]
+                            : ["obj[", this.string(jsonName), "]"],
                     };
                     this.emitLine(
                         name,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -305,6 +305,7 @@ export const PythonLanguage: Language = {
         "bool-string",
         "uuid",
         "integer",
+        "strict-optional",
     ],
     output: "quicktype.py",
     topLevel: "TopLevel",


### PR DESCRIPTION
Required nullable properties currently accept missing keys and silently become `None`. Read required keys directly, preserving `.get()` for optional properties.

Enables the existing `strict-optional` rejection cases for Python. No new inputs or fixtures.

Validation: baseline accepts `{}` for `strict-optional.schema`; fixed code rejects it. All 156 focused Python JSON/schema cases pass, including Python-version options and mypy. Build and targeted Biome checks pass. Production change: 3 lines added, 1 removed.
