### PR TITLE
fix(kotlin): escape Klaxon enum values

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -244,7 +244,7 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
             converters.push([
                 [".convert(", name, "::class,"],
                 [" { ", name, ".fromValue(it.string!!) },"],
-                [' { "\\"${it.value}\\"" })'],
+                [" { Klaxon().toJsonString(it.value) })"],
             ]);
         });
         this.forEachUnion("none", (_, name) => {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1299,8 +1299,6 @@ export const KotlinLanguage: Language = {
     output: "TopLevel.kt",
     topLevel: "TopLevel",
     skipJSON: [
-        // Klaxon emits unescaped control characters in enum values.
-        "objc-control-characters.json",
         // Some odd property names prevent Klaxon from mapping to constructors
         // https://github.com/cbeust/klaxon/issues/146
         "blns-object.json",


### PR DESCRIPTION
Klaxon's generated enum converter wrapped raw values in quotes, producing invalid JSON for control characters. Serialize enum values through Klaxon so JSON escaping is applied, and enable the existing shared control-character fixture.

Testing: `CPUs=1 FIXTURE=kotlin npm run test:fixtures -- test/inputs/json/samples/objc-control-characters.json`; `npm run lint`

Production line count: 1 added, 1 removed.
