### PR TITLE
fix(kotlin): escape Jackson enum values

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -153,7 +153,7 @@ import com.fasterxml.jackson.module.kotlin.*`);
             converters.push([
                 ["convert(", name, "::class,"],
                 [" { ", name, ".fromValue(it.asText()) },"],
-                [' { "\\"${it.value}\\"" })'],
+                [" { ObjectMapper().writeValueAsString(it.value) })"],
             ]);
         });
         this.forEachUnion("none", (_, name) => {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1393,10 +1393,7 @@ export const KotlinJacksonLanguage: Language = {
     ],
     output: "TopLevel.kt",
     topLevel: "TopLevel",
-    skipJSON: [
-        // The enum serializer does not escape control characters.
-        "objc-control-characters.json",
-    ],
+    skipJSON: [],
     skipSchema: ["optional-property.schema", "keyword-unions.schema"],
     skipMiscJSON: false,
     rendererOptions: { framework: "jackson" },


### PR DESCRIPTION
Jackson's generated enum converter wrapped raw values in quotes, producing invalid JSON for control characters. Serialize enum values with `ObjectMapper` so JSON escaping is applied, and enable the existing shared control-character fixture.

Testing: `CPUs=1 FIXTURE=kotlin-jackson npm run test:fixtures -- test/inputs/json/samples/objc-control-characters.json`; `npm run lint`

Production line count: 1 added, 1 removed.
