### PR TITLE
fix: preserve missing nullable properties in Haskell

### DIFF
--- a/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
+++ b/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
@@ -185,7 +185,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
             return multiWord(
                 " ",
                 "Maybe",
-                parenIfNeeded(this.haskellType(p.type, true)),
+                parenIfNeeded(this.haskellType(p.type)),
             ).source;
         }
 
@@ -329,14 +329,17 @@ export class HaskellRenderer extends ConvenienceRenderer {
             } else {
                 this.emitLine("toJSON (", className, ...classProperties, ") =");
                 this.indent(() => {
-                    this.emitLine("object");
+                    this.emitLine("object $ foldMap (maybe [] pure)");
                     let onFirst = true;
+                    const properties = c.getProperties();
                     this.forEachClassProperty(c, "none", (name, jsonName) => {
+                        const optional = properties.get(jsonName)?.isOptional;
                         this.emitLine(
                             onFirst ? "[ " : ", ",
+                            optional ? "(" : "Just $ ",
                             '"',
                             haskellStringEscape(jsonName),
-                            '" .= ',
+                            optional ? '" .=) <$> ' : '" .= ',
                             name,
                             className,
                         );
@@ -363,7 +366,11 @@ export class HaskellRenderer extends ConvenienceRenderer {
                 this.indent(() => {
                     let onFirst = true;
                     this.forEachClassProperty(c, "none", (_, jsonName, p) => {
-                        const operator = p.isOptional ? ".:?" : ".:";
+                        const operator = p.isOptional
+                            ? p.type.isNullable
+                                ? ".:!"
+                                : ".:?"
+                            : ".:";
                         this.emitLine(
                             onFirst ? "<$> " : "<*> ",
                             "v ",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1604,7 +1604,9 @@ export const HaskellLanguage: Language = {
         return `stack run haskell -- "${sample}"`;
     },
     diffViaSchema: true,
+    roundtripViaSchema: true,
     skipDiffViaSchema: [
+        "combinations4.json",
         "keywords.json",
         "00c36.json",
         "10be4.json",
@@ -1655,9 +1657,9 @@ export const HaskellLanguage: Language = {
     features: ["enum", "union", "no-defaults", "integer", "strict-optional"],
     output: "QuickType.hs",
     topLevel: "QuickType",
-    skipJSON: ["combinations4.json"],
+    skipJSON: [],
     skipMiscJSON: false,
-    skipSchema: ["optional-property.schema", "keyword-unions.schema"],
+    skipSchema: ["optional-property.schema"],
     rendererOptions: {},
     // The default is array-type=list; this keeps the Vector code path
     // covered.


### PR DESCRIPTION
Haskell represented optional nullable properties with one `Maybe`, so it could not preserve the difference between a missing key and an explicit `null`. Generate nested `Maybe` where needed, decode optional nullable values with Aeson's `.:!`, and omit only missing properties while encoding.

This enables the existing `combinations4.json` and `keyword-unions.schema` samples. `combinations4` keeps its generated-text exception because schema conversion reorders properties, while both generated programs now roundtrip through the shared harness. Before the fix, absent optional properties were serialized as null.

Testing: `npm run build`; Docker GHC/Aeson direct and schema-driven compile/roundtrip for `combinations4`, both `keyword-unions` samples, and explicit nullable null; `npm run lint`

Production diff: 11 additions, 4 removals.
