### PR TITLE
test: round-trip schema-generated Dart, Go, and KotlinX output

### DIFF
--- a/test/languages.ts
+++ b/test/languages.ts
@@ -202,19 +202,7 @@ export const CSharpLanguageSystemTextJson: Language = {
     additionalSchemaFiles: [
         "test/inputs/regressions/unicode-codepoint-length.schema",
     ],
-    skipSchema: [
-        "optional-property.schema",
-        // The following skips are pre-existing System.Text.Json renderer issues,
-        // found when first enabling the schema fixture for this language:
-        // minmaxlength.schema, optional-constraints.schema, and
-        // optional-const-ref.schema used to be skipped here because the
-        // generated converters triggered CS8602 warnings, which "dotnet
-        // run" prints to stdout, breaking the JSON comparison.  The
-        // generated code now suppresses CS8602 alongside the other NRT
-        // pragmas, so they run.  (Their .fail.<feature>.json samples are
-        // not exercised because this fixture doesn't declare the minmax,
-        // minmaxlength, or pattern features.)
-    ],
+    skipSchema: [],
     rendererOptions: { "check-required": "true", framework: "SystemTextJson" },
     quickTestRendererOptions: [
         { "array-type": "list" },

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -134,7 +134,6 @@ export const CSharpLanguage: Language = {
         "minmax",
         "minmaxInteger",
         "minmaxlength",
-        "minmaxlength",
     ],
     output: "QuickType.cs",
     topLevel: "TopLevel",
@@ -192,7 +191,6 @@ export const CSharpLanguageSystemTextJson: Language = {
         "minmax",
         "minmaxInteger",
         "minmaxlength",
-        "minmaxlength",
         "integer",
     ],
     output: "QuickType.cs",
@@ -202,7 +200,19 @@ export const CSharpLanguageSystemTextJson: Language = {
     additionalSchemaFiles: [
         "test/inputs/regressions/unicode-codepoint-length.schema",
     ],
-    skipSchema: ["optional-property.schema"],
+    skipSchema: [
+        "optional-property.schema",
+        // The following skips are pre-existing System.Text.Json renderer issues,
+        // found when first enabling the schema fixture for this language:
+        // minmaxlength.schema, optional-constraints.schema, and
+        // optional-const-ref.schema used to be skipped here because the
+        // generated converters triggered CS8602 warnings, which "dotnet
+        // run" prints to stdout, breaking the JSON comparison.  The
+        // generated code now suppresses CS8602 alongside the other NRT
+        // pragmas, so they run.  (Their .fail.<feature>.json samples are
+        // not exercised because this fixture doesn't declare the minmax,
+        // minmaxlength, or pattern features.)
+    ],
     rendererOptions: { "check-required": "true", framework: "SystemTextJson" },
     quickTestRendererOptions: [
         { "array-type": "list" },

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -509,6 +509,7 @@ export const GoLanguage: Language = {
         return `go run main.go quicktype.go < "${sample}"`;
     },
     diffViaSchema: true,
+    roundtripViaSchema: true,
     skipDiffViaSchema: [
         "bug427.json",
         "nbl-stats.json",
@@ -1475,6 +1476,7 @@ export const DartLanguage: Language = {
         return `dart --enable-experiment=non-nullable parser.dart "${sample}"`;
     },
     diffViaSchema: true,
+    roundtripViaSchema: true,
     skipDiffViaSchema: [
         "keywords.json",
         "bug427.json",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -202,7 +202,7 @@ export const CSharpLanguageSystemTextJson: Language = {
     additionalSchemaFiles: [
         "test/inputs/regressions/unicode-codepoint-length.schema",
     ],
-    skipSchema: [],
+    skipSchema: ["optional-property.schema"],
     rendererOptions: { "check-required": "true", framework: "SystemTextJson" },
     quickTestRendererOptions: [
         { "array-type": "list" },

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -134,6 +134,7 @@ export const CSharpLanguage: Language = {
         "minmax",
         "minmaxInteger",
         "minmaxlength",
+        "minmaxlength",
     ],
     output: "QuickType.cs",
     topLevel: "TopLevel",
@@ -190,6 +191,7 @@ export const CSharpLanguageSystemTextJson: Language = {
         "uuid",
         "minmax",
         "minmaxInteger",
+        "minmaxlength",
         "minmaxlength",
         "integer",
     ],
@@ -1413,7 +1415,9 @@ export const KotlinXLanguage: Language = {
         return `./run.sh "${sample}"`;
     },
     diffViaSchema: true,
+    roundtripViaSchema: true,
     skipDiffViaSchema: [
+        "blns-object.json",
         "bug427.json",
         "keywords.json",
         "77392.json",
@@ -1450,7 +1454,6 @@ export const KotlinXLanguage: Language = {
         "a3d8c.json",
         "f74d5.json",
         "fcca3.json",
-        "blns-object.json", // JSON-to-schema property naming is not stable for case collisions.
     ],
     skipSchema: [
         "optional-property.schema",


### PR DESCRIPTION
Run schema-generated Dart and Go code through the existing round-trip check, preserving names and existing source-text exclusions. KotlinX's excluded `blns-object.json` also round-trips correctly; enable it and retain only its text-diff exclusion.

Test-only. Build and targeted Biome pass. Validation: 68 Dart JSON/option cases; 143 Go JSON/schema cases; KotlinX `blns-object.json` direct and schema round-trips.
