### PR TITLE
fix: escape retain in Objective-C Swift classes

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -68,7 +68,13 @@ export class SwiftRenderer extends ConvenienceRenderer {
         _c: ClassType,
         _classNamed: Name,
     ): ForbiddenWordsInfo {
-        return { names: ["fromURL", "json"], includeGlobalForbidden: true };
+        const names = ["fromURL", "json"];
+        if (
+            this._options.objcSupport &&
+            (this._options.useClasses || this.isCycleBreakerType(_c))
+        )
+            names.push("retain");
+        return { names, includeGlobalForbidden: true };
     }
 
     protected forbiddenForEnumCases(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -888,6 +888,10 @@ export const SwiftLanguage: Language = {
         { protocol: "equatable" },
         ["simple-object.json", { protocol: "hashable" }],
         { protocol: "hashable" },
+        [
+            "keywords.json",
+            { "struct-or-class": "class", "objective-c-support": "true" },
+        ],
     ],
     sourceFiles: ["src/language/Swift/index.ts"],
 };


### PR DESCRIPTION
Swift classes generated with Objective-C support could declare a `retain` property whose selector conflicts with `NSObject.retain`. Reserve that member name only for explicit or cycle-breaking classes, and exercise the existing shared keyword input with class output.

Without the fix, `swiftc` reports `getter for 'retain' with Objective-C selector 'retain' conflicts with method 'retain()' from superclass 'NSObject'`.

Testing: `CPUs=1 QUICKTEST=true FIXTURE=swift npm run test:fixtures -- test/inputs/json/priority/keywords.json`; `npm run lint`

Production diff: 7 additions, 1 removal.
