### PR TITLE
fix(python): enforce numeric bounds

### DIFF
--- a/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
@@ -2,6 +2,7 @@ import { arrayIntercalate } from "collection-utils";
 
 import {
     minMaxItemsForType,
+    minMaxValueForType,
     patternForType,
 } from "../../attributes/Constraints.js";
 import { topLevelNameOrder } from "../../ConvenienceRenderer.js";
@@ -1118,6 +1119,12 @@ export class JSONPythonRenderer extends PythonRenderer {
                             check([min.toString(), " <= len(", name, ")"]);
                         if (max !== undefined)
                             check(["len(", name, ") <= ", max.toString()]);
+                        const [minValue, maxValue] =
+                            minMaxValueForType(cp.type) ?? [];
+                        if (minValue !== undefined)
+                            check([minValue.toString(), " <= ", name]);
+                        if (maxValue !== undefined)
+                            check([name, " <= ", maxValue.toString()]);
                         const pattern = patternForType(cp.type);
                         if (pattern !== undefined)
                             check([

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -306,6 +306,8 @@ export const PythonLanguage: Language = {
         "uuid",
         "integer",
         "strict-optional",
+        "minmax",
+        "minmaxInteger",
         "minmaxitems",
         "pattern",
     ],


### PR DESCRIPTION
Python generated classes accepted JSON numbers outside schema minimum and maximum bounds. Validate deserialized values before constructing the class, while allowing optional nulls.

Enables the existing `minmax` and `minmaxInteger` schema features for Python.

Testing: `CPUs=1 FIXTURE=schema-python npm run test:fixtures -- test/inputs/schema/minmax.schema test/inputs/schema/minmax-integer.schema test/inputs/schema/fractional-bounds.schema test/inputs/schema/optional-constraints.schema`; `npm run lint -- --no-errors-on-unmatched`

Production change: 15 added lines.

