### PR TITLE
fix(python): enforce string lengths

### DIFF
--- a/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
@@ -2,6 +2,7 @@ import { arrayIntercalate } from "collection-utils";
 
 import {
     minMaxItemsForType,
+    minMaxLengthForType,
     minMaxValueForType,
     patternForType,
 } from "../../attributes/Constraints.js";
@@ -1125,6 +1126,14 @@ export class JSONPythonRenderer extends PythonRenderer {
                             check([minValue.toString(), " <= ", name]);
                         if (maxValue !== undefined)
                             check([name, " <= ", maxValue.toString()]);
+                        const [lo, hi] = minMaxLengthForType(cp.type) ?? [];
+                        if (lo !== undefined || hi !== undefined) {
+                            const raw = this.cast("str", property.value);
+                            if (lo !== undefined)
+                                check([lo.toString(), " <= len(", raw, ")"]);
+                            if (hi !== undefined)
+                                check(["len(", raw, ") <= ", hi.toString()]);
+                        }
                         const pattern = patternForType(cp.type);
                         if (pattern !== undefined)
                             check([

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -309,6 +309,7 @@ export const PythonLanguage: Language = {
         "minmax",
         "minmaxInteger",
         "minmaxitems",
+        "minmaxlength",
         "pattern",
     ],
     output: "quicktype.py",


### PR DESCRIPTION
Python generated classes accepted strings outside schema length bounds. Validate deserialized string lengths before constructing the class, while allowing optional nulls.

Enables the existing `minmaxlength` schema feature for Python.

Testing: `CPUs=1 FIXTURE=schema-python npm run test:fixtures -- test/inputs/schema/minmaxlength.schema test/inputs/schema/optional-constraints.schema test/inputs/schema/schema-constraints.schema test/inputs/schema/optional-const-ref.schema`; `npm run lint -- --no-errors-on-unmatched`

Production change: 14 added lines.


