### PR TITLE
fix(pike): reserve the Standards runtime module name

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -84,7 +84,7 @@ export class PikeRenderer extends ConvenienceRenderer {
     }
 
     protected forbiddenNamesForGlobalNamespace(): string[] {
-        return [...keywords];
+        return [...keywords, "Standards"];
     }
 
     protected forbiddenForObjectProperties(

--- a/test/inputs/json/priority/keywords.json
+++ b/test/inputs/json/priority/keywords.json
@@ -241,6 +241,7 @@
       "signed": { "signed": 123 },
       "sizeof": { "sizeof": 123 },
       "stackalloc": { "stackalloc": 123 },
+      "Standards": { "Standards": 123 },
       "static": { "static": 123 },
       "static_assert": { "static_assert": 123 },
       "static_cast": { "static_cast": 123 },


### PR DESCRIPTION
A generated Pike class named `Standards` shadows the module used for JSON encoding, causing `Index 'JSON' not present in module Standards` compiler errors. Reserve that runtime name and add it to shared `keywords.json`.

Production diff: 1 line added, 1 removed. Build and targeted Biome pass; the shared keyword case compiles and round-trips in Pike, Dart, Python, TypeScript, and JavaScript.
