### PR TITLE
fix(python): enforce string patterns

### DIFF
--- a/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
@@ -1,6 +1,9 @@
 import { arrayIntercalate } from "collection-utils";
 
-import { minMaxItemsForType } from "../../attributes/Constraints.js";
+import {
+    minMaxItemsForType,
+    patternForType,
+} from "../../attributes/Constraints.js";
 import { topLevelNameOrder } from "../../ConvenienceRenderer.js";
 import { DependencyName, type Name, funPrefixNamer } from "../../Naming.js";
 import {
@@ -1115,6 +1118,16 @@ export class JSONPythonRenderer extends PythonRenderer {
                             check([min.toString(), " <= len(", name, ")"]);
                         if (max !== undefined)
                             check(["len(", name, ") <= ", max.toString()]);
+                        const pattern = patternForType(cp.type);
+                        if (pattern !== undefined)
+                            check([
+                                this.withModuleImport("re"),
+                                ".search(",
+                                this.string(pattern),
+                                ", ",
+                                this.cast("str", property.value),
+                                ")",
+                            ]);
                     }
                 });
                 this.emitLine(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -307,6 +307,7 @@ export const PythonLanguage: Language = {
         "integer",
         "strict-optional",
         "minmaxitems",
+        "pattern",
     ],
     output: "quicktype.py",
     topLevel: "TopLevel",


### PR DESCRIPTION
Python generated classes accepted strings that violate JSON Schema patterns. Validate raw JSON strings with regex search semantics, while allowing optional nulls.

Enables the existing `pattern` schema feature for Python and reuses its constraint-validation helper.

Validation: build, targeted Biome checks, and `QUICKTEST=true FIXTURE=python,schema-python npm run test:fixtures`.

Production change: 15 lines added plus removed.
