### PR TITLE
fix(python): enforce array bounds

### DIFF
--- a/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
@@ -1,5 +1,6 @@
 import { arrayIntercalate } from "collection-utils";
 
+import { minMaxItemsForType } from "../../attributes/Constraints.js";
 import { topLevelNameOrder } from "../../ConvenienceRenderer.js";
 import { DependencyName, type Name, funPrefixNamer } from "../../Naming.js";
 import {
@@ -1101,6 +1102,20 @@ export class JSONPythonRenderer extends PythonRenderer {
                         makeValue(this.deserializer(property, cp.type)),
                     );
                     args.push(name);
+                    {
+                        const [min, max] = minMaxItemsForType(cp.type) ?? [];
+                        const check = (condition: Sourcelike): void =>
+                            this.emitLine(
+                                "assert ",
+                                name,
+                                " is None or ",
+                                condition,
+                            );
+                        if (min !== undefined)
+                            check([min.toString(), " <= len(", name, ")"]);
+                        if (max !== undefined)
+                            check(["len(", name, ") <= ", max.toString()]);
+                    }
                 });
                 this.emitLine(
                     "return ",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -306,6 +306,7 @@ export const PythonLanguage: Language = {
         "uuid",
         "integer",
         "strict-optional",
+        "minmaxitems",
     ],
     output: "quicktype.py",
     topLevel: "TopLevel",


### PR DESCRIPTION
Python generated classes accepted arrays outside JSON Schema item-count bounds. Validate deserialized array lengths before constructing the class, while allowing optional nulls.

Enables the existing `minmaxitems` schema feature for Python.

Testing: `CPUs=1 FIXTURE=schema-python npm run test:fixtures -- test/inputs/schema/min-max-items.schema`; `npm run lint -- --no-errors-on-unmatched`

Production change: 15 added lines.

