### PR TITLE
fix(scala3): reject abbreviated UUIDs

### DIFF
--- a/packages/quicktype-core/src/language/Scala3/UpickleRenderer.ts
+++ b/packages/quicktype-core/src/language/Scala3/UpickleRenderer.ts
@@ -66,6 +66,12 @@ given OptionPickler.ReadWriter[java.time.Instant] = OptionPickler.readwriter[ujs
         case ujson.Str(value) => java.time.Instant.parse(value)
         case other => throw new upickle.core.Abort("expected date-time, got " + other)
 )
+given OptionPickler.ReadWriter[java.util.UUID] = OptionPickler.readwriter[String].bimap(
+    _.toString,
+    value =>
+        val uuid = java.util.UUID.fromString(value)
+        if uuid.toString.equalsIgnoreCase(value) then uuid else throw new upickle.core.Abort("invalid UUID")
+)
 
 object JsonExt:
     val valueReader = OptionPickler.readwriter[ujson.Value]

--- a/test/inputs/schema/uuid.3.fail.uuid.json
+++ b/test/inputs/schema/uuid.3.fail.uuid.json
@@ -1,0 +1,5 @@
+{
+  "one": "1-1-1-1-1",
+  "nullable": null,
+  "unionWithEnum": "68ffea67-509e-482e-90ca-e80e5709cd78"
+}


### PR DESCRIPTION
Scala 3 Upickle accepted abbreviated UUID strings such as `1-1-1-1-1` and normalized them to a different value. Require the canonical hyphenated UUID form while preserving uppercase hexadecimal input.

Adds a negative sample to the existing shared UUID schema. Production change: 6 lines added.

Testing: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-scala3-upickle npm run test:fixtures -- test/inputs/schema/uuid.schema`; `npm run lint`.
