### PR TITLE
fix: reject non-objects for empty classes

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -1026,7 +1026,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
                 const isEmpty = !propCount;
                 this.ensureBlankLine();
                 this.emitBlock(
-                    [`def from_map(${isEmpty ? "_" : ""}m) do`],
+                    [`def from_map(m)${isEmpty ? " when is_map(m)" : ""} do`],
                     () => {
                         this.emitLine(
                             "%",

--- a/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
+++ b/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
@@ -494,7 +494,11 @@ export class ElmRenderer extends ConvenienceRenderer {
         this.emitLine(decoderName, " =");
         this.indent(() => {
             if (c.getProperties().size === 0) {
-                this.emitLine("Jdec.dict Jdec.value |> Jdec.map (\\_ -> ", className, ")");
+                this.emitLine(
+                    "Jdec.dict Jdec.value |> Jdec.map (\\_ -> ",
+                    className,
+                    ")",
+                );
                 return;
             }
             this.emitLine("Jdec.succeed ", className);

--- a/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
+++ b/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
@@ -493,6 +493,10 @@ export class ElmRenderer extends ConvenienceRenderer {
         this.emitLine(decoderName, " : Jdec.Decoder ", className);
         this.emitLine(decoderName, " =");
         this.indent(() => {
+            if (c.getProperties().size === 0) {
+                this.emitLine("Jdec.dict Jdec.value |> Jdec.map (\\_ -> ", className, ")");
+                return;
+            }
             this.emitLine("Jdec.succeed ", className);
             this.indent(() => {
                 this.forEachClassProperty(c, "none", (_, jsonName, p) => {

--- a/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
+++ b/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
@@ -357,7 +357,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
 
         this.indent(() => {
             if (this.classPropertyLength(c) === 0) {
-                this.emitLine("parseJSON emptyObject = return ", className);
+                this.emitLine("parseJSON (Object _) = return ", className);
             } else {
                 this.emitLine("parseJSON (Object v) = ", className);
                 this.indent(() => {

--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -293,7 +293,7 @@ import com.fasterxml.jackson.module.kotlin.*`);
     protected emitEmptyClassDefinition(c: ClassType, className: Name): void {
         this.emitDescription(this.descriptionForType(c));
 
-        this.emitLine("typealias ", className, " = JsonNode");
+        this.emitLine("typealias ", className, " = ObjectNode");
     }
 
     protected emitClassDefinitionMethods(c: ClassType, className: Name): void {

--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -369,6 +369,10 @@ export class PikeRenderer extends ConvenienceRenderer {
                         p.type instanceof UnionType
                             ? nullableFromUnion(p.type)
                             : p.type;
+                    if (!p.isOptional && p.type.kind === "class")
+                        this.emitLine(
+                            `if (!mappingp(${jsonValue})) error("Expected object");`,
+                        );
                     if (!p.isOptional && requiredType?.kind === "integer")
                         this.emitLine(
                             `if (!intp(${jsonValue})) error("Expected integer");`,

--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -600,6 +600,21 @@ export class SwiftRenderer extends ConvenienceRenderer {
                     );
                 }
 
+                if (!this._options.justTypes && this.propertyCount(c) === 0) {
+                    this.emitLine(
+                        "private enum K: String, CodingKey { case unused }",
+                    );
+                    this.emitBlockWithAccess(
+                        "init(from decoder: Decoder) throws",
+                        () =>
+                            this.emitLine(
+                                "_ = try decoder.container(keyedBy: K.self)",
+                            ),
+                    );
+                    if (!isClass)
+                        this.emitBlockWithAccess("init()", () => undefined);
+                }
+
                 if (!this._options.justTypes) {
                     const groups = this.getEnumPropertyGroups(c);
                     const allPropertiesRedundant = groups.every((group) => {

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -252,7 +252,9 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
             name,
             '>("',
             name,
-            '")({',
+            t.getProperties().size === 0
+                ? '")(S.Struct({}).pipe(S.filter(value => typeof value === "object" && value !== null && !Array.isArray(value)))'
+                : '")({',
         );
         this.indent(() => {
             this.forEachClassProperty(t, "none", (_, jsonName, property) => {
@@ -264,7 +266,7 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
                 );
             });
         });
-        this.emitLine("}) {}");
+        this.emitLine(t.getProperties().size === 0 ? ") {}" : "}) {}");
         if (t.getProperties().has("toString")) {
             this.emitLine(
                 "Object.defineProperty(",

--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
@@ -66,7 +66,7 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
 
     protected typeMapTypeFor(t: Type): Sourcelike {
         if (this.emptyObjectTypeFor(t) !== undefined) {
-            return '"any"';
+            return 'm("any")';
         }
 
         return super.typeMapTypeFor(t);

--- a/test/inputs/schema/object-type-required.1.json
+++ b/test/inputs/schema/object-type-required.1.json
@@ -1,4 +1,5 @@
 {
     "foo": "abc",
-    "bar": "def"
+    "bar": "def",
+    "empty": {}
 }

--- a/test/inputs/schema/object-type-required.3.fail.json
+++ b/test/inputs/schema/object-type-required.3.fail.json
@@ -1,4 +1,4 @@
 {
     "foo": "abc",
-    "empty": {}
+    "empty": 42
 }

--- a/test/inputs/schema/object-type-required.schema
+++ b/test/inputs/schema/object-type-required.schema
@@ -5,10 +5,15 @@
             "properties": {
                 "foo": {
                     "type": "string"
+                },
+                "empty": {
+                    "type": "object",
+                    "additionalProperties": false
                 }
             },
             "required": [
-                "foo"
+                "foo",
+                "empty"
             ]
         },
         {


### PR DESCRIPTION
Empty generated classes accepted non-object JSON values. Their decoders either matched every value, discarded scalar input, or represented empty objects with unrestricted runtime types.

Extend the existing `object-type-required.schema` with a closed empty object and a numeric negative sample. Haskell, Swift, TypeScript, Effect Schema, Pike, Kotlin/Jackson, Elm, and Elixir now verify object shape while preserving existing public types, constructors, and handling of unknown members.

Testing: `npm run build`; `npm run test:unit`; focused schema fixtures for Swift, TypeScript, TypeScript Effect Schema, Rust, Go, Java, JavaScript, TypeScript Zod, Kotlin, KotlinX, Kotlin/Jackson, Dart, and Objective-C; focused Elm schema fixture; Docker roundtrip/rejection with Elixir 1.15, GHC/Aeson, Pike, PHP 8.4, and all three C# drivers; `npm run lint`.

Production diffs by fix: Haskell 1+/1-; Swift 15+/0-; TypeScript 1+/1-; Effect Schema 4+/2-; Pike 4+/0-; Kotlin/Jackson 1+/1-; Elm 8+/0-; Elixir 1+/1-. Each is at most 15 changed lines.
