### PR TITLE
fix(elm): reject null for optional non-nullable properties

### DIFF
--- a/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
+++ b/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
@@ -312,7 +312,7 @@ export class ElmRenderer extends ConvenienceRenderer {
         if (p.isOptional) {
             return multiWord(
                 " ",
-                "Jdec.nullable",
+                p.type.isNullable ? "Jdec.nullable" : "Jdec.map Just",
                 parenIfNeeded(this.decoderNameForType(p.type, true)),
             );
         }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -825,7 +825,6 @@ export const ElmLanguage: Language = {
     ],
     skipMiscJSON: false,
     skipSchema: [
-        "optional-property.schema",
         "union-list.schema", // recursion
         "list.schema", // recursion
         "ref-remote.schema", // recursion


### PR DESCRIPTION
A JSON Schema optional property with a non-nullable type (`"value": { "type": "string" }` under `additionalProperties: false`) accepted an explicit `{"value":null}`: Elm generated `optionalField "value" (Jdec.nullable Jdec.string) Nothing`, so `null` decoded to `Nothing` and round-tripped as `{}` instead of failing. It now generates `optionalField "value" (Jdec.map Just Jdec.string) Nothing`, which rejects `null` while an absent key still yields `Nothing`. Nullable property types keep `Jdec.nullable`.

Coverage: removes `optional-property.schema` from Elm's `skipSchema`, enabling the shared fixture's three samples, including the expected-failure input `optional-property.1.fail.json`.

Validation: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-elm npm run test:fixtures -- test/inputs/schema/optional-property.schema` (3 files); `CPUs=2 QUICKTEST=true FIXTURE=schema-elm npm run test:fixtures` (87 tests); `CPUs=2 QUICKTEST=true FIXTURE=elm npm run test:fixtures` (57 tests, includes the `array-type: array` renderer-option variant); `npm run lint`.

Production change: 1 line added, 1 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
