### PR TITLE
fix(dart): reserve the MapEntry runtime name

### DIFF
--- a/packages/quicktype-core/src/language/Dart/constants.ts
+++ b/packages/quicktype-core/src/language/Dart/constants.ts
@@ -68,6 +68,7 @@ export const keywords = [
     "DateTime",
     "EnumValues",
     "FormatException",
+    "MapEntry",
     "RegExp",
     "fromJson",
     "toJson",

--- a/test/inputs/json/priority/keywords.json
+++ b/test/inputs/json/priority/keywords.json
@@ -175,6 +175,7 @@
       "lock": { "lock": 123 },
       "long": { "long": 123 },
       "map": { "map": 123 },
+      "MapEntry": { "MapEntry": 123 },
       "metadata_property_handling": { "metadata_property_handling": 123 },
       "module": { "module": 123 },
       "mutable": { "mutable": 123 },
@@ -197,10 +198,10 @@
       "NSError": { "NSError": 123 },
       "NSString": { "NSString": 123 },
       "NULL": { "NULL": 123 },
-      "null": { "null": 123 },
       "dummy": 123
     },
   "obj4": {
+      "null": { "null": 123 },
       "nullptr": { "nullptr": 123 },
       "number": { "number": 123 },
       "object": { "object": 123 },
@@ -264,10 +265,10 @@
       "stackalloc": { "stackalloc": 123 },
       "Standards": { "Standards": 123 },
       "static": { "static": 123 },
-      "static_assert": { "static_assert": 123 },
       "dummy": 123
     },
   "obj5": {
+      "static_assert": { "static_assert": 123 },
       "static_cast": { "static_cast": 123 },
       "StdDeserializer": { "StdDeserializer": 123 },
       "StdSerializer": { "StdSerializer": 123 },

--- a/test/inputs/schema/keyword-enum.schema
+++ b/test/inputs/schema/keyword-enum.schema
@@ -173,6 +173,7 @@
         "lock",
         "long",
         "map",
+        "MapEntry",
         "metadata_property_handling",
         "module",
         "mutable",

--- a/test/inputs/schema/keyword-unions.schema
+++ b/test/inputs/schema/keyword-unions.schema
@@ -1184,6 +1184,13 @@
             ],
             "title": "union_map"
         },
+        "MapEntry": {
+            "oneOf": [
+                { "type": "number" },
+                { "type": "object", "additionalProperties": false, "title": "MapEntry" }
+            ],
+            "title": "union_MapEntry"
+        },
         "metadata_property_handling": {
             "oneOf": [
                 { "type": "number" },

--- a/test/keywords.txt
+++ b/test/keywords.txt
@@ -167,6 +167,7 @@ list
 lock
 long
 map
+MapEntry
 metadata_property_handling
 module
 mutable


### PR DESCRIPTION
A JSON input with a `MapEntry` property makes quicktype emit a Dart class named `MapEntry`, shadowing `dart:core`'s. The generated `EnumValues<T>` helper calls `MapEntry(v, k)`, so the file fails to compile: `TopLevel.dart:6504:52: Error: Too many positional arguments: 0 allowed, but 2 found. ... reverseMap = map.map((k, v) => MapEntry(v, k));`. Reserving `MapEntry` in the Dart keyword list renames the model class instead.

Coverage: `MapEntry` added to `test/keywords.txt`, with `test/inputs/json/priority/keywords.json`, `test/inputs/schema/keyword-enum.schema` and `test/inputs/schema/keyword-unions.schema` regenerated by `test/make-keyword-tests.sh`. These are shared inputs, so all languages that run them now exercise the name.

Validation: `npm run build`; `CPUs=2 QUICKTEST=true FIXTURE=dart npm run test:fixtures` (68 tests, all Dart option variants); `CPUs=2 QUICKTEST=true FIXTURE=schema-dart npm run test:fixtures -- test/inputs/schema/keyword-enum.schema test/inputs/schema/keyword-unions.schema`; `keywords.json` through `typescript, javascript, typescript-zod, typescript-effect-schema, swift, golang, rust, kotlin, kotlin-jackson, cplusplus, objective-c, php, elixir, elm, crystal, pike, flow, javascript-prop-types, python, ruby, csharp, java`; `npm run lint`. Baseline without the `constants.ts` change reproduces the compile error above.

Production change: 1 line added, 0 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
