### PR TITLE
fix(cplusplus): reject null for optional non-nullable properties

### DIFF
--- a/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
+++ b/packages/quicktype-core/src/language/CPlusPlus/CPlusPlusRenderer.ts
@@ -1574,6 +1574,19 @@ export class CPlusPlusRenderer extends ConvenienceRenderer {
                         );
                     }
 
+                    if (p.isOptional && !propType.isNullable) {
+                        const key = this.NarrowString.createStringLiteral([
+                            stringEscape(json),
+                        ]);
+                        this.emitLine(
+                            "if (j.find(",
+                            key,
+                            ") != j.end() && j.at(",
+                            key,
+                            ').is_null()) throw std::runtime_error("Unexpected null");',
+                        );
+                    }
+
                     if (p.isOptional || propType instanceof UnionType) {
                         const [nullOrOptional, typeSet] = ((): [
                             boolean,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -746,7 +746,7 @@ export const CPlusPlusLanguage: Language = {
     topLevel: "TopLevel",
     skipJSON: [],
     skipMiscJSON: false,
-    skipSchema: ["optional-property.schema"],
+    skipSchema: [],
     rendererOptions: {},
     quickTestRendererOptions: [
         { "code-format": "with-struct" },


### PR DESCRIPTION
An optional non-nullable property given an explicit `null` (`{"value": null}` against a schema with `"value": {"type": "string"}`) was silently accepted: the generated `get_stack_optional` helper treats a present-but-null key the same as an absent key, so the deserializer produced an empty optional and round-tripped `{"value":null}` instead of failing. Now `from_json` rejects it with `Unexpected null`.

Coverage: `optional-property.schema` is removed from the C++ `skipSchema` list, enabling the shared `optional-property.1.fail.json` (`{"value":null}`) negative case plus the `.1.json` / `.2.json` positive cases.

Generated `from_json`, before:

```cpp
inline void from_json(const json & j, TopLevel& x) {
    if (!j.is_object()) throw std::runtime_error("Expected object");
    x.set_value(get_stack_optional<std::string>(j, "value"));
}
```

After:

```cpp
inline void from_json(const json & j, TopLevel& x) {
    if (!j.is_object()) throw std::runtime_error("Expected object");
    if (j.find("value") != j.end() && j.at("value").is_null()) throw std::runtime_error("Unexpected null");
    x.set_value(get_stack_optional<std::string>(j, "value"));
}
```

Validation: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-cplusplus npm run test:fixtures -- test/inputs/schema/optional-property.schema` (fails on `optional-property.1.fail.json` without the renderer change, passes with it, 3 files); `CPUs=2 QUICKTEST=true FIXTURE=schema-cplusplus npm run test:fixtures` (88/88, includes the `hide-null-optional` variant); `CPUs=2 QUICKTEST=true FIXTURE=cplusplus npm run test:fixtures` (64/64, includes the `boost`, `wstring`, `with-struct` and `east-const` variants); `CPUs=2 QUICKTEST=true FIXTURE=cplusplus-multi-source npm run test:fixtures`; `npm run lint`.

Production change: 13 lines added, 0 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
