### PR TITLE
fix(effect): reserve the RegExp constructor name

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -60,6 +60,7 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
             "Array",
             "JSON",
             "Error",
+            "RegExp",
         ];
     }
 

--- a/test/inputs/schema/pattern.2.fail.pattern.json
+++ b/test/inputs/schema/pattern.2.fail.pattern.json
@@ -1,0 +1,8 @@
+{
+  "pattern1": "qqq",
+  "pattern2": "ba",
+  "union": "ccc",
+  "RegExp": {
+    "pattern3": "d"
+  }
+}

--- a/test/inputs/schema/pattern.2.json
+++ b/test/inputs/schema/pattern.2.json
@@ -1,0 +1,8 @@
+{
+  "pattern1": "aa",
+  "pattern2": "ba",
+  "union": "ccc",
+  "RegExp": {
+    "pattern3": "d"
+  }
+}

--- a/test/inputs/schema/pattern.schema
+++ b/test/inputs/schema/pattern.schema
@@ -19,6 +19,18 @@
           "pattern": "c[.]*"
         }
       ]
+    },
+    "RegExp": {
+      "type": "object",
+      "title": "RegExp",
+      "properties": {
+        "pattern3": {
+          "type": "string",
+          "pattern": "d[.]*"
+        }
+      },
+      "required": ["pattern3"],
+      "additionalProperties": false
     }
   },
   "required": ["pattern1", "pattern2", "union"]


### PR DESCRIPTION
A JSON Schema model named `RegExp` is rendered as `export class RegExp`, which lives in value space and shadows the global constructor that the same module uses for pattern constraints. Importing the generated code throws before any decoding happens:

```
ReferenceError: Cannot access 'RegExp' before initialization
    at TopLevel.ts:5:45
```

```ts
export class RegExp extends S.Class<RegExp>("RegExp")({
    "pattern3": S.String.pipe(S.pattern(new RegExp("d[.]*"))),
}) {}
```

`RegExp` is now a forbidden name in the global namespace, so the model is emitted as `RegExpClass`.

Coverage: `keywords.json` already has a `RegExp` model, but JSON inference never produces `pattern` constraints, so nothing there emits `new RegExp(...)`. The shared `test/inputs/schema/pattern.schema` gains an optional `RegExp` model with a patterned string property, plus `pattern.2.json` and `pattern.2.fail.pattern.json`. The negative sample violates the top-level `pattern1` rather than the nested property: Kotlin (Klaxon and Jackson) emits its `init { require(...) }` block only for top-level classes, and Pike never calls a nested class's `*_from_JSON`, so neither validates constraints inside nested classes today.

Validation: `npm run build`; all 30 registered schema fixtures run one at a time on `test/inputs/schema/pattern.schema` (haskell untested — its resolver's GHC has no Apple Silicon build); `CPUs=2 QUICKTEST=true FIXTURE=schema-typescript-effect-schema npm run test:fixtures` for the full quick group including the `just-schema` renderer-option variant; `npm run lint`.

Production change: 1 line added, 0 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
