### PR TITLE
fix(ruby): reject null for optional non-nullable properties

### DIFF
--- a/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
+++ b/packages/quicktype-core/src/language/Ruby/RubyRenderer.ts
@@ -568,6 +568,20 @@ export class RubyRenderer extends ConvenienceRenderer {
                                 : // This will raise a runtime error if the key is not found in the hash
                                   `d.fetch("${stringEscape(jsonName)}")`;
 
+                            if (p.isOptional && !p.type.isNullable) {
+                                const key = stringEscape(jsonName);
+                                const strict = this.fromDynamic(
+                                    p.type,
+                                    dynamic,
+                                    false,
+                                    true,
+                                );
+                                inits.push([
+                                    [name, ": "],
+                                    [`d.key?("${key}") ? `, strict, " : nil,"],
+                                ]);
+                                return;
+                            }
                             if (
                                 this.propertyTypeMarshalsImplicitlyFromDynamic(
                                     p.type,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -501,7 +501,7 @@ export const RubyLanguage: Language = {
     output: "TopLevel.rb",
     topLevel: "TopLevel",
     skipJSON: [],
-    skipSchema: ["optional-property.schema"],
+    skipSchema: [],
     skipMiscJSON: false,
     rendererOptions: {},
     quickTestRendererOptions: [["pokedex.json", { namespace: "QuickType" }]],


### PR DESCRIPTION
`test/inputs/schema/optional-property.schema` declares an optional, non-nullable `value: string`. The generated `from_dynamic!` read the key unconditionally and handed the result to a `Types::String.optional` attribute, which accepts `nil`, so `{"value":null}` decoded cleanly and round-tripped back as `{"value":null}` instead of failing. Now an absent key still yields `nil`, a present value goes through the property's own strict dry-type, and an explicit `null` raises `Dry::Types::ConstraintError`.

```ruby
# before
value: d["value"],
# after
value: d.key?("value") ? Types::String[d["value"]] : nil,
```

Coverage: removes `optional-property.schema` from Ruby's `skipSchema`. The shared fixture already carries `{}` and `{"value":"present"}` as round-trips and `{"value":null}` as an expected failure; before this change the expected-failure sample returned `"{\"value\":null}\n"` with exit 0.

Validation: `npm run build`; `FIXTURE=schema-ruby npm run test:fixtures -- test/inputs/schema/optional-property.schema` (3 files, exit 0); the full `schema-ruby` group minus `recursive-union-flattening.schema` (86/86, exit 0) — that one schema fails locally under Homebrew Ruby 4.0 with `uninitialized constant X::XElement (NameError)` from `dry-core`, and reproduces identically without this patch, so CI's pinned Ruby covers it; baseline on the same set without `optional-property.schema` was 85/85; `FIXTURE=ruby npm run test:fixtures -- keywords.json optional-union.json pokedex.json` (3/3, includes the `namespace: QuickType` renderer-option variant); `FIXTURE=schema-ruby-syntax` (1/1); `npm run lint`.

Production change: 14 lines added, 0 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
