### PR TITLE
fix(haskell): reject null for optional non-nullable properties

### DIFF
--- a/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
+++ b/packages/quicktype-core/src/language/Haskell/HaskellRenderer.ts
@@ -366,11 +366,7 @@ export class HaskellRenderer extends ConvenienceRenderer {
                 this.indent(() => {
                     let onFirst = true;
                     this.forEachClassProperty(c, "none", (_, jsonName, p) => {
-                        const operator = p.isOptional
-                            ? p.type.isNullable
-                                ? ".:!"
-                                : ".:?"
-                            : ".:";
+                        const operator = p.isOptional ? ".:!" : ".:";
                         this.emitLine(
                             onFirst ? "<$> " : "<*> ",
                             "v ",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1667,7 +1667,7 @@ export const HaskellLanguage: Language = {
     topLevel: "QuickType",
     skipJSON: [],
     skipMiscJSON: false,
-    skipSchema: ["optional-property.schema"],
+    skipSchema: [],
     rendererOptions: {},
     // The default is array-type=list; this keeps the Vector code path
     // covered.


### PR DESCRIPTION
`optional-property.schema` (one optional non-nullable `value: string`) generated `v .:? "value"`. Aeson's `.:?` parses at type `Maybe a`, so the input `{"value":null}` decoded to `Nothing` and the program round-tripped it to `{}` with exit 0 instead of failing. All optional properties now use `.:!`, which returns `Nothing` only for a missing key and otherwise runs `parseJSON` at type `a`; `{"value":null}` is now rejected. For the nested-`Maybe` nullable case introduced in #3455, `.:!` at `Maybe a` still yields `Just Nothing`, so explicit nulls stay distinguishable from absent keys.

Generated `parseJSON` for `optional-property.schema`:

```diff
 instance FromJSON QuickType where
     parseJSON (Object v) = QuickType
-        <$> v .:? "value"
+        <$> v .:! "value"
```

Coverage: removes `optional-property.schema` from Haskell's `skipSchema`, enabling the existing `optional-property.1.json`, `.2.json` and `.1.fail.json` samples.

Validation: `npm run build`; `npm run lint`. The Haskell fixture pins stack resolver lts-15.12 (GHC 8.8.3), which has no Apple Silicon build, so the fixture harness could not run locally. Verified instead in Docker (debian bookworm, GHC 9.0.2, aeson 2.0.3.0) by compiling the fixture's `Main.hs` against the generated `QuickType.hs` and running the real samples:

- `optional-property` before the fix: `.1.json` exit 0, `.2.json` exit 0, `.1.fail.json` **exit 0** emitting `{}` — the bug.
- `optional-property` after the fix: `.1.json` -> `{}`, `.2.json` -> `{"value":"present"}`, `.1.fail.json` exit 1.
- `optional-any.schema`: `.1.json` -> `{"bar":true}`, `.2.json` -> `{"bar":false,"foo":123}`, `.3.fail.json` exit 1 (optional `any` unchanged).
- `strict-optional.schema`: `.1.fail.strict-optional.json` exit 1.
- `combinations4.json` (JSON input, 150 optional properties incl. `Maybe (Maybe a)` fields): round-trips equal to the input, with explicit `null`s preserved and absent keys omitted.

Generated output for `optional-any.schema`, `strict-optional.schema` and `combinations4.json` is byte-identical to `origin/master` except for the `.:?` -> `.:!` change on optional non-nullable properties.

Production change: 1 line added, 5 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
