### PR TITLE
fix(elm): count string lengths in code points

### DIFF
--- a/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
+++ b/packages/quicktype-core/src/language/Elm/ElmRenderer.ts
@@ -259,7 +259,7 @@ export class ElmRenderer extends ConvenienceRenderer {
         const [min, max] = minMaxLengthForType(t) ?? [];
         if (min === undefined && max === undefined)
             return singleWord("Jdec.string");
-        const length = "String.length x";
+        const length = "List.length (String.toList x)";
         const minCheck = min === undefined ? "True" : `${length} >= ${min}`;
         const maxCheck = max === undefined ? "True" : `${length} <= ${max}`;
         return singleWord(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -824,6 +824,9 @@ export const ElmLanguage: Language = {
         "list.json", // recursion
     ],
     skipMiscJSON: false,
+    additionalSchemaFiles: [
+        "test/inputs/regressions/unicode-codepoint-length.schema",
+    ],
     skipSchema: [
         "optional-property.schema",
         "union-list.schema", // recursion


### PR DESCRIPTION
A JSON Schema with `minLength`/`maxLength` on a string rejected valid input containing astral characters: `{"exact": "😀😀"}` against `minLength: 2, maxLength: 2` failed with `String length out of range`, because the generated decoder used `String.length`, which counts UTF-16 code units (one emoji = 2). JSON Schema defines length in code points. The decoder now counts code points:

```elm
-- before
if String.length x >= 2 && String.length x <= 2 then ...
-- after
if List.length (String.toList x) >= 2 && List.length (String.toList x) <= 2 then ...
```

Coverage: the shared regression schema `test/inputs/regressions/unicode-codepoint-length.schema` is now in Elm's `additionalSchemaFiles` — 2 positive samples (astral pair, combining-mark `é`) and 4 expected `minmaxlength` failures. Elm does not declare the `pattern` feature, so `.5.fail.pattern.json` is not selected (6 samples run).

Validation: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-elm npm run test:fixtures -- test/inputs/regressions/unicode-codepoint-length.schema` (fails on `origin/master` with only the `languages.ts` change, passes with the fix, `(6 files)`); `CPUs=2 QUICKTEST=true FIXTURE=schema-elm npm run test:fixtures` (88/88); `CPUs=2 QUICKTEST=true FIXTURE=elm npm run test:fixtures -- test/inputs/json/priority/keywords.json test/inputs/json/samples/pokedex.json`; `npm run lint`.

Production change: 1 line added, 1 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
