### PR TITLE
fix(pike): match patterns against wide strings

### DIFF
--- a/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
+++ b/packages/quicktype-core/src/language/Pike/PikeRenderer.ts
@@ -363,7 +363,7 @@ export class PikeRenderer extends ConvenienceRenderer {
                     const pattern = patternForType(p.type);
                     if (pattern !== undefined)
                         this.emitLine(
-                            `if (${optionalGuard}!Regexp("${stringEscape(pattern)}")->match(${jsonValue})) error("String does not match pattern");`,
+                            `if (${optionalGuard}!Regexp(string_to_utf8("${stringEscape(pattern)}"))->match(string_to_utf8(${jsonValue}))) error("String does not match pattern");`,
                         );
                     const requiredType =
                         p.type instanceof UnionType

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1583,6 +1583,9 @@ export const PikeLanguage: Language = {
     topLevel: "TopLevel",
     skipJSON: [],
     skipMiscJSON: false,
+    additionalSchemaFiles: [
+        "test/inputs/regressions/unicode-codepoint-length.schema",
+    ],
     skipSchema: [
         "optional-property.schema",
         // no implicit cast int <-> float in Pike


### PR DESCRIPTION
A JSON Schema `pattern` on a string containing any non-Latin-1 character (e.g. `{"exact": "😀😀"}` against `"pattern": "^[^!]+$"`) crashed the generated Pike program: Pike's core `Regexp.SimpleRegexp` only accepts `string(8bit)`, so `match` died with `Bad argument 1 to match(). Expected string(8bit).` instead of validating. Pattern checks now encode both sides first:

```pike
if (!Regexp(string_to_utf8("^[^!]+$"))->match(string_to_utf8(json["exact"]))) error("String does not match pattern");
```

Matching therefore runs on the UTF-8 encoding: a pattern that counts characters (like `^.{3}$`) counts bytes for non-ASCII input. Previously such input crashed outright. `Regexp.PCRE`, which handles wide strings natively, is not an option — CI installs `pike8.0-core`, and the Ubuntu `pike8.0` source ships no `pike8.0-pcre` binary package.

Coverage: `test/inputs/regressions/unicode-codepoint-length.schema` added to Pike's `additionalSchemaFiles`; its `.5.fail.pattern.json` case is the negative test, and the emoji-bearing positive samples are what crashed before.

Validation: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-pike npm run test:fixtures -- test/inputs/regressions/unicode-codepoint-length.schema` (fails on master with the error above, passes here with 7 files); `CPUs=2 QUICKTEST=true FIXTURE=schema-pike npm run test:fixtures` (88/88, incl. `pattern.schema`, `optional-constraints.schema`, `schema-constraints.schema`); `CPUs=2 QUICKTEST=true FIXTURE=pike npm run test:fixtures -- test/inputs/json/priority/keywords.json test/inputs/json/samples/pokedex.json`; `npm run lint`.

Production change: 1 line added, 1 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
