### PR TITLE
fix(objective-c): count string lengths in code points

### DIFF
--- a/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
+++ b/packages/quicktype-core/src/language/Objective-C/ObjectiveCRenderer.ts
@@ -921,12 +921,12 @@ export class ObjectiveCRenderer extends ConvenienceRenderer {
                                     minMaxLengthForType(property.type) ?? [];
                                 if (minLength !== undefined) {
                                     this.emitLine(
-                                        `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [dict[@"${objectiveCStringEscape(jsonName)}"] length] < ${minLength}) return nil;`,
+                                        `if (dict[@"${objectiveCStringEscape(jsonName)}"] && [dict[@"${objectiveCStringEscape(jsonName)}"] lengthOfBytesUsingEncoding:NSUTF32StringEncoding] / 4 < ${minLength}) return nil;`,
                                     );
                                 }
                                 if (maxLength !== undefined) {
                                     this.emitLine(
-                                        `if ([dict[@"${objectiveCStringEscape(jsonName)}"] length] > ${maxLength}) return nil;`,
+                                        `if ([dict[@"${objectiveCStringEscape(jsonName)}"] lengthOfBytesUsingEncoding:NSUTF32StringEncoding] / 4 > ${maxLength}) return nil;`,
                                     );
                                 }
                                 if (property.type.kind === "uuid") {

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -951,6 +951,9 @@ export const ObjectiveCLanguage: Language = {
         "blns-object.json",
     ],
     skipMiscJSON: false,
+    additionalSchemaFiles: [
+        "test/inputs/regressions/unicode-codepoint-length.schema",
+    ],
     skipSchema: ["optional-property.schema"],
     rendererOptions: { functions: "true" },
     quickTestRendererOptions: [],


### PR DESCRIPTION
A schema with `"minLength": 2, "maxLength": 2` and the sample `{"exact": "😀😀", ...}` was rejected by the generated Objective-C code: the guard `[dict[@"exact"] length] > 2` counts UTF-16 code units, so a two-emoji string measures 4 and `QTTopLevelFromData` returns nil (`Could not convert model to JSON: ... value parameter is nil`, exit 1). JSON Schema defines `minLength`/`maxLength` in code points, so `"😀"` must count as 1 and `"é"` written as `e` + U+0301 as 2.

Before:

```objc
if ([dict[@"exact"] length] > 2) return nil;
```

After:

```objc
if ([dict[@"exact"] lengthOfBytesUsingEncoding:NSUTF32StringEncoding] / 4 > 2) return nil;
```

Coverage: the shared `test/inputs/regressions/unicode-codepoint-length.schema` (7 files: 2 passing samples, 5 expected failures) is added to Objective-C's `additionalSchemaFiles`. On master with only that test change, sample `.1.json` fails; with the fix the fixture passes.

Validation: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-objective-c npm run test:fixtures -- test/inputs/regressions/unicode-codepoint-length.schema` (fails before, `(7 files)` after); `CPUs=2 QUICKTEST=true FIXTURE=schema-objective-c npm run test:fixtures` (88/88); `CPUs=2 QUICKTEST=true FIXTURE=objective-c npm run test:fixtures -- test/inputs/json/priority/keywords.json test/inputs/json/samples/pokedex.json`; `CPUs=2 QUICKTEST=true FIXTURE=comment-injection-objective-c npm run test:fixtures` (4/4); `npm run lint`. All run against macOS clang + Foundation.

Production change: 2 lines added, 2 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
