### PR TITLE
fix(javascript-prop-types): count string lengths in code points

### DIFF
--- a/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
+++ b/packages/quicktype-core/src/language/JavaScriptPropTypes/JavaScriptPropTypesRenderer.ts
@@ -123,8 +123,12 @@ export class JavaScriptPropTypesRenderer extends ConvenienceRenderer {
                 return "PropTypes.string";
             return [
                 "(props, name) => { const value = props[name]; return value == null || (typeof value === 'string'",
-                min === undefined ? "" : [" && value.length >= ", String(min)],
-                max === undefined ? "" : [" && value.length <= ", String(max)],
+                min === undefined
+                    ? ""
+                    : [" && [...value].length >= ", String(min)],
+                max === undefined
+                    ? ""
+                    : [" && [...value].length <= ", String(max)],
                 pattern === undefined
                     ? ""
                     : [

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1082,6 +1082,9 @@ export const JavaScriptPropTypesLanguage: Language = {
     skipJSON: [],
     skipSchema: ["optional-property.schema"],
     skipMiscJSON: false,
+    additionalSchemaFiles: [
+        "test/inputs/regressions/unicode-codepoint-length.schema",
+    ],
     rendererOptions: { "module-system": "es6" },
     quickTestRendererOptions: [{ converters: "top-level" }],
     sourceFiles: ["src/language/JavaScriptPropTypes/index.ts"],


### PR DESCRIPTION
A schema with `minLength: 2, maxLength: 2` rejected `{"exact": "😀😀"}` with `Warning: Failed prop type: Invalid prop 'obj.exact' supplied to 'MyComponent'`, because the generated validator measured `value.length` (UTF-16 code units), counting each astral-plane character twice. It now measures `[...value].length`, so lengths are counted in code points as JSON Schema specifies.

Before:

```js
"exact": PropTypes.oneOfType([(props, name) => { const value = props[name]; return value == null || (typeof value === 'string' && value.length >= 2 && value.length <= 2 && new RegExp("^[^!]+$").test(value)) ? null : new Error("Expected bounded string"); }]).isRequired,
```

After:

```js
"exact": PropTypes.oneOfType([(props, name) => { const value = props[name]; return value == null || (typeof value === 'string' && [...value].length >= 2 && [...value].length <= 2 && new RegExp("^[^!]+$").test(value)) ? null : new Error("Expected bounded string"); }]).isRequired,
```

Coverage: the shared `test/inputs/regressions/unicode-codepoint-length.schema` (already used by seven other languages) is added to JavaScriptPropTypes' `additionalSchemaFiles`, giving two positive samples (astral pair, combining sequence) and four `minmaxlength` expected-failure samples.

Validation: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-javascript-prop-types npm run test:fixtures -- test/inputs/regressions/unicode-codepoint-length.schema` (fails before the fix, passes after with `(7 files)`); `CPUs=2 QUICKTEST=true FIXTURE=schema-javascript-prop-types npm run test:fixtures` (88/88); `CPUs=2 QUICKTEST=true FIXTURE=javascript-prop-types npm run test:fixtures -- test/inputs/json/priority/keywords.json test/inputs/json/samples/pokedex.json`; `npm run lint`.

Production change: 6 lines added, 2 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
