### PR TITLE
fix(cjson): count string lengths in code points

### DIFF
--- a/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
+++ b/packages/quicktype-core/src/language/CJSON/CJSONRenderer.ts
@@ -2507,11 +2507,11 @@ export class CJSONRenderer extends ConvenienceRenderer {
                                                     }
                                                     if (minLength !== undefined)
                                                         this.emitLine(
-                                                            `if (strlen(${value}->valuestring) < ${minLength}) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                            `if (quicktype_strlen_codepoints(${value}->valuestring) < ${minLength}) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
                                                         );
                                                     if (maxLength !== undefined)
                                                         this.emitLine(
-                                                            `if (strlen(${value}->valuestring) > ${maxLength}) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
+                                                            `if (quicktype_strlen_codepoints(${value}->valuestring) > ${maxLength}) { cJSON_Delete${this.sourcelikeToString(className)}(x); return NULL; }`,
                                                         );
                                                     if (
                                                         cJSON.cjsonType ===
@@ -5882,6 +5882,17 @@ ${this.sourcelikeToString(cJSON.items?.deleteType ?? "")}(validated);`,
             this.emitLine("#ifndef cJSON_Enum");
             this.emitLine("#define cJSON_Enum (1 << 17)");
             this.emitLine("#endif");
+            this.ensureBlankLine();
+
+            this.emitMultiline(`#ifndef QUICKTYPE_STRLEN_CODEPOINTS
+#define QUICKTYPE_STRLEN_CODEPOINTS
+static inline size_t quicktype_strlen_codepoints(const char * s)
+{
+    size_t n = 0;
+    for (; *s != '\\0'; s++) { if ((*s & 0xC0) != 0x80) { n++; } }
+    return n;
+}
+#endif`);
             this.ensureBlankLine();
         }
     }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -605,6 +605,9 @@ export const CJSONLanguage: Language = {
         "combinations2.json",
     ],
     skipMiscJSON: false,
+    additionalSchemaFiles: [
+        "test/inputs/regressions/unicode-codepoint-length.schema",
+    ],
     skipSchema: [
         /* Enum as TopLevel is not supported */
         "top-level-enum.schema",


### PR DESCRIPTION
A schema with `minLength`/`maxLength` on a string generated `strlen()` checks, which count UTF-8 bytes rather than code points. `{"exact": "😀😀", "minimum": "😀a", "maximum": "😀"}` against `minLength`/`maxLength` of 2/2, 2, and 1 was rejected (`cJSON_ParseTopLevel` returned NULL, driver exited 1). Now the check counts code points and the input round-trips.

Before:

```c
if (strlen(cJSON_GetObjectItemCaseSensitive(j, "exact")->valuestring) < 2) { cJSON_DeleteTopLevel(x); return NULL; }
```

After:

```c
if (quicktype_strlen_codepoints(cJSON_GetObjectItemCaseSensitive(j, "exact")->valuestring) < 2) { cJSON_DeleteTopLevel(x); return NULL; }
```

The helper is emitted once in the header preamble:

```c
#ifndef QUICKTYPE_STRLEN_CODEPOINTS
#define QUICKTYPE_STRLEN_CODEPOINTS
static inline size_t quicktype_strlen_codepoints(const char * s)
{
    size_t n = 0;
    for (; *s != '\0'; s++) { if ((*s & 0xC0) != 0x80) { n++; } }
    return n;
}
#endif
```

Every generated header carries the definition, and under `source-style=multi-source` several of them are included in one translation unit, so the include guard is required to avoid a redefinition error.

Coverage: `test/inputs/regressions/unicode-codepoint-length.schema` (already used by other languages) is added to cJSON's `additionalSchemaFiles`, covering the positive samples and the `minmaxlength`/`pattern` expected failures.

Validation: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-cjson npm run test:fixtures -- test/inputs/regressions/unicode-codepoint-length.schema` (fails on the positive `.1.json` without the renderer change, passes with it, 7 files); `CPUs=2 QUICKTEST=true FIXTURE=schema-cjson npm run test:fixtures` (88/88); `CPUs=2 QUICKTEST=true FIXTURE=cjson npm run test:fixtures -- test/inputs/json/priority/keywords.json test/inputs/json/priority/nbl-stats.json`; `CPUs=2 QUICKTEST=true FIXTURE=cjson-default,cjson-multi-header,cjson-multi-split npm run test:fixtures` (nbl-stats.json in all three source-style/header-only combinations); `npm run lint`. valgrind is unavailable on macOS, so the fixture's `runCommand` ran behind a passthrough shim: leak checking was not exercised locally, CI runs real valgrind.

Production change: 13 lines added, 2 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
