### PR TITLE
fix(kotlin): count string lengths in code points

### DIFF
--- a/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinJacksonRenderer.ts
@@ -341,8 +341,8 @@ import com.fasterxml.jackson.module.kotlin.*`);
                     const [lengthMin, lengthMax] =
                         minMaxLengthForType(p.type) ?? [];
                     const lengthBefore = p.isOptional
-                        ? `${n}?.let { require(it.length`
-                        : `require(${n}.length`;
+                        ? `${n}?.let { require(it.codePointCount(0, it.length)`
+                        : `require(${n}.codePointCount(0, ${n}.length)`;
                     if (lengthMin !== undefined)
                         checks.push(`${lengthBefore} >= ${lengthMin}${after}`);
                     if (lengthMax !== undefined)

--- a/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
+++ b/packages/quicktype-core/src/language/Kotlin/KotlinKlaxonRenderer.ts
@@ -405,8 +405,8 @@ export class KotlinKlaxonRenderer extends KotlinRenderer {
                     if (min !== undefined) emitValidation(validate(">=", min));
                     if (max !== undefined) emitValidation(validate("<=", max));
                     const length = p.isOptional
-                        ? `${value}?.let { require(it.length`
-                        : `require(${value}.length`;
+                        ? `${value}?.let { require(it.codePointCount(0, it.length)`
+                        : `require(${value}.codePointCount(0, ${value}.length)`;
                     const emitLength = (operator: string, bound: number) =>
                         emitValidation(
                             `${length} ${operator} ${bound}${p.isOptional ? ") }" : ")"}`,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1362,6 +1362,9 @@ export const KotlinLanguage: Language = {
         "keyword-unions.schema",
     ],
     skipMiscJSON: false,
+    additionalSchemaFiles: [
+        "test/inputs/regressions/unicode-codepoint-length.schema",
+    ],
     // The default framework is jackson; this fixture deliberately pins
     // klaxon so the Klaxon renderer keeps end-to-end coverage.
     rendererOptions: { framework: "klaxon" },
@@ -1404,6 +1407,9 @@ export const KotlinJacksonLanguage: Language = {
     skipJSON: [],
     skipSchema: ["optional-property.schema", "keyword-unions.schema"],
     skipMiscJSON: false,
+    additionalSchemaFiles: [
+        "test/inputs/regressions/unicode-codepoint-length.schema",
+    ],
     rendererOptions: { framework: "jackson" },
     quickTestRendererOptions: [],
     sourceFiles: ["src/language/Kotlin/index.ts"],


### PR DESCRIPTION
A schema with `minLength`/`maxLength` on a string property, given a value containing astral-plane characters such as `"😀😀"`, produced Kotlin that rejected valid input: `require(exact.length >= 2)` counts UTF-16 code units, so `"😀😀"` measures 4 and `"😀"` measures 2. Both the Klaxon and Jackson renderers now count code points, so lengths match the JSON Schema definition of string length.

Klaxon and Jackson, before:

```kotlin
require(exact.length >= 2)
require(maximum.length <= 1)
```

after:

```kotlin
require(exact.codePointCount(0, exact.length) >= 2)
require(maximum.codePointCount(0, maximum.length) <= 1)
```

Coverage: the shared `test/inputs/regressions/unicode-codepoint-length.schema` (already used by other languages) is added to `additionalSchemaFiles` of both `KotlinLanguage` and `KotlinJacksonLanguage`. Its positive samples use astral and combining-mark strings; its `.fail.minmaxlength` samples still fail. Both renderers carry the same fix because it is one token in each of two sibling renderers, exposed by the same schema.

Validation: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-kotlin` and `FIXTURE=schema-kotlin-jackson` on `unicode-codepoint-length.schema` (fail before, pass after, 7 files each); full `CPUs=2 QUICKTEST=true FIXTURE=schema-kotlin` and `FIXTURE=schema-kotlin-jackson` groups; `CPUs=2 QUICKTEST=true FIXTURE=kotlin,kotlin-jackson` on `keywords.json` and `pokedex.json`; `npm run lint`.

Production change: 4 lines added, 4 removed (2 added and 2 removed per renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
