### PR TITLE
fix(elixir): count string lengths in code points

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -173,7 +173,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
         };
         const pattern = patternForType(t);
         const [minLength, maxLength] = minMaxLengthForType(t) ?? [];
-        const length = "String.length(value)";
+        const length = "length(String.codepoints(value))";
         const constraints: string[] = [];
         if (minLength !== undefined) {
             constraints.push(`${length} >= ${minLength}`);

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1850,6 +1850,9 @@ export const ElixirLanguage: Language = {
         "blns-object.json",
     ],
     skipMiscJSON: false,
+    additionalSchemaFiles: [
+        "test/inputs/regressions/unicode-codepoint-length.schema",
+    ],
     skipSchema: [
         "optional-property.schema",
         // The test incorrectly succeeds due to the emitter being permissive for unions that contain only primitives. A future enhancement


### PR DESCRIPTION
Elixir's generated string-length checks used `String.length(value)`, which counts graphemes. With `minLength: 2` / `maxLength: 2`, the sample `"é"` written as `e` + U+0301 — 2 code points, 1 grapheme — was rejected with `** (ArgumentError)` from `TopLevel.decode_exact/1`. JSON Schema measures string length in code points, so the check now counts code points and the sample round-trips.

```
- if String.length(value) >= 2 and String.length(value) <= 2 and ...
+ if length(String.codepoints(value)) >= 2 and length(String.codepoints(value)) <= 2 and ...
```

Coverage: the shared regression schema `test/inputs/regressions/unicode-codepoint-length.schema` is now in Elixir's `additionalSchemaFiles` — 2 positive samples and 5 expected failures (4 min/max length, 1 pattern).

Validation: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-elixir npm run test:fixtures -- test/inputs/regressions/unicode-codepoint-length.schema` (fails on origin/master with the sample above, passes here, 7 files); `CPUs=2 QUICKTEST=true FIXTURE=schema-elixir npm run test:fixtures` (44/88 before it aborted on `keyword-unions.schema`, which fails locally on Elixir 1.20 because the generated `JSON` module collides with the built-in one added in 1.18; CI pins 1.15.7 — the remaining 42 schemas were then rerun explicitly and all passed); `CPUs=2 QUICKTEST=true FIXTURE=elixir npm run test:fixtures -- test/inputs/json/priority/keywords.json test/inputs/json/samples/pokedex.json`; `npm run lint`.

Production change: 1 line added, 1 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
