### PR TITLE
fix(elixir): reject null for optional non-nullable properties

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
+++ b/packages/quicktype-core/src/language/Elixir/ElixirRenderer.ts
@@ -534,11 +534,14 @@ export class ElixirRenderer extends ConvenienceRenderer {
         jsonName: string,
         name: Name,
         optional = false,
+        allowNull = true,
     ): Sourcelike {
         jsonName = jsonName.replace(/#/g, "\\u{23}");
         const primitive = ['m["', jsonName, '"]'];
         const checked = ["decode_", name, "(", primitive, ")"];
-        const optionalChecked = [primitive, " && ", checked];
+        const optionalChecked = allowNull
+            ? [primitive, " && ", checked]
+            : ['(if Map.has_key?(m, "', jsonName, '"), do: ', checked, ")"];
 
         return matchType<Sourcelike>(
             t,
@@ -1046,6 +1049,7 @@ export class ElixirRenderer extends ConvenienceRenderer {
                                         jsonName,
                                         name,
                                         p.isOptional,
+                                        p.type.isNullable,
                                     );
                                     this.emitLine(name, ": ", expression, ",");
                                 },

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1851,7 +1851,6 @@ export const ElixirLanguage: Language = {
     ],
     skipMiscJSON: false,
     skipSchema: [
-        "optional-property.schema",
         // The test incorrectly succeeds due to the emitter being permissive for unions that contain only primitives. A future enhancement
         // for the Elixir emitter could be a user-controlled 'strict' mode that pattern matches even on unions of only primitive types.
         // A top-level array is deserialized without enforcing its element


### PR DESCRIPTION
`optional-property.schema` declares a non-nullable optional `"value": {"type": "string"}`, but the Elixir renderer emitted `value: m["value"] && decode_value(m["value"])`. The `&&` short-circuits on `nil`, so `{"value":null}` was accepted and round-tripped back as `{"value":null}` instead of being rejected.

The decode expression for an optional property whose type is not itself nullable now guards on key presence:

```elixir
# before
value: m["value"] && decode_value(m["value"]),
# after
value: (if Map.has_key?(m, "value"), do: decode_value(m["value"])),
```

`decode_value(nil)` then falls through to the renderer's existing catch-all clause and returns `{:error, ...}`, which `Jason.encode!` refuses, so the driver exits nonzero — the same failure mechanism already used for required properties. An absent key still yields `nil`.

Scope: this affects the `integer` / `double` / `string` branches of `fromDynamic`, which are exactly the optional properties for which a `decode_<prop>/1` helper is emitted. Optional non-nullable object, array, map and enum properties are unchanged; they have no such helper to call.

Coverage: `optional-property.schema` is removed from Elixir's `skipSchema`, so its two positive samples and the `optional-property.1.fail.json` negative sample now run. On master with only the skip removed, that fixture fails with `Expected failure on input .../optional-property.1.fail.json` and `"result": "{\"value\":null}\n"`.

Validation: `npm run build`; `CPUs=1 QUICKTEST=true FIXTURE=schema-elixir npm run test:fixtures -- test/inputs/schema/optional-property.schema` (3 files, passes); `CPUs=2 QUICKTEST=true FIXTURE=schema-elixir npm run test:fixtures` (86/87; the group aborts on `keyword-unions.schema`, so the remaining 41 schemas were rerun explicitly and all pass); `CPUs=2 QUICKTEST=true FIXTURE=elixir npm run test:fixtures` (51/53 run, `blns-object.json` skipped by config; the group aborts twice, so the remainder was rerun explicitly and all pass); `npm run lint`.

The three local failures are pre-existing and specific to the local Elixir 1.20.4 toolchain — CI pins 1.15.7. `keyword-unions.schema` and `nst-test-suite.json` generate a `JSON` module, which collides with the built-in `JSON` shipped since Elixir 1.18 (`error: struct JSON is undefined`). `objc-control-characters.json` emits a raw U+0085 inside an atom literal, which Elixir 1.20 rejects with `invalid line break character in string`. All three generate output containing no `Map.has_key?`, i.e. this change leaves them byte-identical.

Production change: 5 lines added, 1 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
