### PR TITLE
fix(elixir): reserve the JSON module name

### DIFF
--- a/packages/quicktype-core/src/language/Elixir/constants.ts
+++ b/packages/quicktype-core/src/language/Elixir/constants.ts
@@ -38,6 +38,9 @@ export const forbiddenModuleNames = [
     "IO",
     "Inspect",
     "Integer",
+    // Elixir 1.18 added a built-in JSON module; a generated
+    // `defmodule JSON` shadows it and breaks compilation.
+    "JSON",
     "Kernel",
     "KeyError",
     "Keyword",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1835,6 +1835,10 @@ export const ElixirLanguage: Language = {
         "bug427.json",
         "keywords.json",
         "kitchen-sink.json",
+        // The class inferred from the `y_object_empty_json` property is named
+        // `JSON`, which is reserved; the JSON and JSON Schema pipelines pick
+        // different replacement names for it.
+        "nst-test-suite.json",
         "reddit.json",
     ],
     allowMissingNull: false,


### PR DESCRIPTION
Elixir 1.18 added a built-in `JSON` module. Any input with a `json` key makes quicktype emit `defmodule JSON`, which shadows it, and the generated code no longer compiles on current Elixir: `error: struct JSON is undefined (the module may have been redefined as it no longer defines a struct)` at the generated `%JSON{` constructor, followed by `== Type checking failed with errors ==`. Reserving `JSON` in `forbiddenModuleNames` renames the model to `JSONClass`.

CI pins `elixir-version: "1.15.7"`, which has no built-in `JSON` module, so the existing shared inputs that hit this — `test/inputs/schema/keyword-unions.schema`, `test/inputs/json/priority/keywords.json` and `test/inputs/json/priority/nst-test-suite.json` — compile there today and keep doing so; this fix is what keeps them compiling on a current Elixir.

The `skipDiffViaSchema` entry for `nst-test-suite.json` is required by the rename: its `y_object_empty_json` property infers a class named `JSON`, and once that name is reserved the JSON pipeline picks `YObjectEmptyJSONClass` while the JSON Schema pipeline picks `JSONClass`, so the two outputs no longer match. Ruby already skips that diff for the same input.

Validation: `npm run build`; `CPUs=2 QUICKTEST=true FIXTURE=schema-elixir npm run test:fixtures` (full group, 87 registered / 86 executed — `optional-property.schema` is in `skipSchema` — 0 failures); `CPUs=2 QUICKTEST=true FIXTURE=elixir npm run test:fixtures` over all 52 group samples except `objc-control-characters.json` (51 executed, `blns-object.json` skipped by `skipJSON`, 0 failures); `npm run lint`. Run on local Elixir 1.20.4 / OTP 29. `objc-control-characters.json` is excluded because it fails on Elixir 1.20 for an unrelated, pre-existing reason — a raw U+0085 in a generated enum atom (`invalid line break character in string`) — which reproduces on master and generates no `JSON` module at all.

Production change: 3 lines added, 0 removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
