### PR TITLE
test: expand renderer option coverage

### DIFF
--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -30,7 +30,6 @@ import {
     InputData,
     JSONSchemaInput,
     type LanguageName,
-    type Option,
     type RendererOptions,
     quicktype as quicktypeCore,
     quicktypeMultiFile,
@@ -119,11 +118,12 @@ function runEnvForLanguage(
     const newEnv = { ...process.env };
 
     for (const option of Object.keys(additionalRendererOptions)) {
-        newEnv[`QUICKTYPE_${option.toUpperCase().replace("-", "_")}`] = (
-            additionalRendererOptions[
-                option as keyof typeof additionalRendererOptions
-            ] as Option<string, unknown>
-        ).name;
+        newEnv[`QUICKTYPE_${option.toUpperCase().replaceAll("-", "_")}`] =
+            String(
+                additionalRendererOptions[
+                    option as keyof typeof additionalRendererOptions
+                ],
+            );
     }
     return newEnv;
 }

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -254,6 +254,17 @@ abstract class LanguageFixture extends Fixture {
         additionalFiles: string[],
     ): Promise<number>;
 
+    compileCommand(additionalRendererOptions: RendererOptions) {
+        const options = {
+            ...this.language.rendererOptions,
+            ...additionalRendererOptions,
+        };
+        return (
+            this.language.compileCommandForOptions?.(options) ??
+            this.language.compileCommand
+        );
+    }
+
     additionalFiles(_sample: Sample): string[] {
         return [];
     }
@@ -382,8 +393,9 @@ class JSONFixture extends LanguageFixture {
         additionalRendererOptions: RendererOptions,
         _additionalFiles: string[],
     ): Promise<number> {
-        if (this.language.compileCommand) {
-            await execAsync(this.language.compileCommand);
+        const compileCommand = this.compileCommand(additionalRendererOptions);
+        if (compileCommand) {
+            await execAsync(compileCommand);
         }
         if (this.language.runCommand === undefined) {
             return 0;
@@ -454,8 +466,8 @@ class JSONFixture extends LanguageFixture {
                 );
             }
             if (this.language.roundtripViaSchema) {
-                if (this.language.compileCommand) {
-                    await execAsync(this.language.compileCommand);
+                if (compileCommand) {
+                    await execAsync(compileCommand);
                 }
                 compareJsonFileToJson({
                     ...comparisonArgs(
@@ -897,8 +909,9 @@ class JSONSchemaFixture extends LanguageFixture {
         additionalRendererOptions: RendererOptions,
         additionalFiles: string[],
     ): Promise<number> {
-        if (this.language.compileCommand) {
-            await execAsync(this.language.compileCommand);
+        const compileCommand = this.compileCommand(additionalRendererOptions);
+        if (compileCommand) {
+            await execAsync(compileCommand);
         }
         if (this.language.runCommand === undefined) return 0;
 

--- a/test/fixtures/dart/pubspec.yaml
+++ b/test/fixtures/dart/pubspec.yaml
@@ -1,0 +1,11 @@
+name: quicktype_fixture
+environment:
+  sdk: ">=2.14.0 <4.0.0"
+dependencies:
+  freezed_annotation: 0.14.3
+dev_dependencies:
+  analyzer: 2.7.0
+  build_runner: 2.1.7
+  freezed: 0.14.5
+  json_serializable: 6.1.4
+  meta: 1.7.0

--- a/test/fixtures/javascript/main.js
+++ b/test/fixtures/javascript/main.js
@@ -5,8 +5,13 @@ const process = require("process");
 
 const sample = process.argv[2];
 const json = fs.readFileSync(sample);
+const input = process.env.QUICKTYPE_RAW_TYPE === "any" ? JSON.parse(json) : json;
 
-const value = TopLevel.toTopLevel(json);
+const value = TopLevel.toTopLevel(input);
 const backToJson = TopLevel.topLevelToJson(value);
 
-console.log(backToJson);
+console.log(
+    process.env.QUICKTYPE_RAW_TYPE === "any"
+        ? JSON.stringify(backToJson)
+        : backToJson,
+);

--- a/test/fixtures/typescript/main.ts
+++ b/test/fixtures/typescript/main.ts
@@ -6,8 +6,13 @@ const process = require("process");
 
 const sample = process.argv[2];
 const json = fs.readFileSync(sample);
+const input = process.env.QUICKTYPE_RAW_TYPE === "any" ? JSON.parse(json) : json;
 
-const value = TopLevel.Convert.toTopLevel(json);
+const value = TopLevel.Convert.toTopLevel(input);
 const backToJson = TopLevel.Convert.topLevelToJson(value);
 
-console.log(backToJson);
+console.log(
+    process.env.QUICKTYPE_RAW_TYPE === "any"
+        ? JSON.stringify(backToJson)
+        : backToJson,
+);

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -870,6 +870,8 @@ export const SwiftLanguage: Language = {
     skipSchema: ["optional-property.schema"],
     rendererOptions: { "support-linux": "true" },
     quickTestRendererOptions: [
+        { "mutable-properties": "true" },
+        { "coding-keys-protocol": "CaseIterable" },
         { "support-linux": "false" },
         { "struct-or-class": "class" },
         { sendable: "true" },
@@ -982,6 +984,7 @@ export const TypeScriptLanguage: Language = {
     skipSchema: [],
     rendererOptions: { "explicit-unions": "yes" },
     quickTestRendererOptions: [
+        { "raw-type": "any" },
         { "runtime-typecheck": "false" },
         { "runtime-typecheck-ignore-unknown-properties": "true" },
         { "nice-property-names": "true" },
@@ -1030,6 +1033,7 @@ export const JavaScriptLanguage: Language = {
     skipSchema: [],
     rendererOptions: {},
     quickTestRendererOptions: [
+        { "raw-type": "any" },
         { "runtime-typecheck": "false" },
         { "runtime-typecheck-ignore-unknown-properties": "true" },
         { converters: "top-level" },

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -58,6 +58,7 @@ export interface Language {
     base: string;
     setupCommand?: string;
     compileCommand?: string;
+    compileCommandForOptions?: (options: RendererOptions) => string | undefined;
     runCommand?: (sample: string) => string;
     copyInput?: boolean;
     diffViaSchema: boolean;
@@ -1470,6 +1471,11 @@ export const KotlinXLanguage: Language = {
 export const DartLanguage: Language = {
     name: "dart",
     base: "test/fixtures/dart",
+    compileCommandForOptions(options) {
+        return options["use-freezed"] === "true"
+            ? "dart pub get && mkdir -p lib && cp TopLevel.dart lib/top_level.dart && sed -i.bak s/TopLevel.dart/top_level.dart/ parser.dart && dart pub run build_runner build --delete-conflicting-outputs && cp lib/top_level*.dart ."
+            : undefined;
+    },
     runCommand(sample: string) {
         return `dart --enable-experiment=non-nullable parser.dart "${sample}"`;
     },


### PR DESCRIPTION
The fixture runner exported renderer options as `undefined`, so drivers could not adapt to option-specific converter contracts. Export their actual values and let the JavaScript and TypeScript drivers exercise `raw-type=any` through decode and encode.

Option-specific fixture builds now receive merged base and additional renderer options in JSON and schema tests. The Dart Freezed build installs pinned Dart 2.14-compatible dependencies only when selected, reuses the existing parser, and runs generated `freezed` and `json_serializable` code. This supports the regression coverage in #3499 without changing ordinary Dart fixture setup.

Also enable existing passing coverage for Swift mutable properties and CodingKey protocols.

Validation:

- `npm run build`
- `npm run test:unit`
- `npm run lint`
- `CPUs=2 QUICKTEST=true FIXTURE=javascript,typescript npm run test:fixtures` (169 tests)
- Dart 3 default fixture smoke test without dependency setup
- Dart 2.14.4: 69 Dart fixtures with #3499, including the Freezed identifiers round trip
- Swift `mutable-properties=true` and `coding-keys-protocol=CaseIterable` matrices (8 compile/round-trip cases)

Production lines: 0.
