### PR TITLE
fix(swift): retain required coding key labels

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -641,10 +641,7 @@ export class SwiftRenderer extends ConvenienceRenderer {
                         this.emitBlock(enumDeclaration, () => {
                             for (const group of groups) {
                                 const { name, label } = group[0];
-                                if (
-                                    this._options.explicitCodingKeys &&
-                                    label !== undefined
-                                ) {
+                                if (label !== undefined) {
                                     this.emitLine(
                                         "case ",
                                         name,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -871,6 +871,7 @@ export const SwiftLanguage: Language = {
     rendererOptions: { "support-linux": "true" },
     quickTestRendererOptions: [
         { "support-linux": "false" },
+        { "coding-keys": "false" },
         { "struct-or-class": "class" },
         { sendable: "true" },
         { sendable: "true", "struct-or-class": "class" },


### PR DESCRIPTION
With `--no-coding-keys`, Swift omitted raw JSON labels even when generated property names differed. Decoding `combinations4.json` then failed at runtime. Keep required labels while omitting redundant explicit values.

The Swift option matrix now covers `coding-keys=false`.

Validation: `npm run build`; `npm run lint`; `CPUs=2 QUICKTEST=true FIXTURE=swift npm run test:fixtures`.

Production diff: 5 lines (1 added, 4 removed).
