### PR TITLE
fix(swift): emit decoder helpers without initializers

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -1160,11 +1160,7 @@ encoder.dateEncodingStrategy = .formatted(formatter)`);
             );
         }
 
-        if (
-            (!this._options.justTypes &&
-                this._options.convenienceInitializers) ||
-            this._options.alamofire
-        ) {
+        if (!this._options.justTypes || this._options.alamofire) {
             this.ensureBlankLine();
             this.emitMark(
                 "Helper functions for creating encoders and decoders",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -871,6 +871,7 @@ export const SwiftLanguage: Language = {
     rendererOptions: { "support-linux": "true" },
     quickTestRendererOptions: [
         { "support-linux": "false" },
+        { initializers: "false" },
         { "struct-or-class": "class" },
         { sendable: "true" },
         { sendable: "true", "struct-or-class": "class" },


### PR DESCRIPTION
`--no-initializers` also suppressed `newJSONDecoder` and `newJSONEncoder`, so the generated top-level decoding API and standard fixture driver did not compile. Emit codec helpers independently from convenience initializers.

The Swift option matrix now covers `initializers=false`.

Validation: `npm run build`; `npm run lint`; `CPUs=2 QUICKTEST=true FIXTURE=swift npm run test:fixtures`.

Production diff: 6 lines (1 added, 5 removed).
