### PR TITLE
fix(dart): preserve JSON names with Freezed

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -919,12 +919,10 @@ export class DartRenderer extends ConvenienceRenderer {
                                     this._options.requiredProperties ||
                                     !prop.type.isNullable ||
                                     !prop.isOptional;
-                                if (this._options.useJsonAnnotation) {
-                                    this.classPropertyCounter++;
-                                    this.emitLine(
-                                        `@JsonKey(name: "${jsonName}")`,
-                                    );
-                                }
+                                this.classPropertyCounter++;
+                                this.emitLine(
+                                    `@JsonKey(name: "${stringEscape(jsonName)}")`,
+                                );
 
                                 this.emitLine(
                                     required ? "required " : "",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1535,6 +1535,7 @@ export const DartLanguage: Language = {
         { "copy-with": "true" },
         ["copy-with-property.json", { "copy-with": "true" }],
         ["simple-object.json", { "required-props": "true" }],
+        ["identifiers.json", { "use-freezed": "true" }],
     ],
     sourceFiles: ["src/language/Dart/index.ts"],
 };


### PR DESCRIPTION
Freezed output only emitted `@JsonKey` when `--use-json-annotation` was also set, so renamed and escaped JSON fields failed to deserialize. Emit escaped `@JsonKey` annotations for every Freezed property and exercise the shared `identifiers.json` input.

Tests:
- `npm run build`
- Dart 2.14.4: `CPUs=2 QUICKTEST=true FIXTURE=dart,schema-dart npm run test:fixtures`
- `npm run lint`

Production change: 10 lines (4 added, 6 removed).

Fixes #1875.
