### PR TITLE
fix(swift): honor disabled coding keys

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -627,7 +627,11 @@ export class SwiftRenderer extends ConvenienceRenderer {
                     const allPropertiesRedundant = groups.every((group) => {
                         return group.every((p) => p.label === undefined);
                     });
-                    if (!allPropertiesRedundant && c.getProperties().size > 0) {
+                    if (
+                        this._options.explicitCodingKeys &&
+                        !allPropertiesRedundant &&
+                        c.getProperties().size > 0
+                    ) {
                         this.ensureBlankLine();
                         let enumDeclaration = this.accessLevel;
                         enumDeclaration += "enum CodingKeys: String, CodingKey";

--- a/test/unit/swift-coding-keys.test.ts
+++ b/test/unit/swift-coding-keys.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    jsonInputForTargetLanguage,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+
+describe("Swift coding keys", () => {
+    test("can omit explicit coding keys", async () => {
+        const input = jsonInputForTargetLanguage("swift");
+        await input.addSource({
+            name: "TopLevel",
+            samples: ['{"snake_case": 1}'],
+        });
+        const inputData = new InputData();
+        inputData.addInput(input);
+
+        const result = await quicktype({
+            inputData,
+            lang: "swift",
+            rendererOptions: { "coding-keys": "false" },
+        });
+
+        expect(result.lines.join("\n")).not.toContain("enum CodingKeys");
+    });
+});


### PR DESCRIPTION
`--no-coding-keys` was parsed but ignored, so Swift output still declared every nonredundant `CodingKeys` enum. Honor the option when deciding whether to emit the enum.

Adds a regression for a renamed JSON property. Production change: 6 lines changed (5 added, 1 removed).

Validation: focused unit test, build, generated Swift type-check.
