### PR TITLE
fix(dart): escape JsonKey names

### DIFF
--- a/packages/quicktype-core/src/language/Dart/DartRenderer.ts
+++ b/packages/quicktype-core/src/language/Dart/DartRenderer.ts
@@ -709,7 +709,7 @@ export class DartRenderer extends ConvenienceRenderer {
 
             if (this._options.useJsonAnnotation) {
                 this.classPropertyCounter++;
-                this.emitLine(`@JsonKey(name: "${jsonName}")`);
+                this.emitLine(`@JsonKey(name: "${stringEscape(jsonName)}")`);
             }
 
             this.emitLine(

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1539,6 +1539,7 @@ export const DartLanguage: Language = {
         ["copy-with-property.json", { "copy-with": "true" }],
         ["simple-object.json", { "required-props": "true" }],
         ["identifiers.json", { "use-freezed": "true" }],
+        ["identifiers.json", { "use-json-annotation": "true" }],
     ],
     sourceFiles: ["src/language/Dart/index.ts"],
 };


### PR DESCRIPTION
`--use-json-annotation` embedded JSON property names directly in Dart strings. A quote or newline produced invalid generated code. Escape the name before emitting `@JsonKey`.

Depends on #3503 for the shared Dart option compile hook. This PR pins `identifiers.json` with JSON annotations so CI builds the generated serializers and round-trips the original names. Production change: 2 lines changed (1 added, 1 removed).

Validation with CI's Dart 2.14.4: the baseline fails parsing the unescaped annotation; the fix builds with `json_serializable` and round-trips `identifiers.json`. Build and lint pass.
