### PR TITLE
fix(swift): emit requested coding keys protocol

### DIFF
--- a/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
+++ b/packages/quicktype-core/src/language/Swift/SwiftRenderer.ts
@@ -627,7 +627,11 @@ export class SwiftRenderer extends ConvenienceRenderer {
                     const allPropertiesRedundant = groups.every((group) => {
                         return group.every((p) => p.label === undefined);
                     });
-                    if (!allPropertiesRedundant && c.getProperties().size > 0) {
+                    if (
+                        (!allPropertiesRedundant ||
+                            this._options.codingKeysProtocol.length > 0) &&
+                        c.getProperties().size > 0
+                    ) {
                         this.ensureBlankLine();
                         let enumDeclaration = this.accessLevel;
                         enumDeclaration += "enum CodingKeys: String, CodingKey";

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -873,6 +873,7 @@ export const SwiftLanguage: Language = {
     quickTestRendererOptions: [
         { "mutable-properties": "true" },
         { "coding-keys-protocol": "CaseIterable" },
+        ["simple-object.json", { "coding-keys-protocol": "CaseIterable" }],
         { "support-linux": "false" },
         { "coding-keys": "false" },
         { "struct-or-class": "class" },

--- a/test/unit/swift-coding-keys-protocol.test.ts
+++ b/test/unit/swift-coding-keys-protocol.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    jsonInputForTargetLanguage,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+
+describe("Swift coding keys protocol", () => {
+    test("emits redundant coding keys when a protocol is requested", async () => {
+        const input = jsonInputForTargetLanguage("swift");
+        await input.addSource({ name: "TopLevel", samples: ['{"value": 1}'] });
+        const inputData = new InputData();
+        inputData.addInput(input);
+
+        const result = await quicktype({
+            inputData,
+            lang: "swift",
+            rendererOptions: { "coding-keys-protocol": "CaseIterable" },
+        });
+
+        expect(result.lines.join("\n")).toContain(
+            "enum CodingKeys: String, CodingKey, CaseIterable",
+        );
+    });
+});


### PR DESCRIPTION
`--coding-keys-protocol` was ignored when every property name matched its JSON key because the renderer omitted the otherwise redundant `CodingKeys` enum. Emit the enum whenever a protocol was requested.

Adds a regression for `CaseIterable` on a simple object. Production change: 6 lines changed (5 added, 1 removed).

Validation: focused unit test, build, lint, generated Swift type-check.
