### PR TITLE
fix(typescript): make index signatures readonly

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
@@ -135,7 +135,12 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
             (_classType) => panic("We handled this above"),
             (mapType) =>
                 singleWord([
-                    "{ [key: string]: ",
+                    "{ ",
+                    this._tsFlowOptions.readonly &&
+                    this.targetLanguage.name === "typescript"
+                        ? "readonly "
+                        : "",
+                    "[key: string]: ",
                     this.sourceFor(mapType.values).source,
                     " }",
                 ]),
@@ -228,7 +233,10 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
 
             this.emitTable([
                 [
-                    "[property: string]",
+                    this._tsFlowOptions.readonly &&
+                    this.targetLanguage.name === "typescript"
+                        ? "readonly [property: string]"
+                        : "[property: string]",
                     ": ",
                     multiWord(" | ", ...indexTypes).source,
                     ";",

--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
@@ -136,9 +136,10 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
             (mapType) =>
                 singleWord([
                     "{ ",
-                    this._tsFlowOptions.readonly &&
-                    this.targetLanguage.name === "typescript"
-                        ? "readonly "
+                    this._tsFlowOptions.readonly
+                        ? this.targetLanguage.name === "flow"
+                            ? "+"
+                            : "readonly "
                         : "",
                     "[key: string]: ",
                     this.sourceFor(mapType.values).source,
@@ -189,7 +190,8 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
 
             if (this._tsFlowOptions.readonly) {
                 propertyName = modifySource(
-                    (_propertyName) => `readonly ${_propertyName}`,
+                    (_propertyName) =>
+                        `${this.targetLanguage.name === "flow" ? "+" : "readonly "}${_propertyName}`,
                     propertyName,
                 );
             }
@@ -233,9 +235,8 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
 
             this.emitTable([
                 [
-                    this._tsFlowOptions.readonly &&
-                    this.targetLanguage.name === "typescript"
-                        ? "readonly [property: string]"
+                    this._tsFlowOptions.readonly
+                        ? `${this.targetLanguage.name === "flow" ? "+" : "readonly "}[property: string]`
                         : "[property: string]",
                     ": ",
                     multiWord(" | ", ...indexTypes).source,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -999,6 +999,8 @@ export const TypeScriptLanguage: Language = {
         { "acronym-style": "pascal" },
         { converters: "all-objects" },
         { readonly: "true" },
+        ["number-map.json", { readonly: "true" }],
+        ["class-with-additional.schema", { readonly: "true" }],
         // The default is prefer-unions=true; this keeps the TypeScript
         // enum code path covered.
         { "prefer-unions": "false" },

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1121,6 +1121,9 @@ export const FlowLanguage: Language = {
         // Flow output.
         { "prefer-unions": "false" },
         { "prefer-unknown": "false" },
+        ["simple-object.json", { readonly: "true" }],
+        ["number-map.json", { readonly: "true" }],
+        ["class-with-additional.schema", { readonly: "true" }],
     ],
     sourceFiles: ["src/language/Flow/index.ts"],
 };

--- a/test/unit/typescript-readonly-index.test.ts
+++ b/test/unit/typescript-readonly-index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+import {
+    InputData,
+    JSONSchemaInput,
+    quicktype,
+} from "../../packages/quicktype-core/src/index.js";
+
+describe("TypeScript readonly", () => {
+    test("applies to index signatures", async () => {
+        const input = new JSONSchemaInput(undefined);
+        await input.addSource({
+            name: "TopLevel",
+            schema: JSON.stringify({
+                type: "object",
+                properties: { fixed: { type: "string" } },
+                required: ["fixed"],
+                additionalProperties: { type: "string" },
+            }),
+        });
+        const inputData = new InputData();
+        inputData.addInput(input);
+
+        const result = await quicktype({
+            inputData,
+            lang: "typescript",
+            rendererOptions: { readonly: "true" },
+        });
+
+        expect(result.lines.join("\n")).toContain(
+            "readonly [property: string]: string;",
+        );
+    });
+
+    test("applies to map types", async () => {
+        const input = new JSONSchemaInput(undefined);
+        await input.addSource({
+            name: "TopLevel",
+            schema: JSON.stringify({
+                type: "object",
+                additionalProperties: { type: "string" },
+            }),
+        });
+        const inputData = new InputData();
+        inputData.addInput(input);
+
+        const result = await quicktype({
+            inputData,
+            lang: "typescript",
+            rendererOptions: { readonly: "true" },
+        });
+
+        expect(result.lines.join("\n")).toContain(
+            "{ readonly [key: string]: string }",
+        );
+    });
+});


### PR DESCRIPTION
`--readonly` marked declared properties but left class and map index signatures mutable. Mark TypeScript index signatures readonly so the option covers every property.

Pins the existing `number-map.json` and `class-with-additional.schema` cases and adds focused output assertions. Production change: 12 lines changed (10 added, 2 removed).

Validation: full TypeScript JSON/schema fixture (189 tests), focused unit tests, build, and lint pass. In direct compiler checks, the baseline accepts assignments through both index signatures; the fix rejects them with TS2542.
