### PR TITLE
fix(flow): emit covariant readonly properties

### DIFF
--- a/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptFlow/TypeScriptFlowBaseRenderer.ts
@@ -136,9 +136,10 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
             (mapType) =>
                 singleWord([
                     "{ ",
-                    this._tsFlowOptions.readonly &&
-                    this.targetLanguage.name === "typescript"
-                        ? "readonly "
+                    this._tsFlowOptions.readonly
+                        ? this.targetLanguage.name === "flow"
+                            ? "+"
+                            : "readonly "
                         : "",
                     "[key: string]: ",
                     this.sourceFor(mapType.values).source,
@@ -189,7 +190,8 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
 
             if (this._tsFlowOptions.readonly) {
                 propertyName = modifySource(
-                    (_propertyName) => `readonly ${_propertyName}`,
+                    (_propertyName) =>
+                        `${this.targetLanguage.name === "flow" ? "+" : "readonly "}${_propertyName}`,
                     propertyName,
                 );
             }
@@ -233,9 +235,8 @@ export abstract class TypeScriptFlowBaseRenderer extends JavaScriptRenderer {
 
             this.emitTable([
                 [
-                    this._tsFlowOptions.readonly &&
-                    this.targetLanguage.name === "typescript"
-                        ? "readonly [property: string]"
+                    this._tsFlowOptions.readonly
+                        ? `${this.targetLanguage.name === "flow" ? "+" : "readonly "}[property: string]`
                         : "[property: string]",
                     ": ",
                     multiWord(" | ", ...indexTypes).source,

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1121,6 +1121,9 @@ export const FlowLanguage: Language = {
         // Flow output.
         { "prefer-unions": "false" },
         { "prefer-unknown": "false" },
+        ["simple-object.json", { readonly: "true" }],
+        ["number-map.json", { readonly: "true" }],
+        ["class-with-additional.schema", { readonly: "true" }],
     ],
     sourceFiles: ["src/language/Flow/index.ts"],
 };


### PR DESCRIPTION
Flow's `--readonly` output used TypeScript's `readonly` modifier, which Flow rejects. Emit Flow covariance markers for declared properties and indexers, including pure map types.

Depends on #3504 for the shared readonly index-signature paths. Production change: 15 lines changed (8 added, 7 removed).

Baseline `flow ast` fails on `readonly` properties; the fixed output parses and Flow rejects assignment to both declared and dynamic properties. The full Flow and schema-Flow fixture groups pass: 164/164, including pinned object, map, and additional-property cases. Build and lint pass.
