### PR TITLE
fix(effect, python): validate date and time formats

### DIFF
--- a/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
@@ -521,7 +521,7 @@ export class JSONPythonRenderer extends PythonRenderer {
                 this.emitLine(
                     "assert isinstance(x, str) and ",
                     this.withModuleImport("re"),
-                    '.match(r"^\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})?$", x)',
+                    '.match(r"^\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:[Zz]|[+-]\\d{2}:\\d{2})?$", x)',
                 );
                 this.emitLine("return dateutil.parser.parse(x).timetz()");
             },
@@ -542,7 +542,7 @@ export class JSONPythonRenderer extends PythonRenderer {
             ],
             () => {
                 this._haveDateutil = true;
-                this.emitLine("return dateutil.parser.parse(x)");
+                this.emitLine("return dateutil.parser.isoparse(x)");
             },
         );
     }

--- a/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptEffectSchema/TypeScriptEffectSchemaRenderer.ts
@@ -195,11 +195,11 @@ export class TypeScriptEffectSchemaRenderer extends ConvenienceRenderer {
                         ? 'S.transform(S.Literal("true", "false"), S.Boolean, { strict: true, decode: (value) => value === "true", encode: (value) => value ? "true" : "false" })'
                         : 'S.Literal("true", "false")';
                 if (_transformedStringType.kind === "date")
-                    return "S.String.pipe(S.pattern(/^\\d{4}-\\d{2}-\\d{2}$/))";
+                    return 'S.String.pipe(S.pattern(/^\\d{4}-(?:0[1-9]|1[0-2])-(?:[0-2]\\d|3[01])$/), S.filter(value => (new Date(value + "T00:00:00Z").toJSON() || "").slice(0, 10) === value))';
                 if (_transformedStringType.kind === "time")
-                    return "S.String.pipe(S.pattern(/^\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$/))";
+                    return "S.String.pipe(S.pattern(/^(?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:Z|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$/i))";
                 if (_transformedStringType.kind === "date-time")
-                    return "S.String.pipe(S.pattern(/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$/))";
+                    return 'S.String.pipe(S.pattern(/^\\d{4}-(?:0[1-9]|1[0-2])-(?:[0-2]\\d|3[01])T(?:[01]\\d|2[0-3]):[0-5]\\d:(?:[0-5]\\d|60)(?:\\.\\d+)?(?:Z|[+-](?:[01]\\d|2[0-3]):[0-5]\\d)$/i), S.filter(value => (new Date(value.slice(0, 10) + "T00:00:00Z").toJSON() || "").slice(0, 10) === value.slice(0, 10)))';
                 if (_transformedStringType.kind === "integer-string")
                     return coerceStrings
                         ? "S.NumberFromString.pipe(S.int())"

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -297,6 +297,8 @@ export const PythonLanguage: Language = {
         "union",
         "no-defaults",
         "date-time",
+        "date",
+        "time",
         "integer-string",
         "bool-string",
         "uuid",

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -1787,6 +1787,8 @@ export const TypeScriptEffectSchemaLanguage: Language = {
         "minmaxlength",
         "bool-string",
         "date-time",
+        "date",
+        "time",
         "integer-string",
         "pattern",
         "minmax",


### PR DESCRIPTION
Effect schemas accepted impossible dates and out-of-range times because their patterns only checked digit counts. Validate date, time, and date-time bounds while retaining lowercase RFC 3339 separators.

Python's generated parser also used permissive parsing that accepted malformed values such as `"1"`. Use ISO-specific parsers for generated date, time, and date-time conversion.

Depends on #3505 and exercises its shared date/time cases. Python #3518 was merged into this branch.

Production diff: Effect 6 lines; Python 4 lines.

Validation:
- focused shared date-time fixtures pass for Effect and Python
- full Effect fixtures: 145/145 pass
- full Python fixtures: 88/88 pass
- build and lint pass
