### PR TITLE
fix(python): validate ISO date-times

### DIFF
--- a/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
+++ b/packages/quicktype-core/src/language/Python/JSONPythonRenderer.ts
@@ -515,7 +515,7 @@ export class JSONPythonRenderer extends PythonRenderer {
                 this.emitLine(
                     "assert isinstance(x, str) and ",
                     this.withModuleImport("re"),
-                    '.match(r"^\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})?$", x)',
+                    '.match(r"^\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:[Zz]|[+-]\\d{2}:\\d{2})?$", x)',
                 );
                 this.emitLine("return dateutil.parser.parse(x).timetz()");
             },
@@ -536,7 +536,7 @@ export class JSONPythonRenderer extends PythonRenderer {
             ],
             () => {
                 this._haveDateutil = true;
-                this.emitLine("return dateutil.parser.parse(x)");
+                this.emitLine("return dateutil.parser.isoparse(x)");
             },
         );
     }

--- a/test/languages.ts
+++ b/test/languages.ts
@@ -297,6 +297,8 @@ export const PythonLanguage: Language = {
         "union",
         "no-defaults",
         "date-time",
+        "date",
+        "time",
         "integer-string",
         "bool-string",
         "uuid",


### PR DESCRIPTION
Python's time converter rejected lowercase `z`, while its permissive date-time parser accepted malformed and impossible ISO dates. Accept lowercase UTC markers and use `dateutil.parser.isoparse` for date-times.

Depends on #3512. This prepares Python for shared malformed case 8, introduced by #3509.

Production diff: 4 lines changed.

Validation: all 88 Python schema fixtures pass.
