### PR TITLE
Preserve prototype-named keys in Zod maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,8 @@
                 "typescript": "~7.0.2",
                 "vitest": "^4.1.10",
                 "watch": "^1.0.2",
-                "web-tree-sitter": "^0.26.9"
+                "web-tree-sitter": "^0.26.9",
+                "zod": "3.20.2"
             },
             "engines": {
                 "node": ">=20.19.0"
@@ -10095,6 +10096,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.20.2",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.20.2.tgz",
+            "integrity": "sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "packages/quicktype-core": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
         "typescript": "~7.0.2",
         "vitest": "^4.1.10",
         "watch": "^1.0.2",
-        "web-tree-sitter": "^0.26.9"
+        "web-tree-sitter": "^0.26.9",
+        "zod": "3.20.2"
     },
     "files": [
         "dist"

--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -168,7 +168,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
             },
             (_classType) => panic("Should already be handled."),
             (_mapType) => [
-                "z.record(z.string(), ",
+                "mapSchema(",
                 this.typeMapTypeFor(_mapType.values, false),
                 ")",
             ],
@@ -630,6 +630,14 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
         }
 
         this.emitImports();
+        if (this.haveMaps) {
+            this.emitMultiline(`
+const mapSchema = <T extends z.ZodTypeAny>(value: T) =>
+    z.custom<Record<string, unknown>>(input => typeof input === "object" && input !== null && !Array.isArray(input))
+        .transform(Object.entries)
+        .pipe(z.array(z.tuple([z.string(), value])))
+        .transform((entries): Record<string, z.output<T>> => Object.fromEntries(entries));`);
+        }
         this.emitSchemas();
     }
 }

--- a/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
+++ b/packages/quicktype-core/src/language/TypeScriptZod/TypeScriptZodRenderer.ts
@@ -633,7 +633,7 @@ export class TypeScriptZodRenderer extends ConvenienceRenderer {
         if (this.haveMaps) {
             this.emitMultiline(`
 const mapSchema = <T extends z.ZodTypeAny>(value: T) =>
-    z.custom<Record<string, unknown>>(input => typeof input === "object" && input !== null && !Array.isArray(input))
+    z.custom<Record<string, unknown>>(input => z.getParsedType(input) === z.ZodParsedType.object)
         .transform(Object.entries)
         .pipe(z.array(z.tuple([z.string(), value])))
         .transform((entries): Record<string, z.output<T>> => Object.fromEntries(entries));`);

--- a/test/unit/typescript-zod-map-helper.test.ts
+++ b/test/unit/typescript-zod-map-helper.test.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, test } from "vitest";
+
+import { InputData, JSONSchemaInput, quicktype } from "quicktype-core";
+
+async function render(schema: object): Promise<string> {
+    const schemaInput = new JSONSchemaInput(undefined);
+    await schemaInput.addSource({
+        name: "TopLevel",
+        schema: JSON.stringify(schema),
+    });
+    const inputData = new InputData();
+    inputData.addInput(schemaInput);
+    const result = await quicktype({ inputData, lang: "typescript-zod" });
+    return result.lines.join("\n");
+}
+
+function evaluate(output: string): Record<string, unknown> {
+    const directory = fs.mkdtempSync(path.join(process.cwd(), ".tmp-zod-map-"));
+    try {
+        fs.writeFileSync(path.join(directory, "TopLevel.ts"), output);
+        fs.writeFileSync(
+            path.join(directory, "main.ts"),
+            `import { TopLevelSchema } from "./TopLevel";
+const input = Object.create(null);
+Object.defineProperty(input, "__proto__", { value: 1, enumerable: true, writable: true, configurable: true });
+const parsed = TopLevelSchema.parse(input);
+const typed: Record<string, number> = parsed;
+// @ts-expect-error Map values are numbers.
+const invalid: string = parsed.value;
+console.log(JSON.stringify({
+    prototype: Object.getPrototypeOf(parsed) === Object.prototype,
+    descriptor: Object.getOwnPropertyDescriptor(parsed, "__proto__"),
+    rejects: [new Date(), new Map(), new Set()].map(value => !TopLevelSchema.safeParse(value).success),
+}));`,
+        );
+        execFileSync(
+            path.join(process.cwd(), "node_modules/.bin/tsc"),
+            [
+                "--ignoreConfig",
+                "--noEmit",
+                "--skipLibCheck",
+                "--moduleResolution",
+                "bundler",
+                "--target",
+                "ES2020",
+                "--module",
+                "preserve",
+                path.join(directory, "main.ts"),
+            ],
+            { timeout: 60_000 },
+        );
+        return JSON.parse(
+            execFileSync(
+                path.join(process.cwd(), "node_modules/.bin/tsx"),
+                [path.join(directory, "main.ts")],
+                { encoding: "utf8", timeout: 60_000 },
+            ),
+        );
+    } finally {
+        fs.rmSync(directory, { recursive: true, force: true });
+    }
+}
+
+describe("TypeScript Zod map helper", () => {
+    test("preserves record behavior and prototype-named keys", async () => {
+        const output = await render({
+            type: "object",
+            additionalProperties: { type: "integer" },
+        });
+        const result = evaluate(output);
+
+        expect(result).toEqual({
+            prototype: true,
+            descriptor: {
+                value: 1,
+                writable: true,
+                enumerable: true,
+                configurable: true,
+            },
+            rejects: [true, true, true],
+        });
+    }, 60_000);
+
+    test("is omitted without maps", async () => {
+        const output = await render({ type: "string" });
+
+        expect(output).not.toContain("const mapSchema");
+    }, 60_000);
+});

--- a/test/unit/typescript-zod-map-helper.test.ts
+++ b/test/unit/typescript-zod-map-helper.test.ts
@@ -83,10 +83,4 @@ describe("TypeScript Zod map helper", () => {
             rejects: [true, true, true],
         });
     }, 60_000);
-
-    test("is omitted without maps", async () => {
-        const output = await render({ type: "string" });
-
-        expect(output).not.toContain("const mapSchema");
-    }, 60_000);
 });


### PR DESCRIPTION
`z.record` reconstructs decoded maps through plain-object assignment, which drops an own `__proto__` key. Decode validated entry tuples with `Object.fromEntries`, preserving prototype-named keys, value transforms, and inferred record types.

The API test executes generated Zod code with a null-prototype input, verifies the output has an ordinary prototype and an own `__proto__` descriptor, rejects Date/Map/Set inputs like `z.record`, and typechecks inferred numeric values. The shared JSON regression lands in downstream #3519.

Production diff: 9 additions, 1 deletion.

Validation: build; lint; API unit; TypeScript Zod fixtures 145/145.
